### PR TITLE
fix: resolve GraphQL schema mismatches for Unraid 7.2.x API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 COPY pyproject.toml .
 COPY uv.lock .
 COPY README.md .
+COPY LICENSE .
 
 # Copy the source code
 COPY unraid_mcp/ ./unraid_mcp/

--- a/unraid_mcp/tools/docker.py
+++ b/unraid_mcp/tools/docker.py
@@ -33,11 +33,6 @@ QUERIES: dict[str, str] = {
           } }
         }
     """,
-    "logs": """
-        query GetContainerLogs($id: PrefixedID!, $tail: Int) {
-          docker { logs(id: $id, tail: $tail) }
-        }
-    """,
     "networks": """
         query GetDockerNetworks {
           dockerNetworks { id name driver scope }
@@ -286,11 +281,11 @@ def register_docker_tool(mcp: FastMCP) -> None:
                 raise ToolError(msg)
 
             if action == "logs":
-                actual_id = await _resolve_container_id(container_id or "")
-                data = await make_graphql_request(
-                    QUERIES["logs"], {"id": actual_id, "tail": tail_lines}
+                raise ToolError(
+                    "Container logs are not available via the Unraid GraphQL API. "
+                    "Use the Unraid web UI (Docker tab → container → Logs) or SSH: "
+                    f"`docker logs {container_id} --tail {tail_lines}`"
                 )
-                return {"logs": _safe_get(data, "docker", "logs")}
 
             if action == "networks":
                 data = await make_graphql_request(QUERIES["networks"])

--- a/unraid_mcp/tools/health.py
+++ b/unraid_mcp/tools/health.py
@@ -103,7 +103,7 @@ async def _comprehensive_check() -> dict[str, Any]:
         query ComprehensiveHealthCheck {
           info {
             machineId time
-            versions { unraid }
+            versions { core { unraid } }
             os { uptime }
           }
           array { state }
@@ -137,7 +137,7 @@ async def _comprehensive_check() -> dict[str, Any]:
                 "status": "connected",
                 "url": UNRAID_API_URL,
                 "machine_id": info.get("machineId"),
-                "version": info.get("versions", {}).get("unraid"),
+                "version": info.get("versions", {}).get("core", {}).get("unraid"),
                 "uptime": info.get("os", {}).get("uptime"),
             }
         else:

--- a/unraid_mcp/tools/info.py
+++ b/unraid_mcp/tools/info.py
@@ -49,9 +49,8 @@ QUERIES: dict[str, str] = {
     """,
     "network": """
         query GetNetworkConfig {
-          network {
-            id
-            accessUrls { type name ipv4 ipv6 }
+          vars {
+            id useSsl port portssl localTld
           }
         }
     """,
@@ -66,7 +65,7 @@ QUERIES: dict[str, str] = {
     """,
     "connect": """
         query GetConnectSettings {
-          connect { status sandbox flashGuid }
+          vars { id flashGuid flashProduct flashVendor }
         }
     """,
     "variables": """
@@ -91,7 +90,7 @@ QUERIES: dict[str, str] = {
     """,
     "services": """
         query GetServices {
-          services { name state }
+          services { name }
         }
     """,
     "display": """
@@ -130,12 +129,12 @@ QUERIES: dict[str, str] = {
     """,
     "servers": """
         query GetServers {
-          servers { id name status description ip port }
+          servers { id name status }
         }
     """,
     "flash": """
         query GetFlash {
-          flash { id guid product vendor size }
+          flash { id product vendor }
         }
     """,
     "ups_devices": """
@@ -358,9 +357,9 @@ def register_info_tool(mcp: FastMCP) -> None:
         # Lookup tables for common response patterns
         # Simple dict actions: action -> GraphQL response key
         dict_actions: dict[str, str] = {
-            "network": "network",
+            "network": "vars",
             "registration": "registration",
-            "connect": "connect",
+            "connect": "vars",
             "variables": "vars",
             "metrics": "metrics",
             "config": "config",

--- a/unraid_mcp/tools/info.py
+++ b/unraid_mcp/tools/info.py
@@ -18,15 +18,14 @@ QUERIES: dict[str, str] = {
     "overview": """
         query GetSystemInfo {
           info {
-            os { platform distro release codename kernel arch hostname codepage logofile serial build uptime }
+            os { platform distro release codename kernel arch hostname logofile serial build uptime }
             cpu { manufacturer brand vendor family model stepping revision voltage speed speedmin speedmax threads cores processors socket cache flags }
             memory {
               layout { bank type clockSpeed formFactor manufacturer partNum serialNum }
             }
             baseboard { manufacturer model version serial assetTag }
             system { manufacturer model version serial uuid sku }
-            versions { kernel openssl systemOpenssl systemOpensslLib node v8 npm yarn pm2 gulp grunt git tsc mysql redis mongodb apache nginx php docker postfix postgresql perl python gcc unraid }
-            apps { installed started }
+            versions { id core { unraid api kernel } packages { openssl node npm pm2 git nginx php docker } }
             machineId
             time
           }
@@ -87,7 +86,7 @@ QUERIES: dict[str, str] = {
     """,
     "metrics": """
         query GetMetrics {
-          metrics { cpu { used } memory { used total } }
+          metrics { cpu { percentTotal } memory { used total } }
         }
     """,
     "services": """
@@ -122,7 +121,7 @@ QUERIES: dict[str, str] = {
         query GetServer {
           info {
             os { hostname uptime }
-            versions { unraid }
+            versions { core { unraid } }
             machineId time
           }
           array { state }


### PR DESCRIPTION
## Summary

Fixes all GraphQL schema mismatches introduced in Unraid 7.2.x that caused multiple MCP tools to fail with field validation errors. Verified and tested against a live Unraid 7.2.3 installation.

Closes #9

---

## Changes

### `unraid_mcp/tools/info.py`

| Query | Before (broken) | After (fixed) |
|---|---|---|
| `GetSystemInfo` (`overview`) | `os { ... codepage ... }` | removed `codepage` (field removed in 7.2 API) |
| `GetSystemInfo` (`overview`) | `versions { kernel openssl ... unraid }` | `versions { id core { unraid api kernel } packages { openssl node npm pm2 git nginx php docker } }` |
| `GetSystemInfo` (`overview`) | `apps { installed started }` | removed (field removed in 7.2 API) |
| `GetNetworkConfig` (`network`) | `network { id accessUrls { ... } }` | `vars { id useSsl port portssl localTld }` |
| `GetConnectSettings` (`connect`) | `connect { status sandbox flashGuid }` | `vars { id flashGuid flashProduct flashVendor }` |
| `GetMetrics` (`metrics`) | `cpu { used }` | `cpu { percentTotal }` |
| `GetServices` (`services`) | `services { name state }` | `services { name }` (`state` removed) |
| `GetServer` (`server`) | `versions { unraid }` | `versions { core { unraid } }` |
| `GetServers` (`servers`) | `servers { id name status description ip port }` | `servers { id name status }` |
| `GetFlash` (`flash`) | `flash { id guid product vendor size }` | `flash { id product vendor }` |
| Response handler | `"network": "network"` | `"network": "vars"` |
| Response handler | `"connect": "connect"` | `"connect": "vars"` |

### `unraid_mcp/tools/health.py`

| Section | Before (broken) | After (fixed) |
|---|---|---|
| `ComprehensiveHealthCheck` query | `versions { unraid }` | `versions { core { unraid } }` |
| Version extraction | `.get("versions", {}).get("unraid")` | `.get("versions", {}).get("core", {}).get("unraid")` |

### `unraid_mcp/tools/docker.py`

- Removed `logs` GraphQL query — `docker.logs` field does not exist in the current API
- Replaced with a helpful `ToolError` directing users to the Unraid web UI or SSH (`docker logs <id>`)

---

## Test Environment

| Property | Value |
|---|---|
| **Unraid OS** | 7.2.3 x86_64 |
| **Kernel** | 6.12.54-Unraid |
| **API version** | 4.28.2+d13a1f61 |
| **CPU** | Intel Core i3-10105 (4c/8t) |
| **RAM** | 64 GiB DDR4 3600MHz (Corsair) |
| **Motherboard** | MSI B560M PRO-E (MS-7D22) |
| **MCP transport** | streamable-http (`http://<unraid-host>:6970/mcp`) |
| **MCP server version** | 0.1.0 (Docker) |

---

## Tool-by-Tool Test Results

### `unraid_info` — 16 actions tested against Unraid 7.2.3

| Action | Before PR | After PR |
|---|---|---|
| `overview` | ❌ GraphQL error: `Cannot query field "codepage"`, `"apps"`, flat `versions` fields | ✅ Full system info returned |
| `array` | ✅ Working | ✅ Working |
| `network` | ❌ GraphQL error: `Cannot query field "network"` | ✅ Network vars returned |
| `registration` | ✅ Working | ✅ Working |
| `connect` | ❌ GraphQL error: `Cannot query field "connect"` | ✅ Connect settings returned |
| `variables` | ✅ Working | ✅ Working |
| `metrics` | ❌ GraphQL error: `Cannot query field "used" on CpuMetrics` | ✅ `percentTotal` returned |
| `services` | ❌ GraphQL error: `Cannot query field "state" on Service` | ✅ Services listed by name |
| `display` | ✅ Working | ✅ Working |
| `config` | ✅ Working | ✅ Working |
| `online` | ✅ Working | ✅ Working |
| `owner` | ✅ Working | ✅ Working |
| `server` | ❌ GraphQL error: `Cannot query field "unraid" on InfoVersions` | ✅ Server summary with OS version |
| `servers` | ❌ GraphQL error: extra fields on `servers` type | ✅ Servers listed |
| `flash` | ❌ GraphQL error: `guid`, `size` fields removed | ✅ Flash info returned |
| `settings` | ✅ Working | ✅ Working |

### `unraid_health` — all 3 actions

| Action | Before PR | After PR |
|---|---|---|
| `check` | ❌ GraphQL error: `Cannot query field "unraid" on InfoVersions` → returned `unhealthy` | ✅ Returns `healthy`, includes version, uptime, array state, docker containers |
| `test_connection` | ✅ Working | ✅ Working |
| `diagnose` | ✅ Working | ✅ Working |

### `unraid_array` — all 5 actions

| Action | Before PR | After PR |
|---|---|---|
| `parity_status` | ✅ Working | ✅ Working |
| All others | ✅ Working | ✅ Working |

### `unraid_docker` — 14 actions (logs removed)

| Action | Before PR | After PR |
|---|---|---|
| `list` | ✅ Working | ✅ Working |
| `details` | ✅ Working | ✅ Working |
| `start/stop/restart` | ✅ Working | ✅ Working |
| `logs` | ❌ GraphQL error: `docker.logs` field does not exist | ℹ️ Returns helpful error with web UI / SSH alternative |
| All others | ✅ Working | ✅ Working |

### `unraid_storage`, `unraid_vm`, `unraid_notifications`, `unraid_rclone`, `unraid_users`, `unraid_keys`

All actions verified working before and after (no schema changes needed).

---

## Root Cause

The Unraid 7.2.x API removed or restructured several GraphQL fields:
- `info.os.codepage` removed
- `info.apps` removed  
- `info.versions` changed from a flat scalar map to a nested object (`core`, `packages`)
- `network` top-level field removed (replaced by `vars`)
- `connect` top-level field removed (replaced by `vars`)
- `metrics.cpu.used` renamed to `metrics.cpu.percentTotal`
- `services.state` removed
- `servers.description/ip/port` removed
- `flash.guid/size` removed
- `docker.logs` removed entirely

---

🤖 Tested with [Claude Code](https://claude.ai/claude-code) against a live Unraid 7.2.3 instance

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GraphQL schema mismatches for Unraid 7.2.x to restore all MCP tools and stop field validation errors. Verified against Unraid 7.2.3.

- **Bug Fixes**
  - Info queries: remove os.codepage and apps; update versions to core/packages; cpu.used -> cpu.percentTotal; services.state removed; adjust server, servers, flash fields; move network/connect to vars and update handlers.
  - Health: query versions.core.unraid and update version extraction path.
  - Docker: remove unsupported logs query; return a clear error directing to the web UI or SSH.
  - Build: include LICENSE in Docker image.

<sup>Written for commit 8f388158b76d212d3b75a89ce7c34bd86f0f026c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logs are no longer available via GraphQL. Use the Unraid UI or docker CLI to view container logs.

* **Chores**
  * Updated Docker image to include LICENSE file.
  * Restructured system information queries for improved data organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->