### PR TITLE
fix: update GraphQL queries for Unraid API v4.21.0+

### DIFF
--- a/unraid_mcp/tools/health.py
+++ b/unraid_mcp/tools/health.py
@@ -32,12 +32,13 @@ def register_health_tools(mcp: FastMCP) -> None:
 
         try:
             # Enhanced health check with multiple system components
+            # Updated for Unraid API v4.21.0+ (Unraid 7.1.4+)
+            # Removed deprecated versions.unraid field
             comprehensive_query = """
             query ComprehensiveHealthCheck {
               info {
                 machineId
                 time
-                versions { unraid }
                 os { uptime }
               }
               array {
@@ -91,7 +92,6 @@ def register_health_tools(mcp: FastMCP) -> None:
                     "url": UNRAID_API_URL,
                     "machine_id": info.get("machineId"),
                     "time": info.get("time"),
-                    "version": info.get("versions", {}).get("unraid"),
                     "uptime": info.get("os", {}).get("uptime")
                 }
             else:


### PR DESCRIPTION
## Summary

Updates GraphQL queries to work with modern Unraid API schema (v4.21.0+, Unraid 7.1.4+).

- Fix `get_system_info` query validation errors by removing deprecated fields and updating schema structure
- Add new `get_metrics` tool for real-time CPU and memory utilization
- Fix `health_check` query to remove deprecated version field

## Changes

### `get_system_info` query fixes:
- Remove deprecated `codepage` field (replaced by `codename`)
- Remove deprecated `apps` field (removed from schema)
- Fix case sensitivity: `speedMin/speedMax` → `speedmin/speedmax`, `vendorName/productName` → `vendorname/productname`
- Update `versions` structure: now `core { unraid api kernel }` + `packages { ... }`
- Remove memory stats from info query (moved to metrics)

### New `get_metrics` tool:
- Queries the new `metrics` endpoint for real-time utilization data
- CPU: overall usage %, per-core stats (CpuLoad objects with user/system/idle breakdown)
- Memory: total/used/free/available, swap stats, usage percentages

### `health_check` fix:
- Remove deprecated `versions { unraid }` field

## Test plan

- [ ] Verify `get_system_info` returns valid data without GraphQL errors
- [ ] Verify new `get_metrics` tool returns CPU and memory utilization
- [ ] Verify `health_check` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time system metrics reporting for CPU, memory, and swap utilization.
  * Expanded system information surface with detailed API, kernel, and software version data, plus PCI device details.

* **Updates**
  * Updated compatibility for Unraid API v4.21.0+ with removal of deprecated fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->