### PR TITLE
Add Codex plugin scanner CI workflow

### DIFF
--- a/.github/workflows/codex-plugin-scanner.yml
+++ b/.github/workflows/codex-plugin-scanner.yml
@@ -1,0 +1,24 @@
+name: Codex Plugin Quality Gate
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: codex-plugin-scanner-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Codex plugin scanner
+        uses: hashgraph-online/hol-codex-plugin-scanner-action@b45d6b583afe05819b24edc8e6418c9ad2e1f1d0 # v1
+        with:
+          plugin_dir: "."


### PR DESCRIPTION
This PR adds a Codex plugin scanner CI workflow to maintain code quality and security standards. The scanner will run on all pull requests to ensure the plugin follows best practices for manifest validation, security, and code quality. 

Personalized note: This Unraid MCP plugin shows good overall quality (B grade 81/100) but has significant security concerns with 11 high-severity hardcoded secrets that need immediate attention across tests, documentation, and skill scripts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Codex plugin scanner CI workflow for pushes and PRs to `main` to enforce manifest validation, security, and code quality. Uses pinned `actions/checkout` and `hashgraph-online/hol-codex-plugin-scanner-action` with read-only permissions, concurrency cancel, and a 10‑min timeout; initial scan flagged 11 high‑severity hardcoded secrets to fix.

<sup>Written for commit 4d4a63d17e318f2ab7eca9f068332a5f7f270c4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated quality validation checks now run on code updates to ensure plugin integrity and maintain code standards on the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->