### PR TITLE
docs: add comprehensive documentation from templates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unraid-mcp",
   "displayName": "Unraid MCP",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools. Supports system info, Docker, VMs, array/parity, notifications, plugins, rclone, and live telemetry.",
   "author": {
     "name": "Jacob Magar",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unraid-mcp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Unraid server management via MCP.",
   "homepage": "https://github.com/jmagar/unraid-mcp",
   "repository": "https://github.com/jmagar/unraid-mcp",

--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,6 @@ UNRAID_MCP_BEARER_TOKEN=your_bearer_token
 
 # Safety flags
 # ------------
-UNRAID_MCP_ALLOW_DESTRUCTIVE=false
-UNRAID_MCP_ALLOW_YOLO=false
 UNRAID_MCP_DISABLE_HTTP_AUTH=false
 
 # Docker user / network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-04-04
+
+### Added
+- **Comprehensive test suite**: Added tests for core modules, configuration, validation, subscriptions, and edge cases
+- **Test coverage documentation**: `tests/TEST_COVERAGE.md` with coverage map and gap analysis
+
+### Changed
+- **Documentation**: Comprehensive updates across CLAUDE.md, README, and reference docs
+- **Version sync**: Fixed `pyproject.toml` version mismatch (was 1.2.2, now aligned with all manifests at 1.2.4)
+
 ## [1.2.3] - 2026-04-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -383,8 +383,6 @@ just setup
 | `UNRAID_MCP_PORT` | No | `6970` | Listen port for HTTP transports |
 | `UNRAID_MCP_BEARER_TOKEN` | Conditional | — | Static Bearer token for HTTP transports; auto-generated on first start if unset |
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | No | `false` | Set `true` to skip Bearer auth (use behind a reverse proxy that handles auth) |
-| `UNRAID_MCP_ALLOW_DESTRUCTIVE` | No | `false` | Reserved safety flag |
-| `UNRAID_MCP_ALLOW_YOLO` | No | `false` | Reserved safety flag |
 | `DOCKER_NETWORK` | No | — | External Docker network to join; leave blank for default bridge |
 | `PGID` | No | `1000` | Container process GID |
 | `PUID` | No | `1000` | Container process UID |

--- a/docs/CHECKLIST.md
+++ b/docs/CHECKLIST.md
@@ -1,0 +1,71 @@
+# Plugin Checklist -- unraid-mcp
+
+Pre-release and quality checklist. Complete all items before tagging a release.
+
+## Version and metadata
+
+- [ ] `pyproject.toml` version bumped
+- [ ] `.claude-plugin/plugin.json` version matches
+- [ ] `.codex-plugin/plugin.json` version matches
+- [ ] `gemini-extension.json` version matches
+- [ ] `server.json` version matches (updated by publish workflow)
+- [ ] `CHANGELOG.md` has entry for the new version
+- [ ] All four version files show the same version string
+
+## Code quality
+
+- [ ] `uv run ruff check unraid_mcp/` passes (no lint errors)
+- [ ] `uv run ruff format --check unraid_mcp/` passes (no format drift)
+- [ ] `uv run ty check unraid_mcp/` passes (no type errors)
+- [ ] `uv run pytest -m "not slow and not integration"` passes (all unit tests green)
+- [ ] `uv run pytest tests/safety/` passes (destructive action guards verified)
+- [ ] `uv run pytest tests/schema/` passes (GraphQL query validation)
+
+## Security
+
+- [ ] No credentials in code, docs, or commit history
+- [ ] `~/.unraid-mcp/.env` has `chmod 600` permissions
+- [ ] `~/.unraid-mcp/` directory has `chmod 700` permissions
+- [ ] `scripts/check-docker-security.sh` passes
+- [ ] `scripts/check-no-baked-env.sh` passes
+- [ ] `scripts/ensure-ignore-files.sh --check` passes
+- [ ] Bearer token uses constant-time comparison (`hmac.compare_digest`)
+- [ ] No sensitive values logged (even at DEBUG level)
+- [ ] `UNRAID_MCP_BEARER_TOKEN` removed from `os.environ` after startup
+
+## Plugin manifests
+
+- [ ] `.claude-plugin/plugin.json` has correct `mcpServers` config
+- [ ] `.codex-plugin/plugin.json` has correct interface metadata
+- [ ] `gemini-extension.json` has correct `mcpServers` and `settings`
+- [ ] `server.json` has correct MCP registry schema and PyPI package info
+- [ ] `skills/unraid/SKILL.md` is up to date with all actions and subactions
+
+## Docker
+
+- [ ] `Dockerfile` uses multi-stage build (builder + runtime)
+- [ ] Runtime image runs as non-root user (`mcp:1000`)
+- [ ] `HEALTHCHECK` configured in Dockerfile
+- [ ] `docker-compose.yaml` healthcheck works for both HTTP and stdio transports
+- [ ] Resource limits set (1024M memory, 1.0 CPU)
+- [ ] Credentials volume mount is named volume (not bind mount)
+
+## CI/CD
+
+- [ ] `ci.yml` lint, typecheck, test, version-sync, audit, docker-security jobs pass
+- [ ] `docker-publish.yml` builds multi-arch (amd64, arm64) images
+- [ ] `publish-pypi.yml` tag-version check, PyPI publish, GitHub release, MCP registry publish all configured
+- [ ] Trivy vulnerability scan runs on published images
+
+## Hooks
+
+- [ ] `hooks/hooks.json` registers PostToolUse hooks
+- [ ] `fix-env-perms.sh` enforces 600 on credential files
+- [ ] `ensure-ignore-files.sh` keeps `.gitignore` and `.dockerignore` aligned
+
+## Documentation
+
+- [ ] `CLAUDE.md` reflects current architecture and tool counts
+- [ ] `README.md` has correct tool table and quick start examples
+- [ ] `skills/unraid/SKILL.md` documents all 15 action domains
+- [ ] `docs/` directory is complete and has no template placeholders

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,121 @@
+# Configuration Reference -- unraid-mcp
+
+Complete environment variable reference and configuration options.
+
+## Environment file
+
+The canonical configuration file is `~/.unraid-mcp/.env`. The server searches for `.env` files in this priority order:
+
+1. `~/.unraid-mcp/.env` -- primary (canonical credentials dir, all runtimes)
+2. `~/.unraid-mcp/.env.local` -- local overrides (only if primary is absent)
+3. `/app/.env.local` -- Docker compat mount
+4. `<project-root>/.env.local` -- dev overrides
+5. `<project-root>/.env` -- dev fallback
+6. `unraid_mcp/.env` -- last resort
+
+Override the credentials directory with `UNRAID_CREDENTIALS_DIR`.
+
+## Required variables
+
+| Variable | Description |
+| --- | --- |
+| `UNRAID_API_URL` | Unraid GraphQL endpoint (e.g. `https://tower.local/graphql`). No trailing slash. |
+| `UNRAID_API_KEY` | Unraid API key. Found in Settings > Management Access > API Keys. |
+
+## Server variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_MCP_HOST` | `0.0.0.0` | Bind address for HTTP transport |
+| `UNRAID_MCP_PORT` | `6970` | Port for the MCP HTTP server. Must be 1-65535. |
+| `UNRAID_MCP_TRANSPORT` | `streamable-http` | Transport method: `streamable-http`, `stdio`, or `sse` (deprecated) |
+
+## Authentication variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_MCP_BEARER_TOKEN` | auto-generated | Bearer token for HTTP auth. Auto-generated on first HTTP startup if absent. Generate manually with `openssl rand -hex 32`. |
+| `UNRAID_MCP_DISABLE_HTTP_AUTH` | `false` | Set `true` to disable bearer auth (only behind a trusted gateway). |
+
+## SSL variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_VERIFY_SSL` | `true` | SSL verification for upstream Unraid API. Set `false` for self-signed certs. Can also be a path to a CA bundle. |
+
+## Logging variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_MCP_LOG_LEVEL` | `INFO` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
+| `UNRAID_MCP_LOG_FILE` | `unraid-mcp.log` | Log filename (written to `logs/` directory or `/app/logs/` in Docker) |
+
+Log files are capped at 10 MB and overwritten to prevent disk space issues.
+
+## Subscription variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_AUTO_START_SUBSCRIPTIONS` | `true` | Auto-start WebSocket subscriptions on server boot |
+| `UNRAID_MAX_RECONNECT_ATTEMPTS` | `10` | Maximum WebSocket reconnection attempts before giving up |
+| `UNRAID_AUTOSTART_LOG_PATH` | auto-detect | Log file path for the log tail subscription. Defaults to `/var/log/syslog` if available. |
+
+## Credentials directory
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_CREDENTIALS_DIR` | `~/.unraid-mcp` | Override the credentials directory path. Useful for containers or custom deployments. |
+
+## Docker variables
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PUID` | `1000` | User ID for the container process |
+| `PGID` | `1000` | Group ID for the container process |
+| `DOCKER_NETWORK` | -- | External Docker network name. Leave unset for default bridge. |
+
+## Timeouts
+
+Configured in code (not via environment variables):
+
+| Context | Timeout | Notes |
+| --- | --- | --- |
+| Default HTTP requests | 30s | Standard GraphQL queries |
+| Disk operations | 90s | SMART data queries need longer |
+| Tool execution | 120s | FastMCP tool timeout |
+| WebSocket collection | 5s default | Configurable via `collect_for` parameter |
+
+## Middleware configuration
+
+Configured in code:
+
+| Middleware | Setting | Value |
+| --- | --- | --- |
+| Rate limiting | Max requests | 540 per 60-second sliding window |
+| Response limiting | Max size | 512 KB (truncated, not errored) |
+| Logging | Methods logged | `tools/call`, `resources/read` |
+| Error handling | Traceback included | Only when `LOG_LEVEL=DEBUG` |
+
+## Example .env file
+
+```bash
+# Core API Configuration (Required)
+UNRAID_API_KEY=your_api_key
+UNRAID_API_URL=http://your-unraid-server
+
+# MCP Server Settings
+UNRAID_MCP_HOST=0.0.0.0
+UNRAID_MCP_PORT=6970
+UNRAID_MCP_TRANSPORT=streamable-http
+
+# HTTP Bearer Token Authentication
+UNRAID_MCP_BEARER_TOKEN=your_bearer_token
+
+# Safety flags
+UNRAID_MCP_DISABLE_HTTP_AUTH=false
+
+# Docker user / network
+DOCKER_NETWORK=
+PGID=1000
+PUID=1000
+```

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -1,0 +1,117 @@
+# Security Guardrails -- unraid-mcp
+
+Safety and security patterns enforced across the unraid-mcp server.
+
+## Credential management
+
+### Storage
+
+- Credentials live in `~/.unraid-mcp/.env` (mode 600, directory mode 700)
+- The elicitation setup wizard writes credentials atomically (tmp file + `os.replace`)
+- Credentials are never written to `os.environ` after startup -- all internal consumers read from module globals via `from ..config import settings`
+- Bearer tokens are removed from `os.environ` immediately after being applied to prevent subprocess inheritance
+
+### Loading priority
+
+The server loads from the first `.env` file found:
+1. `~/.unraid-mcp/.env`
+2. `~/.unraid-mcp/.env.local`
+3. `/app/.env.local`
+4. `<project-root>/.env.local`
+5. `<project-root>/.env`
+6. `unraid_mcp/.env`
+
+### Sensitive value redaction
+
+The `redact_sensitive()` function in `core/client.py` recursively replaces values for keys matching:
+- Exact: `key`, `pin`
+- Substring: `password`, `secret`, `token`, `apikey`, `authorization`, `credential`, `passphrase`, `jwt`, `cookie`, `session`
+
+All debug logging passes through this function.
+
+## Destructive action gating
+
+### Two-tier confirmation
+
+All destructive operations are gated by the `gate_destructive_action()` function in `core/guards.py`:
+
+1. **Interactive clients (elicitation)**: The server sends an elicitation request with a checkbox confirmation. The user must explicitly check "confirmed" and submit.
+2. **Non-interactive clients (confirm=True)**: Agents and API callers must pass `confirm=True` to bypass elicitation.
+
+### Destructive actions registry
+
+| Domain | Destructive subactions |
+| --- | --- |
+| `array` | `stop_array`, `remove_disk`, `clear_disk_stats` |
+| `vm` | `force_stop`, `reset` |
+| `notification` | `delete`, `delete_archived` |
+| `rclone` | `delete_remote` |
+| `key` | `delete` |
+| `disk` | `flash_backup` |
+| `setting` | `configure_ups` |
+| `plugin` | `remove` |
+
+Each domain module defines its own `_*_DESTRUCTIVE` set and per-action description dictionary.
+
+### Elicitation fallback
+
+When the MCP client does not support elicitation:
+- `NotImplementedError` is caught
+- A warning is logged
+- The operation is blocked with a `ToolError` instructing the user to re-run with `confirm=True`
+
+## HTTP authentication
+
+### Bearer token (RFC 6750)
+
+- Constant-time comparison via `hmac.compare_digest` prevents timing attacks
+- Missing header returns 401 with `WWW-Authenticate: Bearer realm="unraid-mcp"`
+- Invalid token returns 401 with `error="invalid_token"`
+- Per-IP rate limiting: 60 failures per 60-second window triggers 429 with `Retry-After: 60`
+- Maximum 10,000 unique IPs tracked to prevent memory exhaustion DoS
+- Log throttling: at most one warning per IP per 30 seconds
+
+### RFC 9728 well-known endpoint
+
+`GET /.well-known/oauth-protected-resource` returns resource metadata with an empty `authorization_servers` list, telling MCP clients to use a pre-shared bearer token (no OAuth flow).
+
+### Health endpoint bypass
+
+`GET /health` is served by `HealthMiddleware` outside the auth layer, allowing unauthenticated Docker healthchecks.
+
+## Input validation
+
+### Log path validation
+
+Log file paths are restricted to allowed prefixes (`/var/log/`, `/boot/logs/`, `/mnt/`) to prevent path traversal.
+
+### GraphQL injection prevention
+
+- All queries and mutations use pre-built query dicts (`_*_QUERIES`, `_*_MUTATIONS`)
+- No string interpolation of user input into GraphQL query strings
+- Subscription test tool only allows whitelisted field names: `containerStats`, `cpu`, `memory`, `array`, `network`, `docker`, `vm`
+
+### Port validation
+
+`UNRAID_MCP_PORT` is validated as an integer in range 1-65535 at startup. Invalid values cause immediate exit.
+
+## Response safety
+
+### Size limiting
+
+`ResponseLimitingMiddleware` truncates responses exceeding 512 KB with a clear suffix rather than erroring. This protects client context windows from oversized responses.
+
+### Rate limiting
+
+`SlidingWindowRateLimitingMiddleware` enforces 540 requests per 60-second sliding window. This stays under the Unraid API's 600 req/min ceiling.
+
+### Log content capping
+
+Subscription data with log content is capped at 1 MB / 5,000 lines to prevent unbounded memory growth from persistent WebSocket streams.
+
+## Hooks enforcement
+
+PostToolUse hooks run after every Write, Edit, MultiEdit, or Bash operation:
+
+- `fix-env-perms.sh`: Ensures `~/.unraid-mcp/.env` stays at mode 600
+- `ensure-ignore-files.sh`: Keeps `.gitignore` and `.dockerignore` aligned with security requirements

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -1,0 +1,118 @@
+# Component Inventory -- unraid-mcp
+
+Complete listing of all plugin components.
+
+## MCP tools
+
+| Tool | Type | Module | Description |
+| --- | --- | --- | --- |
+| `unraid` | Primary | `tools/unraid.py` | Unified action router: 15 domains, 107 subactions |
+| `unraid_help` | Helper | `tools/unraid.py` | Returns markdown reference for all actions |
+| `diagnose_subscriptions` | Diagnostic | `subscriptions/diagnostics.py` | Inspect subscription states, errors, WebSocket URLs |
+| `test_subscription_query` | Diagnostic | `subscriptions/diagnostics.py` | Test a GraphQL subscription query (allowlisted fields) |
+
+## MCP resources
+
+| URI | Source | Description |
+| --- | --- | --- |
+| `unraid://logs/stream` | `logFileSubscription` | Real-time log stream data |
+| `unraid://live/cpu` | `cpu` subscription | Live CPU utilization |
+| `unraid://live/memory` | `memory` subscription | Live memory usage |
+| `unraid://live/cpu_telemetry` | `cpu_telemetry` subscription | CPU power and temperature |
+| `unraid://live/array_state` | `array_state` subscription | Array state changes |
+| `unraid://live/parity_progress` | `parity_progress` subscription | Parity check progress |
+| `unraid://live/ups_status` | `ups_status` subscription | UPS battery and power |
+| `unraid://live/notifications_overview` | `notifications_overview` subscription | Notification counts |
+| `unraid://live/owner` | `owner` subscription | Server owner info |
+| `unraid://live/server_status` | `server_status` subscription | Server status and connectivity |
+
+## Action domains
+
+| Domain | Subaction count | Module | Destructive? |
+| --- | --- | --- | --- |
+| `system` | 18 | `tools/_system.py` | No |
+| `health` | 4 | `tools/unraid.py` | No |
+| `array` | 13 | `tools/_array.py` | Yes (3) |
+| `disk` | 6 | `tools/_disk.py` | Yes (1) |
+| `docker` | 7 | `tools/_docker.py` | No |
+| `vm` | 9 | `tools/_vm.py` | Yes (2) |
+| `notification` | 12 | `tools/_notification.py` | Yes (2) |
+| `key` | 7 | `tools/_key.py` | Yes (1) |
+| `plugin` | 3 | `tools/_plugin.py` | Yes (1) |
+| `rclone` | 4 | `tools/_rclone.py` | Yes (1) |
+| `setting` | 2 | `tools/_setting.py` | Yes (1) |
+| `customization` | 5 | `tools/_customization.py` | No |
+| `oidc` | 5 | `tools/_oidc.py` | No |
+| `user` | 1 | `tools/_user.py` | No |
+| `live` | 11 | `tools/_live.py` | No |
+
+## Middleware chain
+
+| Layer | Class | Purpose |
+| --- | --- | --- |
+| 1 (outermost) | `LoggingMiddleware` | Logs every tools/call and resources/read with duration |
+| 2 | `ErrorHandlingMiddleware` | Converts unhandled exceptions to MCP errors |
+| 3 | `SlidingWindowRateLimitingMiddleware` | 540 req/min sliding window |
+| 4 (innermost) | `ResponseLimitingMiddleware` | Truncates responses > 512 KB |
+
+## ASGI middleware
+
+| Layer | Class | Purpose |
+| --- | --- | --- |
+| 1 (outermost) | `HealthMiddleware` | `GET /health` returns 200 without auth |
+| 2 | `WellKnownMiddleware` | RFC 9728 OAuth protected resource metadata |
+| 3 (innermost) | `BearerAuthMiddleware` | RFC 6750 bearer token validation |
+
+## Plugin manifests
+
+| File | Client | Transport |
+| --- | --- | --- |
+| `.claude-plugin/plugin.json` | Claude Code | stdio (via `uv run`) |
+| `.codex-plugin/plugin.json` | Codex CLI | stdio (via `.mcp.json`) |
+| `gemini-extension.json` | Gemini CLI | stdio (via `uv run`) |
+| `server.json` | MCP Registry (tv.tootie/unraid-mcp) | stdio (PyPI package) |
+
+## Skills
+
+| Path | Name | Description |
+| --- | --- | --- |
+| `skills/unraid/SKILL.md` | unraid | Client-facing skill with all domains, subactions, and workflows |
+
+## Hooks
+
+| Hook | Trigger | Script |
+| --- | --- | --- |
+| Fix env permissions | PostToolUse (Write/Edit/Bash) | `hooks/scripts/fix-env-perms.sh` |
+| Ensure ignore files | PostToolUse (Write/Edit/Bash) | `hooks/scripts/ensure-ignore-files.sh` |
+
+## Scripts
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/check-docker-security.sh` | Dockerfile security audit |
+| `scripts/check-no-baked-env.sh` | Verify no env vars baked into images |
+| `scripts/check-outdated-deps.sh` | Dependency freshness check |
+| `scripts/ensure-ignore-files.sh` | Gitignore/dockerignore alignment |
+| `scripts/generate_unraid_api_reference.py` | Generate API reference from GraphQL introspection |
+| `scripts/lint-plugin.sh` | Plugin manifest validation |
+| `scripts/validate-marketplace.sh` | Marketplace JSON validation |
+
+## CI/CD workflows
+
+| Workflow | Trigger | Jobs |
+| --- | --- | --- |
+| `ci.yml` | Push/PR to main | lint, typecheck, test, version-sync, mcp-integration, audit, docker-security |
+| `docker-publish.yml` | Push to main/tags | Build multi-arch Docker image, push to ghcr.io, Trivy scan |
+| `publish-pypi.yml` | Tag `v*.*.*` | Build, PyPI publish, GitHub release, MCP registry publish |
+
+## Test suites
+
+| Directory | Focus | Count |
+| --- | --- | --- |
+| `tests/` (root) | Unit tests per domain | 28 test files |
+| `tests/safety/` | Destructive action guards | guard verification |
+| `tests/schema/` | GraphQL query validation | 119 tests |
+| `tests/http_layer/` | httpx request/response | HTTP client tests |
+| `tests/integration/` | WebSocket subscription lifecycle | slow, live tests |
+| `tests/contract/` | Response shape contracts | shape validation |
+| `tests/property/` | Input validation (Hypothesis) | property-based |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,216 @@
+# Unraid MCP
+
+<!-- mcp-name: tv.tootie/unraid-mcp -->
+
+[![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/jmagar/unraid-mcp/pkgs/container/unraid-mcp)
+
+MCP server for Unraid NAS management. Exposes a unified `unraid` action router with 15 action domains and 107 subactions, plus `unraid_help` and two diagnostic tools, all backed by Unraid's GraphQL API and real-time WebSocket subscriptions.
+
+## Overview
+
+Four MCP tools are exposed:
+
+| Tool | Purpose |
+| --- | --- |
+| `unraid` | Unified action router for all Unraid operations (15 domains, 107 subactions) |
+| `unraid_help` | Returns markdown documentation for all actions and parameters |
+| `diagnose_subscriptions` | Inspect WebSocket subscription connection states and errors |
+| `test_subscription_query` | Test a specific GraphQL subscription query against allowlisted fields |
+
+The server supports streamable-http (default), SSE (deprecated), and stdio transports. HTTP transports require RFC 6750 bearer authentication via `UNRAID_MCP_BEARER_TOKEN`.
+
+## What this repository ships
+
+- `unraid_mcp/server.py`: FastMCP server with 4-layer middleware chain and ASGI bearer auth
+- `unraid_mcp/tools/`: 16 domain modules (array, customization, disk, docker, health, key, live, notification, oidc, plugin, rclone, setting, system, user, vm) plus the consolidated `unraid.py` router
+- `unraid_mcp/subscriptions/`: WebSocket subscription manager, resource registration, diagnostics, and snapshot queries
+- `unraid_mcp/core/`: GraphQL client, elicitation-based setup, destructive action guards, auth middleware
+- `unraid_mcp/config/`: Settings management and structured logging
+- `skills/unraid/SKILL.md`: Client-facing skill documentation
+- `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`: Client manifests
+- `docker-compose.yaml`, `Dockerfile`, `entrypoint.sh`: Container deployment
+- `scripts/`: Security checks, dependency audits, and plugin validation
+- `hooks/`: Post-tool hooks for env permissions and gitignore enforcement
+
+## Tools
+
+### `unraid`
+
+Single entry point for all Unraid operations. Select the operation with `action` + `subaction`.
+
+| Action | Subactions | Description |
+| --- | --- | --- |
+| `system` (18) | `overview`, `array`, `network`, `registration`, `variables`, `metrics`, `services`, `display`, `config`, `online`, `owner`, `settings`, `server`, `servers`, `flash`, `ups_devices`, `ups_device`, `ups_config` | Server info, metrics, network, UPS |
+| `health` (4) | `check`, `test_connection`, `diagnose`, `setup` | Health checks, connection test, credential setup |
+| `array` (13) | `parity_status`, `parity_history`, `parity_start`, `parity_pause`, `parity_resume`, `parity_cancel`, `start_array`, `stop_array`\*, `add_disk`, `remove_disk`\*, `mount_disk`, `unmount_disk`, `clear_disk_stats`\* | Parity checks, array lifecycle, disk operations |
+| `disk` (6) | `shares`, `disks`, `disk_details`, `log_files`, `logs`, `flash_backup`\* | Shares, physical disks, log files |
+| `docker` (7) | `list`, `details`, `start`, `stop`, `restart`, `networks`, `network_details` | Container lifecycle and network inspection |
+| `vm` (9) | `list`, `details`, `start`, `stop`, `pause`, `resume`, `force_stop`\*, `reboot`, `reset`\* | Virtual machine lifecycle |
+| `notification` (12) | `overview`, `list`, `create`, `archive`, `mark_unread`, `recalculate`, `archive_all`, `archive_many`, `unarchive_many`, `unarchive_all`, `delete`\*, `delete_archived`\* | Notification CRUD |
+| `key` (7) | `list`, `get`, `create`, `update`, `delete`\*, `add_role`, `remove_role` | API key management |
+| `plugin` (3) | `list`, `add`, `remove`\* | Plugin management |
+| `rclone` (4) | `list_remotes`, `config_form`, `create_remote`, `delete_remote`\* | Cloud storage remotes |
+| `setting` (2) | `update`, `configure_ups`\* | System settings and UPS config |
+| `customization` (5) | `theme`, `public_theme`, `is_initial_setup`, `sso_enabled`, `set_theme` | Theme and UI customization |
+| `oidc` (5) | `providers`, `provider`, `configuration`, `public_providers`, `validate_session` | OIDC/SSO provider management |
+| `user` (1) | `me` | Current authenticated user |
+| `live` (11) | `cpu`, `memory`, `cpu_telemetry`, `array_state`, `parity_progress`, `ups_status`, `notifications_overview`, `notification_feed`, `log_tail`, `owner`, `server_status` | Real-time WebSocket subscription snapshots |
+
+\* Destructive -- requires `confirm=True`
+
+### `unraid_help`
+
+Returns the full action reference as Markdown. Call this to discover available actions.
+
+```python
+unraid_help()
+```
+
+## Installation
+
+### Marketplace
+
+```bash
+/plugin marketplace add jmagar/claude-homelab
+/plugin install unraid-mcp @jmagar-claude-homelab
+```
+
+### Local development
+
+```bash
+uv sync --dev
+uv run unraid-mcp-server
+```
+
+### Docker
+
+```bash
+just up
+```
+
+Or manually:
+
+```bash
+docker compose up -d
+```
+
+## Authentication
+
+The MCP server uses bearer token authentication for HTTP transports (streamable-http, SSE).
+
+A token is auto-generated on first HTTP startup if none is configured. It is written to `~/.unraid-mcp/.env`.
+
+To generate manually:
+
+```bash
+openssl rand -hex 32
+```
+
+Set it in `~/.unraid-mcp/.env`:
+
+```bash
+UNRAID_MCP_BEARER_TOKEN=<generated-token>
+```
+
+Configure your MCP client to send the token as a Bearer header. See [AUTH](mcp/AUTH.md) for detailed setup.
+
+To disable auth (only behind a trusted reverse proxy):
+
+```bash
+UNRAID_MCP_DISABLE_HTTP_AUTH=true
+```
+
+## Configuration
+
+Copy `.env.example` to `~/.unraid-mcp/.env` and fill in the required values:
+
+```bash
+mkdir -p ~/.unraid-mcp
+cp .env.example ~/.unraid-mcp/.env
+chmod 600 ~/.unraid-mcp/.env
+```
+
+Or use the interactive setup wizard:
+
+```python
+unraid(action="health", subaction="setup")
+```
+
+### Environment variables
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `UNRAID_API_URL` | yes | -- | Unraid GraphQL endpoint (e.g. `https://tower.local/graphql`) |
+| `UNRAID_API_KEY` | yes | -- | Unraid API key (Settings > Management Access > API Keys) |
+| `UNRAID_MCP_BEARER_TOKEN` | yes\* | auto-generated | Bearer token for MCP HTTP auth |
+| `UNRAID_MCP_PORT` | no | `6970` | Port for the MCP HTTP server |
+
+\*Required when `UNRAID_MCP_TRANSPORT != stdio` and `UNRAID_MCP_DISABLE_HTTP_AUTH != true`.
+
+See [CONFIG](CONFIG.md) for all variables including logging, SSL, subscriptions, and Docker settings.
+
+## Quick start
+
+```python
+# First-time setup
+unraid(action="health", subaction="setup")
+
+# System overview
+unraid(action="system", subaction="overview")
+
+# Health check
+unraid(action="health", subaction="check")
+
+# List Docker containers
+unraid(action="docker", subaction="list")
+
+# Restart a container
+unraid(action="docker", subaction="restart", container_id="plex")
+
+# Parity status
+unraid(action="array", subaction="parity_status")
+
+# Live CPU monitoring
+unraid(action="live", subaction="cpu")
+
+# Stop array (destructive)
+unraid(action="array", subaction="stop_array", confirm=True)
+```
+
+## Docker usage
+
+```bash
+# Build and start
+just up
+
+# View logs
+just logs
+
+# Health check
+just health
+# or: curl http://localhost:6970/health
+
+# Stop
+just down
+```
+
+The `/health` endpoint is unauthenticated for liveness probes.
+
+## Related plugins
+
+| Plugin | Category | Description |
+|--------|----------|-------------|
+| [homelab-core](https://github.com/jmagar/claude-homelab) | core | Core agents, commands, skills, and setup/health workflows for homelab management. |
+| [overseerr-mcp](https://github.com/jmagar/overseerr-mcp) | media | Search movies and TV shows, submit requests, and monitor failed requests via Overseerr. |
+| [unifi-mcp](https://github.com/jmagar/unifi-mcp) | infrastructure | Monitor and manage UniFi devices and network health. |
+| [swag-mcp](https://github.com/jmagar/swag-mcp) | infrastructure | Manage SWAG nginx reverse proxy configurations. |
+| [synapse-mcp](https://github.com/jmagar/synapse-mcp) | infrastructure | Docker management and SSH remote operations across homelab hosts. |
+| [arcane-mcp](https://github.com/jmagar/arcane-mcp) | infrastructure | Manage Docker environments, containers, images, volumes, and networks. |
+| [syslog-mcp](https://github.com/jmagar/syslog-mcp) | infrastructure | Receive, index, and search syslog streams via SQLite FTS5. |
+| [gotify-mcp](https://github.com/jmagar/gotify-mcp) | utilities | Send push notifications and manage Gotify messages and applications. |
+| [plugin-lab](https://github.com/jmagar/plugin-lab) | dev-tools | Scaffold, review, align, and deploy homelab MCP plugins. |
+| [axon](https://github.com/jmagar/axon) | research | Self-hosted web crawl, ingest, embed, and RAG pipeline with MCP tooling. |
+
+## License
+
+MIT

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,0 +1,133 @@
+# Setup Guide -- unraid-mcp
+
+Step-by-step instructions to get unraid-mcp running locally, in Docker, or as a Claude Code plugin.
+
+## Prerequisites
+
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/) package manager
+- An Unraid server with the API enabled (Settings > Management Access > API Keys)
+- Docker and Docker Compose (for container deployment)
+
+## Option 1: Interactive setup (recommended)
+
+The server includes an elicitation-based setup wizard that collects credentials interactively.
+
+1. Install as a Claude Code plugin:
+   ```bash
+   /plugin marketplace add jmagar/claude-homelab
+   /plugin install unraid-mcp @jmagar-claude-homelab
+   ```
+
+2. Run the setup wizard:
+   ```python
+   unraid(action="health", subaction="setup")
+   ```
+
+3. The wizard prompts for:
+   - **API URL**: Your Unraid GraphQL endpoint (e.g. `https://10-1-0-2.xxx.myunraid.net:31337`)
+   - **API Key**: Found in Unraid > Settings > Management Access > API Keys
+
+4. Credentials are written to `~/.unraid-mcp/.env` with mode 600.
+
+5. Verify the connection:
+   ```python
+   unraid(action="health", subaction="test_connection")
+   ```
+
+## Option 2: Manual .env setup
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/jmagar/unraid-mcp.git
+   cd unraid-mcp
+   ```
+
+2. Create the credentials directory and file:
+   ```bash
+   mkdir -p ~/.unraid-mcp
+   cp .env.example ~/.unraid-mcp/.env
+   chmod 700 ~/.unraid-mcp
+   chmod 600 ~/.unraid-mcp/.env
+   ```
+
+3. Edit `~/.unraid-mcp/.env` with your credentials:
+   ```bash
+   UNRAID_API_URL=https://your-unraid-server
+   UNRAID_API_KEY=your_api_key
+   ```
+
+4. Install dependencies and start:
+   ```bash
+   uv sync
+   uv run unraid-mcp-server
+   ```
+
+## Option 3: Docker deployment
+
+1. Clone and configure:
+   ```bash
+   git clone https://github.com/jmagar/unraid-mcp.git
+   cd unraid-mcp
+   ```
+
+2. Set up credentials (the Docker container reads from `~/.claude-homelab/.env` via env_file):
+   ```bash
+   # Ensure your credentials are in ~/.claude-homelab/.env
+   # or modify docker-compose.yaml to point to ~/.unraid-mcp/.env
+   ```
+
+3. Start the container:
+   ```bash
+   docker compose up -d
+   ```
+
+4. Verify:
+   ```bash
+   curl http://localhost:6970/health
+   ```
+
+## Option 4: PyPI install
+
+```bash
+uvx unraid-mcp
+# or
+pip install unraid-mcp
+unraid-mcp-server
+```
+
+## Post-setup verification
+
+After any installation method, verify the setup:
+
+```python
+# Test connection
+unraid(action="health", subaction="test_connection")
+
+# Run full health check
+unraid(action="health", subaction="check")
+
+# Get system overview
+unraid(action="system", subaction="overview")
+```
+
+## Troubleshooting
+
+**"Credentials not configured"**
+- Run `unraid(action="health", subaction="setup")` to configure interactively
+- Or create `~/.unraid-mcp/.env` manually from `.env.example`
+
+**"Connection refused"**
+- Verify `UNRAID_API_URL` is correct and accessible from the server host
+- Check if Unraid's API is enabled in Settings > Management Access
+
+**"SSL verification failed"**
+- For self-signed certificates, set `UNRAID_VERIFY_SSL=false` in `.env`
+- Only use this in trusted networks
+
+**"Bearer token required"**
+- The server auto-generates a token on first HTTP startup
+- Check `~/.unraid-mcp/.env` for the generated `UNRAID_MCP_BEARER_TOKEN`
+- Configure your MCP client to send it as `Authorization: Bearer <token>`
+
+See [CONFIG](CONFIG.md) for all environment variables and [mcp/AUTH](mcp/AUTH.md) for authentication details.

--- a/docs/mcp/AUTH.md
+++ b/docs/mcp/AUTH.md
@@ -1,0 +1,130 @@
+# Authentication Reference
+
+## Overview
+
+unraid-mcp has two authentication boundaries:
+
+1. **Inbound (client to MCP server)**: Bearer token authentication on HTTP transports
+2. **Outbound (MCP server to Unraid)**: API key authentication via `x-api-key` header
+
+## Inbound: Bearer token (RFC 6750)
+
+### How it works
+
+The `BearerAuthMiddleware` (ASGI-level) wraps the entire HTTP stack. It fires before any MCP protocol processing.
+
+1. Client sends `Authorization: Bearer <token>` header
+2. Server validates with constant-time comparison (`hmac.compare_digest`)
+3. Valid token: request forwarded to MCP server
+4. Invalid/missing token: 401 with `WWW-Authenticate` header
+
+### Token management
+
+**Auto-generation**: On first HTTP startup, if no token is configured:
+1. Server generates a `secrets.token_urlsafe(32)` token
+2. Writes it to `~/.unraid-mcp/.env` using `dotenv.set_key` (in-place, preserves comments)
+3. Sets file permissions to 600
+4. Removes the token from `os.environ` (prevents subprocess inheritance)
+5. Prints the token location to stderr
+
+**Manual generation**:
+```bash
+openssl rand -hex 32
+```
+
+Set in `~/.unraid-mcp/.env`:
+```bash
+UNRAID_MCP_BEARER_TOKEN=<your-token>
+```
+
+### Client configuration
+
+#### Claude Code plugin
+The `userConfig` in `.claude-plugin/plugin.json` includes `unraid_mcp_token` (sensitive: true). Claude Code prompts the user for this value during plugin installation.
+
+#### Direct HTTP
+```bash
+curl -H "Authorization: Bearer <token>" http://localhost:6970/mcp
+```
+
+### Disabling auth
+
+For deployments behind a trusted reverse proxy (e.g., SWAG with its own auth):
+
+```bash
+UNRAID_MCP_DISABLE_HTTP_AUTH=true
+```
+
+When disabled, all HTTP requests are forwarded without token validation. The server logs a warning.
+
+### Error responses
+
+| Status | Condition | WWW-Authenticate |
+|--------|-----------|-----------------|
+| 401 | Missing Authorization header | `Bearer realm="unraid-mcp"` |
+| 401 | Non-bearer auth scheme | `Bearer realm="unraid-mcp"` |
+| 401 | Invalid token | `Bearer realm="unraid-mcp", error="invalid_token"` |
+| 429 | Rate limit exceeded (60 failures/60s per IP) | -- (includes `Retry-After: 60`) |
+
+### Rate limiting
+
+Per-IP failure tracking:
+- Window: 60 seconds
+- Max failures: 60 per IP before 429
+- Max IPs tracked: 10,000 (oldest evicted on overflow)
+- Log throttle: one warning per IP per 30 seconds
+
+### Well-known endpoint (RFC 9728)
+
+`GET /.well-known/oauth-protected-resource` returns:
+
+```json
+{
+  "resource": "http://localhost:6970",
+  "bearer_methods_supported": ["header"]
+}
+```
+
+Empty `authorization_servers` tells MCP clients there is no OAuth flow -- use a pre-shared token. This endpoint is unauthenticated.
+
+## Outbound: Unraid API key
+
+### How it works
+
+The GraphQL client in `core/client.py` sends requests to the Unraid API with:
+
+```
+x-api-key: <UNRAID_API_KEY>
+```
+
+### Credential sources
+
+1. **Elicitation**: The `health/setup` subaction collects credentials interactively and writes them to `~/.unraid-mcp/.env`
+2. **Environment file**: Loaded from the `.env` priority chain at startup
+3. **Runtime update**: `apply_runtime_config()` updates module globals without touching `os.environ`
+
+### SSL/TLS
+
+The `UNRAID_VERIFY_SSL` setting controls SSL verification for outbound requests:
+- `true` (default): Full SSL verification
+- `false`: Disables verification (self-signed certs)
+- Path string: Custom CA bundle
+
+A warning is logged when SSL verification is disabled.
+
+## Unauthenticated endpoints
+
+| Endpoint | Middleware | Purpose |
+|----------|-----------|---------|
+| `GET /health` | `HealthMiddleware` | Docker/container healthchecks |
+| `GET /.well-known/oauth-protected-resource` | `WellKnownMiddleware` | MCP client OAuth discovery |
+| `GET /.well-known/oauth-protected-resource/mcp` | `WellKnownMiddleware` | MCP-specific OAuth discovery |
+
+These endpoints are handled before `BearerAuthMiddleware` in the ASGI middleware stack.
+
+## See Also
+
+- [ENV.md](ENV.md) -- Environment variables for auth configuration
+- [TRANSPORT.md](TRANSPORT.md) -- Transport-specific auth requirements
+- [ELICITATION.md](ELICITATION.md) -- Interactive credential setup flow
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Security patterns

--- a/docs/mcp/CICD.md
+++ b/docs/mcp/CICD.md
@@ -1,0 +1,83 @@
+# CI/CD Workflows
+
+GitHub Actions configuration for unraid-mcp.
+
+## Workflows
+
+### `ci.yml` -- Continuous Integration
+
+**Triggers**: Push to `main`, `feat/**`, `fix/**`; PRs to `main`.
+
+| Job | Purpose | Tools |
+|-----|---------|-------|
+| `lint` | Ruff check and format verification | `ruff check`, `ruff format --check` |
+| `typecheck` | Static type analysis | `ty check` |
+| `test` | Unit tests with coverage | `pytest -m "not slow and not integration" --cov` |
+| `version-sync` | Verify all version files match | Shell script comparing pyproject.toml, plugin.json (x3), gemini-extension.json |
+| `mcp-integration` | Live MCP integration tests | `test_live.sh` with secrets (push/same-repo PRs only) |
+| `audit` | Dependency security audit | `uv audit` |
+| `docker-security` | Docker security checks | `check-docker-security.sh`, `check-no-baked-env.sh`, `ensure-ignore-files.sh` |
+
+### `docker-publish.yml` -- Docker Image Build
+
+**Triggers**: Push to `main`, tags `v*`, PRs to `main`, manual dispatch.
+
+| Step | Purpose |
+|------|---------|
+| Docker Buildx setup | Multi-platform build support |
+| GHCR login | Authenticate to GitHub Container Registry |
+| Metadata extraction | Generate image tags (semver, branch, SHA, latest) |
+| Build and push | Multi-arch (amd64, arm64), layer caching (GHA), SBOM, provenance |
+| Trivy scan | Vulnerability scan for CRITICAL and HIGH severity |
+
+**Image tags**: `latest` (main branch), `v1.2.3`, `v1.2`, `v1`, `main`, `pr-N`, `sha-<hex>`.
+
+**Registry**: `ghcr.io/jmagar/unraid-mcp`.
+
+### `publish-pypi.yml` -- PyPI and Registry Release
+
+**Triggers**: Tags matching `v*.*.*`.
+
+| Step | Purpose |
+|------|---------|
+| Version verification | Tag must match `pyproject.toml` version |
+| Build | `uv build` produces sdist and wheel |
+| PyPI publish | Trusted publisher with attestations |
+| GitHub Release | Auto-generated release notes with dist artifacts |
+| MCP Registry publish | DNS-authenticated publish to `tv.tootie/unraid-mcp` via `mcp-publisher` |
+
+## Version sync enforcement
+
+The `version-sync` job ensures these files all contain the same version string:
+- `pyproject.toml`
+- `.claude-plugin/plugin.json`
+- `.codex-plugin/plugin.json`
+- `gemini-extension.json`
+
+Failure blocks the CI pipeline.
+
+## Secrets required
+
+| Secret | Used by | Purpose |
+|--------|---------|---------|
+| `GITHUB_TOKEN` | All workflows | GHCR login, release creation |
+| `UNRAID_API_URL` | `mcp-integration` | Live test target |
+| `UNRAID_API_KEY` | `mcp-integration` | Live test auth |
+| `MCP_PRIVATE_KEY` | `publish-pypi` | DNS-authenticated MCP registry publish |
+
+## Local equivalents
+
+| CI Job | Local command |
+|--------|--------------|
+| lint | `just lint` or `uv run ruff check .` |
+| format | `just fmt` or `uv run ruff format .` |
+| typecheck | `just typecheck` or `uv run ty check unraid_mcp/` |
+| test | `just test` or `uv run pytest` |
+| docker-security | `just check-contract` |
+| build | `just build` or `docker build -t unraid-mcp .` |
+
+## See Also
+
+- [TESTS.md](TESTS.md) -- Test suite details
+- [PUBLISH.md](PUBLISH.md) -- Versioning and release strategy
+- [PRE-COMMIT.md](PRE-COMMIT.md) -- Local pre-commit checks

--- a/docs/mcp/CLAUDE.md
+++ b/docs/mcp/CLAUDE.md
@@ -1,0 +1,50 @@
+# MCP Server Documentation
+
+Documentation for the unraid-mcp MCP server.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [TOOLS.md](TOOLS.md) | Tool definitions, action/subaction routing, parameters, and examples |
+| [RESOURCES.md](RESOURCES.md) | MCP resource URIs for live subscription data |
+| [SCHEMA.md](SCHEMA.md) | Pydantic models and input validation |
+| [ENV.md](ENV.md) | All environment variables with types, defaults, and sensitivity |
+| [AUTH.md](AUTH.md) | Bearer token auth (inbound) and API key auth (outbound to Unraid) |
+| [TRANSPORT.md](TRANSPORT.md) | stdio, streamable-http, and SSE configuration |
+| [DEPLOY.md](DEPLOY.md) | Docker, local, and PyPI deployment patterns |
+| [LOGS.md](LOGS.md) | Structured logging, log rotation, and error handling |
+| [TESTS.md](TESTS.md) | Unit, schema, safety, property, and contract test suites |
+| [MCPORTER.md](MCPORTER.md) | End-to-end HTTP and stdio smoke tests |
+| [CICD.md](CICD.md) | GitHub Actions workflows for CI, Docker publish, and PyPI release |
+| [PRE-COMMIT.md](PRE-COMMIT.md) | Ruff lint/format and PostToolUse hook enforcement |
+| [PUBLISH.md](PUBLISH.md) | Versioning, PyPI, Docker, and MCP registry publishing |
+| [CONNECT.md](CONNECT.md) | Client connection guides for Claude Code, Codex, Gemini, and direct HTTP |
+| [DEV.md](DEV.md) | Day-to-day development workflow with uv and Justfile recipes |
+| [ELICITATION.md](ELICITATION.md) | Interactive credential setup and destructive action confirmation |
+| [PATTERNS.md](PATTERNS.md) | Common code patterns: action routing, GraphQL queries, error handling |
+| [WEBMCP.md](WEBMCP.md) | Health endpoint, well-known discovery, and CORS configuration |
+| [MCPUI.md](MCPUI.md) | Protocol-level UI hints for tool rendering |
+
+## Reading Order
+
+**New to this MCP server:**
+1. ENV.md -- understand required configuration
+2. AUTH.md -- set up authentication
+3. TRANSPORT.md -- choose a transport and connect
+4. TOOLS.md -- learn available operations (15 domains, 107 subactions)
+5. RESOURCES.md -- discover live subscription data endpoints
+6. ELICITATION.md -- understand the setup wizard and destructive action gates
+
+**Experienced developers:**
+- TOOLS.md and RESOURCES.md for the API surface
+- ENV.md for configuration reference
+- PATTERNS.md for code conventions
+- TESTS.md for test suite structure
+
+## Cross-References
+
+- [plugin/](../plugin/) -- Plugin manifests, hooks, skills, and marketplace config
+- [stack/](../stack/) -- Python/FastMCP/uv implementation details
+- [upstream/](../upstream/) -- Unraid GraphQL API documentation
+- [repo/](../repo/) -- Repository structure and development workflow

--- a/docs/mcp/CONNECT.md
+++ b/docs/mcp/CONNECT.md
@@ -1,0 +1,118 @@
+# Connect to MCP
+
+How to connect to the unraid-mcp server from every supported client and transport.
+
+## Claude Code (plugin -- recommended)
+
+### Install from marketplace
+
+```bash
+/plugin marketplace add jmagar/claude-homelab
+/plugin install unraid-mcp @jmagar-claude-homelab
+```
+
+Claude Code runs the server in stdio mode via `uv run --directory <plugin-root> unraid-mcp-server`.
+
+The plugin prompts for `userConfig` values:
+- **Unraid MCP Server URL**: URL of the MCP server (default: `https://unraid.tootie.tv/mcp`)
+- **MCP Server Bearer Token**: For HTTP transport auth
+- **Unraid GraphQL API URL**: Your Unraid server's GraphQL endpoint
+- **Unraid API Key**: API key from Unraid Settings
+
+### Connect to remote HTTP server
+
+If running the server separately (Docker, remote host):
+
+```json
+{
+  "mcpServers": {
+    "unraid": {
+      "type": "url",
+      "url": "http://localhost:6970/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
+## Codex CLI
+
+The `.codex-plugin/plugin.json` provides Codex integration:
+
+```bash
+# Install plugin
+codex plugin install ./
+```
+
+Codex discovers the MCP server via `.mcp.json` referenced in the manifest.
+
+## Gemini CLI
+
+The `gemini-extension.json` provides Gemini integration:
+
+```json
+{
+  "mcpServers": {
+    "unraid-mcp": {
+      "command": "uv",
+      "args": ["run", "unraid-mcp-server"],
+      "cwd": "${extensionPath}"
+    }
+  }
+}
+```
+
+Settings are collected via the `settings` array for `UNRAID_API_URL` and `UNRAID_API_KEY`.
+
+## Direct HTTP (any client)
+
+### streamable-http
+
+```bash
+# Health check (no auth)
+curl http://localhost:6970/health
+
+# Tool call (with auth)
+curl -X POST http://localhost:6970/mcp \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"unraid","arguments":{"action":"system","subaction":"overview"}},"id":1}'
+```
+
+### stdio
+
+```bash
+# Spawn and interact via pipes
+echo '{"jsonrpc":"2.0","method":"tools/list","params":{},"id":1}' | \
+  UNRAID_MCP_TRANSPORT=stdio uv run unraid-mcp-server
+```
+
+## MCP Registry
+
+The server is published to the MCP Registry as `tv.tootie/unraid-mcp`. Clients that support registry discovery can auto-install:
+
+```bash
+uvx unraid-mcp
+```
+
+Required environment variables: `UNRAID_API_URL`, `UNRAID_API_KEY`.
+
+## MCP Inspector
+
+For development and debugging:
+
+```bash
+# Start server
+uv run unraid-mcp-server
+
+# Open MCP Inspector in browser
+# Connect to http://localhost:6970/mcp with bearer token
+```
+
+## See Also
+
+- [TRANSPORT.md](TRANSPORT.md) -- Transport configuration details
+- [AUTH.md](AUTH.md) -- Authentication setup
+- [DEPLOY.md](DEPLOY.md) -- Server deployment options

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -1,0 +1,128 @@
+# Deployment Guide
+
+Deployment patterns for unraid-mcp. Choose the method that fits your environment.
+
+## Local Development
+
+```bash
+# Install dependencies
+uv sync --dev
+
+# Start server (streamable-http on port 6970)
+uv run unraid-mcp-server
+
+# Or via Justfile
+just dev
+```
+
+The server reads credentials from `~/.unraid-mcp/.env`. Create this file from `.env.example` or use the setup wizard.
+
+## Docker Compose (recommended for production)
+
+### Quick start
+
+```bash
+just up
+```
+
+### Manual
+
+```bash
+docker compose up -d
+```
+
+### Configuration
+
+The `docker-compose.yaml` provides:
+
+- **Multi-stage build**: Builder (uv + dependencies) and runtime (Python 3.12 slim)
+- **Non-root user**: Runs as `mcp:1000`
+- **Resource limits**: 1024 MB memory, 1.0 CPU
+- **Named volume**: `unraid-mcp-credentials` for `~/.unraid-mcp/`
+- **Health check**: HTTP `GET /health` every 30s (auto-skips for stdio transport)
+- **External network**: Optional `DOCKER_NETWORK` for service mesh integration
+
+### Environment
+
+The container reads from `~/.claude-homelab/.env` via `env_file`. Required variables:
+
+```bash
+UNRAID_API_URL=https://your-unraid-server
+UNRAID_API_KEY=your_api_key
+UNRAID_MCP_BEARER_TOKEN=your_bearer_token
+```
+
+### Volumes
+
+| Volume | Container path | Purpose |
+|--------|---------------|---------|
+| `./logs` | `/app/logs` | Application logs |
+| `./backups` | `/app/backups` | Flash backup storage |
+| `unraid-mcp-credentials` | `/home/mcp/.unraid-mcp` | Credential persistence |
+
+## Docker standalone
+
+```bash
+# Build
+docker build -t unraid-mcp .
+
+# Run
+docker run -d \
+  --name unraid-mcp \
+  -p 6970:6970 \
+  -e UNRAID_API_URL=https://your-unraid-server \
+  -e UNRAID_API_KEY=your_api_key \
+  -e UNRAID_MCP_BEARER_TOKEN=your_bearer_token \
+  -v unraid-mcp-credentials:/home/mcp/.unraid-mcp \
+  unraid-mcp
+```
+
+## PyPI package
+
+```bash
+# Install globally
+pip install unraid-mcp
+
+# Run
+unraid-mcp-server
+
+# Or via uvx (no install needed)
+uvx unraid-mcp
+```
+
+## GitHub Container Registry
+
+```bash
+docker pull ghcr.io/jmagar/unraid-mcp:latest
+```
+
+Available tags: `latest`, `main`, `v1.2.3`, `v1.2`, `v1`, `sha-<commit>`.
+
+Multi-arch: `linux/amd64` and `linux/arm64`.
+
+## Entrypoint validation
+
+The `entrypoint.sh` validates required environment variables before starting the server:
+
+- `UNRAID_API_URL` -- always required
+- `UNRAID_API_KEY` -- always required
+- `UNRAID_MCP_BEARER_TOKEN` -- required for HTTP transport with auth enabled
+
+If any are missing, the container exits with a descriptive error listing the missing variables.
+
+## Behind a reverse proxy
+
+For SWAG, nginx, or Traefik:
+
+1. Set `UNRAID_MCP_DISABLE_HTTP_AUTH=true` (the proxy handles auth)
+2. Proxy to `http://unraid-mcp:6970/mcp`
+3. Ensure WebSocket upgrade headers are forwarded for subscription support
+
+See `docs/unraid.subdomain.conf` for a SWAG nginx example.
+
+## See Also
+
+- [TRANSPORT.md](TRANSPORT.md) -- Transport-specific configuration
+- [AUTH.md](AUTH.md) -- Bearer token setup
+- [CONNECT.md](CONNECT.md) -- Client connection guides
+- [../CONFIG.md](../CONFIG.md) -- Full environment variable reference

--- a/docs/mcp/DEV.md
+++ b/docs/mcp/DEV.md
@@ -1,0 +1,153 @@
+# Development Workflow
+
+Day-to-day development guide for unraid-mcp.
+
+## Setup
+
+```bash
+# Clone
+git clone https://github.com/jmagar/unraid-mcp.git
+cd unraid-mcp
+
+# Install all dependencies (including dev)
+uv sync --group dev
+
+# Create credentials
+mkdir -p ~/.unraid-mcp
+cp .env.example ~/.unraid-mcp/.env
+chmod 700 ~/.unraid-mcp && chmod 600 ~/.unraid-mcp/.env
+# Edit ~/.unraid-mcp/.env with your Unraid credentials
+```
+
+## Running the server
+
+```bash
+# Local dev (streamable-http on port 6970)
+just dev
+# or: uv run python -m unraid_mcp
+
+# Direct entry point
+uv run unraid-mcp-server
+
+# stdio mode (for testing with MCP clients)
+UNRAID_MCP_TRANSPORT=stdio uv run unraid-mcp-server
+```
+
+## Code quality
+
+```bash
+# Lint
+just lint           # uv run ruff check .
+
+# Format
+just fmt            # uv run ruff format .
+
+# Type check
+just typecheck      # uv run ty check unraid_mcp/
+
+# All quality gates
+just lint && just fmt && just typecheck
+```
+
+## Testing
+
+```bash
+# All unit tests
+just test           # uv run pytest tests/ -v
+
+# Specific domain
+uv run pytest tests/test_docker.py
+
+# Safety guards only
+uv run pytest tests/safety/
+
+# Schema validation only
+uv run pytest tests/schema/
+
+# With coverage
+uv run pytest --cov=unraid_mcp --cov-report=term-missing
+```
+
+## Docker development
+
+```bash
+# Build image
+just build          # docker build -t unraid-mcp .
+
+# Start container
+just up             # docker compose up -d
+
+# View logs
+just logs           # docker compose logs -f
+
+# Health check
+just health         # curl /health endpoint
+
+# Stop
+just down           # docker compose down
+
+# Restart
+just restart        # docker compose restart
+```
+
+## Adding a new action domain
+
+1. Create `unraid_mcp/tools/_newdomain.py`:
+   - Define `_NEWDOMAIN_QUERIES` dict with GraphQL queries
+   - Define `_NEWDOMAIN_MUTATIONS` dict (if applicable)
+   - Define `_NEWDOMAIN_DESTRUCTIVE` set (if applicable)
+   - Implement `_handle_newdomain()` async function
+   - Mutation handlers MUST return before the query dict lookup
+
+2. Register in `unraid_mcp/tools/unraid.py`:
+   - Import handler and constants
+   - Add to `UNRAID_ACTIONS` Literal type
+   - Add routing in `unraid()` function
+   - Update `_HELP_TEXT`
+
+3. Add tests:
+   - `tests/test_newdomain.py` -- unit tests with mocked GraphQL
+   - Update `tests/schema/` if new queries
+   - Update `tests/safety/` if destructive actions
+
+4. Update documentation:
+   - `skills/unraid/SKILL.md`
+   - `CLAUDE.md` tool table
+   - `docs/mcp/TOOLS.md`
+
+## Adding a new subscription
+
+1. Add query to `unraid_mcp/subscriptions/queries.py`:
+   - Add to `SNAPSHOT_ACTIONS` (continuous) or `COLLECT_ACTIONS` (event-driven)
+   - If event-driven, add to `EVENT_DRIVEN_ACTIONS`
+
+2. Resources are auto-registered for `SNAPSHOT_ACTIONS` entries.
+
+3. Add to `_handle_live()` in `tools/_live.py`.
+
+4. Update `docs/mcp/RESOURCES.md`.
+
+## Useful Justfile recipes
+
+```bash
+just                # List all recipes
+just dev            # Start dev server
+just test           # Run tests
+just lint           # Lint check
+just fmt            # Format code
+just build          # Build Docker image
+just up / down      # Docker compose up/down
+just logs           # Tail container logs
+just health         # Check /health endpoint
+just setup          # Create .env from .env.example
+just gen-token      # Generate a bearer token
+just check-contract # Run security checks
+just clean          # Remove build artifacts
+just publish patch  # Bump version and release
+```
+
+## See Also
+
+- [TESTS.md](TESTS.md) -- Detailed testing guide
+- [PATTERNS.md](PATTERNS.md) -- Code patterns and conventions
+- [CICD.md](CICD.md) -- CI pipeline details

--- a/docs/mcp/ELICITATION.md
+++ b/docs/mcp/ELICITATION.md
@@ -1,0 +1,117 @@
+# MCP Elicitation
+
+Interactive credential and configuration entry via the MCP elicitation protocol.
+
+## What is elicitation
+
+Elicitation is an MCP protocol capability that allows servers to request information from users interactively through the client. Instead of requiring pre-configured environment variables, the server can prompt the user for missing values at runtime.
+
+## When elicitation is used
+
+- **First-run setup**: Server detects missing `UNRAID_API_URL` or `UNRAID_API_KEY` and prompts the user via `health/setup`.
+- **Credential rotation**: User triggers `health/setup` to reconfigure credentials, even when existing credentials are working.
+- **Destructive operation confirmation**: All 12 destructive subactions gate execution behind explicit user acknowledgment.
+
+## Credential setup flow
+
+### Implementation (`core/setup.py`)
+
+The `elicit_and_configure()` function handles first-run and reconfiguration:
+
+1. Client calls `unraid(action="health", subaction="setup")`
+2. If credentials exist:
+   - Server tests the connection (GraphQL query for `online` status)
+   - Reports whether connection is working, failing, or uncertain
+   - Asks via `elicit_reset_confirmation()` whether to overwrite (uses `bool` response type)
+   - If user declines, returns current status without changes
+3. Server sends elicitation request with `_UnraidCredentials` schema:
+   ```
+   Fields:
+     api_url: str  -- Unraid GraphQL endpoint (e.g. https://10-1-0-2.xxx.myunraid.net:31337)
+     api_key: str  -- API key from Unraid Settings > Management Access > API Keys
+   ```
+4. Client renders an interactive form
+5. User fills in values and submits
+6. Server writes to `~/.unraid-mcp/.env` (atomic: tmp file + `os.replace`)
+7. Sets directory to mode 700, file to mode 600
+8. Applies credentials to running process via `apply_runtime_config()`
+9. Returns success message
+
+### Connection probe behavior
+
+The setup wizard always prompts for confirmation before overwriting, even if the current connection is failing. This prevents a transient outage from silently triggering a credential reset.
+
+Status messages:
+- "Credentials already configured (and working)" -- connection test passed
+- "Credentials already configured (but the connection test failed -- may be a transient outage)" -- connection test failed
+- "Credentials not configured" -- no `.env` file found
+
+## Destructive operation confirmation
+
+### Implementation (`core/guards.py`)
+
+The `gate_destructive_action()` function provides two-tier confirmation:
+
+1. **Check**: Is the subaction in the domain's `_*_DESTRUCTIVE` set?
+   - No: proceed immediately (non-destructive)
+   - Yes: continue to confirmation
+
+2. **Bypass check**: Is `confirm=True`?
+   - Yes: proceed (logged as "bypassed via confirm=True")
+   - No: continue to elicitation
+
+3. **Elicitation**: Send `_ConfirmAction` form to client:
+   ```
+   Fields:
+     confirmed: bool (default: False)  -- "Check the box to confirm and proceed"
+   ```
+
+4. **User response**:
+   - Accepted + confirmed: proceed with operation
+   - Accepted but not confirmed: `ToolError("Action was not confirmed")`
+   - Cancelled/declined: `ToolError("Action was not confirmed")`
+
+### Per-domain descriptions
+
+Each domain provides human-readable descriptions for its destructive actions:
+
+```python
+# Example from _array.py
+_ARRAY_DESTRUCTIVE = {"stop_array", "remove_disk", "clear_disk_stats"}
+# Each has a description dict explaining the impact
+```
+
+## Client support
+
+| Client | Elicitation support | Behavior |
+|--------|-------------------|----------|
+| Claude Code | Full | Interactive form rendering with checkboxes |
+| Codex CLI | Partial | Text-based prompts |
+| Gemini CLI | Partial | Text-based prompts |
+| MCP Inspector | Full | Form rendering in web UI |
+| Non-interactive | None | Falls back to `ToolError` with instructions |
+
+## Fallback for unsupported clients
+
+When the client does not support elicitation (`NotImplementedError`):
+
+**Credential setup**: Returns a `ToolError` with manual instructions:
+```
+Missing required configuration. Create ~/.unraid-mcp/.env with:
+  UNRAID_API_URL=https://your-unraid-server:port
+  UNRAID_API_KEY=your-api-key
+```
+
+**Destructive actions**: Returns a `ToolError` instructing:
+```
+Action 'stop_array' was not confirmed. Re-run with confirm=True to bypass elicitation.
+```
+
+**Reset confirmation**: Silently declines the reset (returns False). Overwriting working credentials on a non-interactive client could be destructive.
+
+## See Also
+
+- [AUTH.md](AUTH.md) -- How credentials are used after setup
+- [ENV.md](ENV.md) -- Environment variables set by elicitation
+- [TOOLS.md](TOOLS.md) -- Destructive action list
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Security patterns

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -1,0 +1,75 @@
+# Environment Variable Reference
+
+## Upstream Service
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_API_URL` | yes | -- | yes (in plugin.json) | Unraid GraphQL endpoint. No trailing slash. |
+| `UNRAID_API_KEY` | yes | -- | yes | Unraid API key from Settings > Management Access > API Keys |
+
+## MCP Server
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_MCP_HOST` | no | `0.0.0.0` | no | Bind address for HTTP transport |
+| `UNRAID_MCP_PORT` | no | `6970` | no | HTTP server port (1-65535) |
+| `UNRAID_MCP_TRANSPORT` | no | `streamable-http` | no | Transport: `streamable-http`, `stdio`, or `sse` |
+
+## Authentication
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_MCP_BEARER_TOKEN` | conditional | auto-generated | yes | Bearer token for HTTP auth. Required when transport is HTTP and auth is not disabled. |
+| `UNRAID_MCP_DISABLE_HTTP_AUTH` | no | `false` | no | Disable bearer auth (only behind a trusted gateway) |
+
+## SSL/TLS
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_VERIFY_SSL` | no | `true` | no | SSL verification for upstream API. `false` for self-signed certs, or a CA bundle path. |
+
+## Logging
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_MCP_LOG_LEVEL` | no | `INFO` | no | Log verbosity: DEBUG, INFO, WARNING, ERROR, CRITICAL |
+| `UNRAID_MCP_LOG_FILE` | no | `unraid-mcp.log` | no | Log filename in the logs/ directory |
+
+## Subscriptions
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_AUTO_START_SUBSCRIPTIONS` | no | `true` | no | Auto-start WebSocket subscriptions on boot |
+| `UNRAID_MAX_RECONNECT_ATTEMPTS` | no | `10` | no | Max WebSocket reconnection attempts |
+| `UNRAID_AUTOSTART_LOG_PATH` | no | auto-detect | no | Log file path for log tail subscription |
+
+## Credentials Directory
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_CREDENTIALS_DIR` | no | `~/.unraid-mcp` | no | Override credentials directory path |
+
+## Docker / Compose
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `PUID` | no | `1000` | no | User ID for container process |
+| `PGID` | no | `1000` | no | Group ID for container process |
+| `DOCKER_NETWORK` | no | -- | no | External Docker network name |
+
+## Loading priority
+
+The server loads the first `.env` file found:
+
+1. `~/.unraid-mcp/.env`
+2. `~/.unraid-mcp/.env.local`
+3. `/app/.env.local`
+4. `<project-root>/.env.local`
+5. `<project-root>/.env`
+6. `unraid_mcp/.env`
+
+## See Also
+
+- [AUTH.md](AUTH.md) -- Authentication details
+- [../CONFIG.md](../CONFIG.md) -- Full configuration reference with timeouts and middleware
+- [ELICITATION.md](ELICITATION.md) -- Interactive credential setup

--- a/docs/mcp/LOGS.md
+++ b/docs/mcp/LOGS.md
@@ -1,0 +1,121 @@
+# Logging and Error Handling
+
+Logging and error handling patterns for unraid-mcp.
+
+## Log Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `UNRAID_MCP_LOG_LEVEL` | `INFO` | Log verbosity: DEBUG, INFO, WARNING, ERROR, CRITICAL |
+| `UNRAID_MCP_LOG_FILE` | `unraid-mcp.log` | Log filename |
+
+### Log locations
+
+- **Local**: `<project-root>/logs/unraid-mcp.log`
+- **Docker**: `/app/logs/unraid-mcp.log`
+- **Fallback**: `<project-root>/.cache/logs/unraid-mcp.log` (if primary logs dir creation fails)
+
+### Log rotation
+
+Log files are capped at 10 MB and overwritten to prevent disk space issues. The cap is enforced at the application level.
+
+## Structured Logging
+
+The `config/logging.py` module provides:
+
+- Structured log format with timestamps, module names, and log levels
+- Console output (stderr) for immediate visibility
+- File output for persistent history
+- Configuration summary logged at startup
+
+### Middleware logging
+
+The `LoggingMiddleware` (outermost MCP middleware) logs:
+- Every `tools/call` invocation with action, subaction, and duration
+- Every `resources/read` invocation with URI and duration
+- Errors after they've been processed by ErrorHandlingMiddleware
+
+## Error Handling
+
+### Exception hierarchy
+
+```
+Exception
+  +-- ToolError (FastMCP)
+  |     +-- ToolError (unraid_mcp) -- user-facing MCP errors
+  +-- CredentialsNotConfiguredError -- triggers elicitation flow
+```
+
+### Error handling chain
+
+1. **tool_error_handler** context manager (per-domain):
+   - Re-raises `ToolError` as-is
+   - Converts `CredentialsNotConfiguredError` to setup instructions
+   - Wraps `TimeoutError` with descriptive message
+   - Catches all other exceptions, logs full traceback, wraps in `ToolError`
+
+2. **ErrorHandlingMiddleware** (MCP-level):
+   - Catches any unhandled exceptions that escape tool handlers
+   - Converts to proper MCP error responses
+   - Tracks `error_counts` per `(exception_type, method)` for health diagnostics
+   - Includes traceback only when `LOG_LEVEL=DEBUG`
+
+### Error stats
+
+The `ErrorHandlingMiddleware` exposes error statistics via `get_error_stats()`, accessible through `health/diagnose`:
+
+```python
+unraid(action="health", subaction="diagnose")
+# Returns: { "errors": { "ToolError:tools/call": 3, ... } }
+```
+
+## Sensitive Value Protection
+
+### Redaction
+
+The `redact_sensitive()` function processes all debug log output:
+- Exact key match: `key`, `pin`
+- Substring match: `password`, `secret`, `token`, `apikey`, `authorization`, `credential`, `passphrase`, `jwt`, `cookie`, `session`
+- Normalizes keys by stripping underscores and hyphens before matching
+
+### URL display
+
+The `safe_display_url()` function masks sensitive parts of URLs for logging:
+- Shows scheme and host
+- Masks path components that might contain tokens
+- Used in configuration summaries and error messages
+
+### Bearer token isolation
+
+- Removed from `os.environ` immediately after startup
+- Stored only in module globals (not accessible by subprocesses)
+- Never logged, even at DEBUG level
+
+## Subscription Logging
+
+WebSocket subscription events are logged with `[STARTUP]`, `[AUTOSTART]`, `[RESOURCE]` prefixes for easy filtering:
+
+```
+[STARTUP] First async operation detected, starting subscriptions...
+[AUTOSTART] Initiating subscription auto-start process...
+[RESOURCE] Capped log content from 8000 to 5000 lines
+```
+
+## Viewing Logs
+
+```bash
+# Tail application logs
+just logs
+
+# Docker container logs
+docker compose logs -f unraid-mcp
+
+# Direct file access
+tail -f logs/unraid-mcp.log
+```
+
+## See Also
+
+- [ENV.md](ENV.md) -- Log-related environment variables
+- [TESTS.md](TESTS.md) -- Testing error handling
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Security logging patterns

--- a/docs/mcp/MCPORTER.md
+++ b/docs/mcp/MCPORTER.md
@@ -1,0 +1,87 @@
+# Live Smoke Testing (mcporter)
+
+End-to-end verification against a running unraid-mcp server. Complements unit/integration tests in [TESTS.md](TESTS.md).
+
+## Purpose
+
+Mcporter tests verify that the MCP server responds correctly over both HTTP and stdio transports with real GraphQL queries against a live Unraid API.
+
+## Test scripts
+
+### HTTP smoke test (`test-actions.sh`)
+
+Tests all non-destructive actions over HTTP transport:
+
+```bash
+./tests/mcporter/test-actions.sh [MCP_URL]
+# Default: http://localhost:6970/mcp
+```
+
+Sends tool calls for every non-destructive action/subaction combination and validates response format.
+
+### stdio smoke test (`test-tools.sh`)
+
+Tests tool availability without a running HTTP server:
+
+```bash
+./tests/mcporter/test-tools.sh [--parallel] [--timeout-ms N] [--verbose]
+```
+
+Spawns the server in stdio mode and sends tool list/call requests over stdin/stdout. Good for CI environments where no network is needed.
+
+### Destructive action smoke test (`test-destructive.sh`)
+
+Confirms that destructive action guards block execution without `confirm=True`:
+
+```bash
+./tests/mcporter/test-destructive.sh [MCP_URL]
+```
+
+Sends destructive subactions without `confirm=True` and verifies the server returns an error (not execution).
+
+### HTTP e2e test (`test-http.sh`)
+
+Full HTTP transport test with automatic bearer token loading:
+
+```bash
+# Standard (reads token from ~/.unraid-mcp/.env)
+just test-http
+
+# Skip auth (for gateway-protected deployments)
+just test-http-no-auth
+
+# Remote URL
+just test-http-remote https://unraid.tootie.tv/mcp
+```
+
+## Justfile recipes
+
+| Recipe | Description |
+|--------|-------------|
+| `just test-http` | HTTP e2e test with auto-read token |
+| `just test-http-no-auth` | HTTP e2e test without auth |
+| `just test-http-remote <url>` | HTTP e2e test against a remote URL |
+| `just test-live` | Run pytest integration tests (`-m live`) |
+
+## Transport differences
+
+| Aspect | HTTP (`test-actions.sh`) | stdio (`test-tools.sh`) |
+|--------|--------------------------|------------------------|
+| Server required | Yes (running on port) | No (spawned inline) |
+| Auth | Bearer token | None |
+| Network | HTTP to `/mcp` | stdin/stdout pipes |
+| CI friendly | Needs Docker or port | Yes (process only) |
+| Parallelism | Native (concurrent HTTP) | Optional (`--parallel`) |
+
+## CI integration
+
+The `ci.yml` workflow runs `test_live.sh` in the `mcp-integration` job:
+- Only runs on pushes and same-repo PRs (needs secrets)
+- Uses `UNRAID_API_URL` and `UNRAID_API_KEY` from GitHub secrets
+- Validates real GraphQL connectivity
+
+## See Also
+
+- [TESTS.md](TESTS.md) -- Unit and specialized test suites
+- [CICD.md](CICD.md) -- CI workflow configuration
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Destructive action guard details

--- a/docs/mcp/MCPUI.md
+++ b/docs/mcp/MCPUI.md
@@ -1,0 +1,73 @@
+# MCP UI Patterns
+
+Protocol-level UI hints for MCP servers to improve client-side rendering of tools and results.
+
+## Tool descriptions
+
+The `unraid` tool includes an ASCII table in its docstring that MCP clients render when displaying tool information:
+
+```
++-------------------+----------------------------------------------------------------------+
+| action            | subactions                                                           |
++-------------------+----------------------------------------------------------------------+
+| system            | overview, array, network, registration, variables, metrics, ...      |
+| health            | check, test_connection, diagnose, setup                              |
+| ...               | ...                                                                  |
++-------------------+----------------------------------------------------------------------+
+```
+
+This helps clients display the full action matrix without requiring a separate `unraid_help` call.
+
+## Help tool
+
+The `unraid_help` tool returns a complete markdown document with:
+- Table of all actions and subactions
+- Destructive action markers (`*`)
+- Parameter reference table
+- Usage examples
+
+Clients that support markdown rendering display this as formatted documentation.
+
+## Elicitation forms
+
+### Credential setup form
+
+The `_UnraidCredentials` dataclass generates a two-field form:
+- `api_url` (string): "Your Unraid GraphQL endpoint"
+- `api_key` (string): "Found in Unraid > Settings > Management Access > API Keys"
+
+### Destructive confirmation form
+
+The `_ConfirmAction` Pydantic model generates a single checkbox:
+- `confirmed` (boolean, default False): "Check the box to confirm and proceed"
+
+The confirmation message includes:
+- Bold action name
+- Human-readable description of the impact
+- "Are you sure you want to proceed?"
+
+### Reset confirmation
+
+Uses a simple `bool` response type, rendering as a yes/no prompt.
+
+## Response formatting
+
+Tool responses are formatted for LLM consumption:
+
+- **Health check**: Structured dict with severity indicators and recommendations
+- **System overview**: Nested dict with server info, resources, array status
+- **Docker list**: List of dicts with container names, states, images
+- **Live data**: JSON with `_fetched_at` timestamp for staleness detection
+
+## Error messages
+
+`ToolError` messages are written for both human and LLM consumption:
+- Include the action/subaction context
+- Provide actionable next steps (e.g., "Run unraid(action='health', subaction='setup')")
+- Reference environment variables and file paths when relevant
+
+## See Also
+
+- [TOOLS.md](TOOLS.md) -- Tool interface details
+- [ELICITATION.md](ELICITATION.md) -- Interactive form patterns
+- [RESOURCES.md](RESOURCES.md) -- Resource data formats

--- a/docs/mcp/PATTERNS.md
+++ b/docs/mcp/PATTERNS.md
@@ -1,0 +1,137 @@
+# Common MCP Code Patterns
+
+Reusable patterns across the unraid-mcp server implementation.
+
+## Action routing pattern
+
+The consolidated `unraid` tool uses a flat `if action == "..."` dispatch:
+
+```python
+async def unraid(action: UNRAID_ACTIONS, subaction: str, ...):
+    if action == "system":
+        return await _handle_system(subaction, device_id)
+    if action == "docker":
+        return await _handle_docker(subaction, container_id, network_id)
+    # ... one branch per domain
+    raise ToolError(f"Invalid action '{action}'")
+```
+
+Each handler is in its own `_<domain>.py` module.
+
+## Query dict pattern
+
+Each domain organizes GraphQL operations into dicts:
+
+```python
+_DOCKER_QUERIES = {
+    "list": """{ docker { containers { names state status image } } }""",
+    "details": """query ($id: String!) { docker { container(id: $id) { ... } } }""",
+}
+
+_DOCKER_MUTATIONS = {
+    "start": """mutation ($id: String!) { dockerContainerStart(id: $id) { ... } }""",
+}
+```
+
+### Critical: Mutation handler ordering
+
+Mutation handlers MUST return before the query dict lookup. Mutations are not in `_*_QUERIES` dicts -- reaching the lookup line causes a `KeyError`:
+
+```python
+async def _handle_docker(subaction, container_id, ...):
+    # Mutations first -- early return before query dict lookup
+    if subaction == "start":
+        return await _client.make_graphql_request(
+            _DOCKER_MUTATIONS["start"], {"id": container_id}
+        )
+
+    # Query dict lookup -- only reached for read operations
+    query = _DOCKER_QUERIES.get(subaction)
+    if query is None:
+        raise ToolError(f"Invalid subaction '{subaction}'")
+    return await _client.make_graphql_request(query, variables)
+```
+
+## Destructive action gate pattern
+
+```python
+_VM_DESTRUCTIVE = {"force_stop", "reset"}
+
+async def _handle_vm(subaction, vm_id, ctx, confirm):
+    await gate_destructive_action(
+        ctx, subaction, _VM_DESTRUCTIVE, confirm,
+        description={
+            "force_stop": "Force stop VM without graceful shutdown",
+            "reset": "Hard reset VM, may cause data loss",
+        }
+    )
+    # If we get here, action is either non-destructive or confirmed
+```
+
+## Error handling pattern
+
+All domain handlers use the `tool_error_handler` context manager:
+
+```python
+async def _handle_system(subaction, device_id):
+    with tool_error_handler("system", subaction, logger):
+        # ToolError re-raised as-is
+        # CredentialsNotConfiguredError -> setup instructions
+        # TimeoutError -> descriptive message
+        # Other exceptions -> logged + wrapped in ToolError
+        ...
+```
+
+## GraphQL client pattern
+
+```python
+from ..core import client as _client
+
+# Simple query
+data = await _client.make_graphql_request(query_string)
+
+# Query with variables
+data = await _client.make_graphql_request(query_string, {"id": item_id})
+
+# Custom timeout (disk operations)
+data = await _client.make_graphql_request(query_string, timeout=90)
+```
+
+## Subscription resource pattern
+
+Resources are auto-registered from `SNAPSHOT_ACTIONS`:
+
+```python
+for _action in SNAPSHOT_ACTIONS:
+    mcp.resource(f"unraid://live/{_action}")(_make_resource_fn(_action))
+```
+
+The factory function handles:
+- Ensuring subscriptions are started
+- Returning cached data with `_fetched_at` timestamp
+- Falling back to `subscribe_once` when auto-start is disabled
+- Surfacing terminal errors
+
+## Elicitation pattern
+
+```python
+# Credential collection
+result = await ctx.elicit(
+    message="Prompt text with **markdown** formatting",
+    response_type=_UnraidCredentials,  # dataclass with typed fields
+)
+if result.action != "accept":
+    return  # User cancelled
+
+# Boolean confirmation
+result = await ctx.elicit(
+    message="Are you sure?",
+    response_type=bool,
+)
+```
+
+## See Also
+
+- [SCHEMA.md](SCHEMA.md) -- Schema definitions
+- [TOOLS.md](TOOLS.md) -- Full tool reference
+- [DEV.md](DEV.md) -- Adding new domains

--- a/docs/mcp/PRE-COMMIT.md
+++ b/docs/mcp/PRE-COMMIT.md
@@ -1,0 +1,81 @@
+# Pre-commit Hook Configuration
+
+Pre-commit checks and PostToolUse hooks for unraid-mcp.
+
+## Code Quality Tools
+
+### Ruff (linting and formatting)
+
+Configured in `pyproject.toml`:
+
+```bash
+# Lint
+uv run ruff check unraid_mcp/
+
+# Auto-fix
+uv run ruff check --fix unraid_mcp/
+
+# Format
+uv run ruff format unraid_mcp/
+
+# Format check (no changes)
+uv run ruff format --check unraid_mcp/
+```
+
+**Configuration highlights**:
+- Target: Python 3.12
+- Line length: 100
+- Enabled rule sets: F, E, W, I, N, D, UP, YTT, B, Q, C4, SIM, TCH, PTH, ASYNC, RET, PERF, RUF, S
+- Docstring convention: Google style
+- Per-file ignores: relaxed rules for `__init__.py` and `tests/`
+- Cache: `.cache/.ruff_cache`
+
+### ty (type checking)
+
+Astral's fast type checker:
+
+```bash
+uv run ty check unraid_mcp/
+```
+
+Configured for Python 3.12 with respect for `type: ignore` comments.
+
+## PostToolUse Hooks
+
+The `.claude-plugin/hooks/hooks.json` registers hooks that run after Write, Edit, MultiEdit, or Bash operations:
+
+### fix-env-perms.sh
+
+Ensures credential files maintain secure permissions:
+- `~/.unraid-mcp/.env` stays at mode 600
+- `~/.unraid-mcp/` directory stays at mode 700
+
+### ensure-ignore-files.sh
+
+Keeps `.gitignore` and `.dockerignore` aligned:
+- Ensures sensitive patterns are never committed
+- Prevents credential files from being included in Docker images
+- Runs in check mode (no modifications) during CI
+
+## Justfile Integration
+
+```bash
+just lint       # uv run ruff check .
+just fmt        # uv run ruff format .
+just typecheck  # uv run ty check unraid_mcp/
+```
+
+## CI Enforcement
+
+The `ci.yml` workflow runs lint and format checks:
+- `uv run ruff check unraid_mcp/ tests/`
+- `uv run ruff format --check unraid_mcp/ tests/`
+- `uv run ty check unraid_mcp/`
+
+All three must pass for the CI pipeline to succeed.
+
+## See Also
+
+- [CICD.md](CICD.md) -- CI workflow details
+- [DEV.md](DEV.md) -- Development workflow
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Security enforcement via hooks

--- a/docs/mcp/PUBLISH.md
+++ b/docs/mcp/PUBLISH.md
@@ -1,0 +1,91 @@
+# Publishing Strategy
+
+Versioning and release workflow for unraid-mcp.
+
+## Versioning
+
+Semantic versioning (MAJOR.MINOR.PATCH):
+
+- **MAJOR** (X.0.0): Breaking changes to the MCP tool interface
+- **MINOR** (1.X.0): New actions, subactions, or features (backward compatible)
+- **PATCH** (1.0.X): Bug fixes, documentation updates
+
+## Version files
+
+All must contain the same version string:
+
+| File | Format |
+|------|--------|
+| `pyproject.toml` | `version = "X.Y.Z"` in `[project]` |
+| `.claude-plugin/plugin.json` | `"version": "X.Y.Z"` |
+| `.codex-plugin/plugin.json` | `"version": "X.Y.Z"` |
+| `gemini-extension.json` | `"version": "X.Y.Z"` |
+| `server.json` | Updated by publish workflow at release time |
+| `CHANGELOG.md` | Entry under the new version header |
+
+CI enforces version sync across the first four files.
+
+## Release workflow
+
+### Automated (Justfile)
+
+```bash
+# Patch release (1.2.2 -> 1.2.3)
+just publish patch
+
+# Minor release (1.2.3 -> 1.3.0)
+just publish minor
+
+# Major release (1.3.0 -> 2.0.0)
+just publish major
+```
+
+The `just publish` recipe:
+1. Verifies you are on `main` with a clean working tree
+2. Pulls latest from origin
+3. Bumps version in `pyproject.toml` and all plugin manifests
+4. Commits as `release: vX.Y.Z`
+5. Tags as `vX.Y.Z`
+6. Pushes to origin with tags
+
+### What happens after push
+
+The tag push triggers two workflows:
+
+**`publish-pypi.yml`**:
+1. Verifies tag version matches `pyproject.toml`
+2. Builds sdist and wheel with `uv build`
+3. Publishes to PyPI with trusted publisher attestations
+4. Creates GitHub Release with auto-generated notes and dist artifacts
+5. Updates `server.json` version and publishes to MCP Registry via `mcp-publisher`
+
+**`docker-publish.yml`**:
+1. Builds multi-arch Docker image (amd64, arm64)
+2. Tags with semver variants (`v1.2.3`, `v1.2`, `v1`, `latest`)
+3. Pushes to `ghcr.io/jmagar/unraid-mcp`
+4. Runs Trivy vulnerability scan
+
+## Distribution channels
+
+| Channel | Package | Install command |
+|---------|---------|----------------|
+| PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
+| GHCR | `ghcr.io/jmagar/unraid-mcp` | `docker pull ghcr.io/jmagar/unraid-mcp:latest` |
+| MCP Registry | `tv.tootie/unraid-mcp` | MCP client auto-discovery |
+| Claude Plugin | `jmagar/unraid-mcp` | `/plugin install unraid-mcp` |
+| GitHub Release | Source + wheel | Download from releases page |
+
+## MCP Registry
+
+Published as `tv.tootie/unraid-mcp` using DNS authentication via `tootie.tv`.
+
+The `server.json` defines the registry entry:
+- Package type: `pypi`
+- Runtime hint: `uvx`
+- Transport: `stdio`
+- Required env vars: `UNRAID_API_URL`, `UNRAID_API_KEY`
+
+## See Also
+
+- [CICD.md](CICD.md) -- Workflow configuration details
+- [../CHECKLIST.md](../CHECKLIST.md) -- Pre-release checklist

--- a/docs/mcp/RESOURCES.md
+++ b/docs/mcp/RESOURCES.md
@@ -1,0 +1,137 @@
+# MCP Resources Reference
+
+## Overview
+
+MCP resources expose real-time subscription data via URI-based access. Unlike tools, resources do not perform mutations -- they return the latest cached data from persistent WebSocket subscriptions to the Unraid GraphQL API.
+
+Use resources when:
+- Reading live telemetry (CPU, memory, array state)
+- Monitoring ongoing events (notifications, parity progress)
+- Providing real-time context to the LLM without tool invocation overhead
+
+Use the `live` action on the `unraid` tool when:
+- You need a one-shot snapshot with a specific collection duration
+- You want to control the `collect_for` parameter
+- The resource data shows "connecting" (subscription not yet initialized)
+
+## URI Scheme
+
+All resources use the `unraid://` scheme:
+
+```
+unraid://logs/stream
+unraid://live/<subscription-name>
+```
+
+## Available Resources
+
+### Log stream
+
+| URI | Description | Source subscription |
+|-----|-------------|---------------------|
+| `unraid://logs/stream` | Real-time log file stream | `logFileSubscription` |
+
+Returns log file content with path, total lines, start line, and content. Auto-starts on boot if `UNRAID_AUTOSTART_LOG_PATH` is set or `/var/log/syslog` exists.
+
+### Live telemetry (snapshot subscriptions)
+
+These subscriptions emit data continuously. The resource returns the latest cached value.
+
+| URI | Description | Source subscription |
+|-----|-------------|---------------------|
+| `unraid://live/cpu` | CPU utilization per core and total | `systemMetricsCpu` |
+| `unraid://live/memory` | Memory usage, swap, available, buffer/cache | `systemMetricsMemory` |
+| `unraid://live/cpu_telemetry` | CPU power draw and temperature | `systemMetricsCpuTelemetry` |
+| `unraid://live/array_state` | Array state, capacity, parity check status | `arraySubscription` |
+
+### Live telemetry (event-driven subscriptions)
+
+These subscriptions only emit when state changes. A timeout does not indicate an error -- it means no recent change occurred.
+
+| URI | Description | Source subscription |
+|-----|-------------|---------------------|
+| `unraid://live/parity_progress` | Parity check progress, speed, errors | `parityHistorySubscription` |
+| `unraid://live/ups_status` | UPS battery, power, model, status | `upsUpdates` |
+| `unraid://live/notifications_overview` | Unread/archive notification counts by type | `notificationsOverview` |
+| `unraid://live/owner` | Server owner username, URL, avatar | `ownerSubscription` |
+| `unraid://live/server_status` | Server name, status, GUID, WAN/LAN IPs | `serversSubscription` |
+
+## Response Format
+
+All resource responses return JSON:
+
+```json
+{
+  "systemMetricsCpu": {
+    "id": "...",
+    "percentTotal": 12.5,
+    "cpus": [
+      {"percentTotal": 15.0, "percentUser": 10.0, "percentSystem": 5.0, "percentIdle": 85.0}
+    ]
+  },
+  "_fetched_at": "2026-04-04T12:00:00.000000"
+}
+```
+
+The `_fetched_at` timestamp indicates when the data was last received from the WebSocket.
+
+### Connecting state
+
+When a subscription has not yet received data:
+
+```json
+{
+  "status": "connecting",
+  "message": "Subscription 'cpu' is starting. Retry in a moment."
+}
+```
+
+### Error state
+
+When a subscription has permanently failed:
+
+```json
+{
+  "status": "error",
+  "message": "Subscription 'cpu' failed: WebSocket authentication error"
+}
+```
+
+Terminal failure states: `failed`, `auth_failed`, `max_retries_exceeded`.
+
+## Auto-start Behavior
+
+When `UNRAID_AUTO_START_SUBSCRIPTIONS=true` (default):
+- All snapshot subscriptions start automatically on server boot
+- The log file subscription starts if `UNRAID_AUTOSTART_LOG_PATH` is set or `/var/log/syslog` exists
+- Resources serve cached data immediately after the first WebSocket message arrives
+
+When `UNRAID_AUTO_START_SUBSCRIPTIONS=false`:
+- Subscriptions do not start on boot
+- Resources fall back to `subscribe_once` -- a one-shot WebSocket query
+- This is useful for low-resource environments or when real-time data is not needed
+
+## Subscription Manager
+
+The `SubscriptionManager` singleton manages persistent WebSocket connections:
+
+- Maintains one WebSocket per subscription type
+- Automatic reconnection with exponential backoff (up to `UNRAID_MAX_RECONNECT_ATTEMPTS`)
+- Resets reconnect counter after 30 seconds of stable connection
+- Log content capped at 1 MB / 5,000 lines to prevent memory growth
+- GraphQL-over-WebSocket protocol with `connection_init` and `subscribe` messages
+
+## Diagnostic Tools
+
+Two diagnostic tools help troubleshoot subscription issues:
+
+| Tool | Purpose |
+|------|---------|
+| `diagnose_subscriptions` | Shows connection states, errors, WebSocket URLs, and data availability for all subscriptions |
+| `test_subscription_query` | Sends a test subscription query (allowlisted fields: `containerStats`, `cpu`, `memory`, `array`, `network`, `docker`, `vm`) |
+
+## See Also
+
+- [TOOLS.md](TOOLS.md) -- For the `live` action that provides on-demand snapshots
+- [SCHEMA.md](SCHEMA.md) -- GraphQL subscription query definitions
+- [../upstream/CLAUDE.md](../upstream/CLAUDE.md) -- Unraid GraphQL subscription schema

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -1,0 +1,144 @@
+# Tool Schema Documentation
+
+## Overview
+
+Tool schemas in unraid-mcp are defined using Python type hints and Pydantic models, validated at runtime by FastMCP. The primary `unraid` tool uses `Literal` types for action routing and optional typed parameters for domain-specific operations.
+
+## Action Type
+
+```python
+UNRAID_ACTIONS = Literal[
+    "array", "customization", "disk", "docker", "health",
+    "key", "live", "notification", "oidc", "plugin",
+    "rclone", "setting", "system", "user", "vm",
+]
+```
+
+This `Literal` type is registered as an enum in the MCP tool schema, ensuring clients can only pass valid action values.
+
+## Tool Function Signature
+
+The `unraid` tool accepts all possible parameters as optional keyword arguments:
+
+```python
+async def unraid(
+    action: UNRAID_ACTIONS,           # Required: domain selector
+    subaction: str,                    # Required: operation within domain
+    ctx: Context | None = None,       # MCP context for elicitation
+    confirm: bool = False,            # Destructive action bypass
+    # system
+    device_id: str | None = None,
+    # array + disk
+    disk_id: str | None = None,
+    correct: bool | None = None,
+    slot: int | None = None,
+    # disk
+    log_path: str | None = None,
+    tail_lines: int = 100,
+    remote_name: str | None = None,
+    source_path: str | None = None,
+    destination_path: str | None = None,
+    backup_options: dict[str, Any] | None = None,
+    # docker
+    container_id: str | None = None,
+    network_id: str | None = None,
+    # vm
+    vm_id: str | None = None,
+    # notification
+    notification_id: str | None = None,
+    notification_ids: list[str] | None = None,
+    notification_type: str | None = None,
+    importance: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+    list_type: str = "UNREAD",
+    title: str | None = None,
+    subject: str | None = None,
+    description: str | None = None,
+    # key
+    key_id: str | None = None,
+    name: str | None = None,
+    roles: list[str] | None = None,
+    permissions: list[str] | None = None,
+    # plugin
+    names: list[str] | None = None,
+    bundled: bool = False,
+    restart: bool = True,
+    # rclone
+    provider_type: str | None = None,
+    config_data: dict[str, Any] | None = None,
+    # setting
+    settings_input: dict[str, Any] | None = None,
+    ups_config: dict[str, Any] | None = None,
+    # customization
+    theme_name: str | None = None,
+    # oidc
+    provider_id: str | None = None,
+    token: str | None = None,
+    # live
+    path: str | None = None,
+    collect_for: float = 5.0,
+    timeout: float = 10.0,
+) -> dict[str, Any] | str:
+```
+
+## Elicitation Models
+
+### Credential setup
+
+```python
+@dataclass
+class _UnraidCredentials:
+    api_url: str
+    api_key: str
+```
+
+Used by `elicit_and_configure()` to collect Unraid server credentials interactively.
+
+### Destructive action confirmation
+
+```python
+class _ConfirmAction(BaseModel):
+    confirmed: bool = Field(False, description="Check the box to confirm and proceed")
+```
+
+Used by `elicit_destructive_confirmation()` to gate destructive operations.
+
+### Reset confirmation
+
+The reset flow uses a simple `bool` response type to ask whether to overwrite existing credentials.
+
+## GraphQL Query Organization
+
+Each domain module defines query dicts:
+
+```python
+# Example from _docker.py
+_DOCKER_QUERIES = {
+    "list": "{ docker { containers { ... } } }",
+    "details": "query ($id: String!) { docker { container(id: $id) { ... } } }",
+    "networks": "{ docker { networks { ... } } }",
+}
+
+_DOCKER_MUTATIONS = {
+    "start": "mutation ($id: String!) { dockerContainerStart(id: $id) { ... } }",
+}
+```
+
+Mutations are handled with early-return blocks before the query dict lookup to prevent `KeyError`.
+
+## Destructive Action Sets
+
+Each domain with destructive operations defines a frozenset:
+
+```python
+_ARRAY_DESTRUCTIVE = {"stop_array", "remove_disk", "clear_disk_stats"}
+_VM_DESTRUCTIVE = {"force_stop", "reset"}
+_NOTIFICATION_DESTRUCTIVE = {"delete", "delete_archived"}
+```
+
+## See Also
+
+- [TOOLS.md](TOOLS.md) -- Full action/subaction reference
+- [PATTERNS.md](PATTERNS.md) -- Code patterns for query dict and handler organization
+- [../upstream/CLAUDE.md](../upstream/CLAUDE.md) -- GraphQL schema reference

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -1,0 +1,163 @@
+# Testing Guide
+
+Testing patterns for unraid-mcp. All non-live testing is covered here; see [MCPORTER.md](MCPORTER.md) for end-to-end smoke tests.
+
+## Unit Tests
+
+### Running
+
+```bash
+# All unit tests (excludes slow and integration)
+uv run pytest -m "not slow and not integration"
+
+# Single domain
+uv run pytest tests/test_docker.py
+
+# Fail fast
+uv run pytest -x
+
+# With coverage
+uv run pytest --cov=unraid_mcp --cov-report=term-missing
+```
+
+### Organization
+
+```
+tests/
++-- conftest.py                    # Shared fixtures + make_tool_fn() helper
++-- test_array.py                  # Array domain tests
++-- test_auth.py                   # Bearer auth middleware tests
++-- test_client.py                 # GraphQL client tests
++-- test_customization.py          # Customization domain tests
++-- test_docker.py                 # Docker domain tests
++-- test_guards.py                 # Destructive action guard tests
++-- test_health.py                 # Health domain tests
++-- test_info.py                   # System info tests
++-- test_keys.py                   # API key domain tests
++-- test_live.py                   # Live subscription tests
++-- test_notifications.py          # Notification domain tests
++-- test_oidc.py                   # OIDC domain tests
++-- test_plugins.py                # Plugin domain tests
++-- test_rclone.py                 # Rclone domain tests
++-- test_resources.py              # MCP resource tests
++-- test_review_regressions.py     # Regression tests
++-- test_settings.py               # Settings domain tests
++-- test_setup.py                  # Elicitation setup flow tests
++-- test_snapshot.py               # WebSocket snapshot tests
++-- test_storage.py                # Storage/disk domain tests
++-- test_subscription_manager.py   # Subscription manager tests
++-- test_subscription_validation.py # Subscription validation tests
++-- test_users.py                  # User domain tests
++-- test_validation.py             # Input validation tests
++-- test_vm.py                     # VM domain tests
+```
+
+### Patching convention
+
+Patch at the **tool module level**, not the core module:
+
+```python
+# Correct
+@patch("unraid_mcp.tools.unraid.make_graphql_request")
+
+# Wrong -- conftest's mock_graphql_request patches core, not tools
+@patch("unraid_mcp.core.client.make_graphql_request")
+```
+
+Use `conftest.py`'s `make_tool_fn()` helper for creating test tool functions.
+
+## Specialized Test Suites
+
+### Safety tests (`tests/safety/`)
+
+Verify that all destructive actions are properly gated:
+
+```bash
+uv run pytest tests/safety/
+```
+
+Tests confirm that:
+- Destructive subactions are blocked without `confirm=True`
+- Elicitation is triggered for interactive clients
+- `ToolError` is raised for non-interactive clients without `confirm=True`
+
+### Schema tests (`tests/schema/`)
+
+Validate GraphQL query strings against the Unraid API schema (119 tests):
+
+```bash
+uv run pytest tests/schema/
+```
+
+Uses `graphql-core` to parse and validate all query dicts.
+
+### HTTP layer tests (`tests/http_layer/`)
+
+Test httpx request/response handling using `respx`:
+
+```bash
+uv run pytest tests/http_layer/
+```
+
+### Contract tests (`tests/contract/`)
+
+Verify response shape contracts:
+
+```bash
+uv run pytest tests/contract/
+```
+
+### Property tests (`tests/property/`)
+
+Input validation using Hypothesis:
+
+```bash
+uv run pytest tests/property/
+```
+
+### Integration tests (`tests/integration/`)
+
+WebSocket subscription lifecycle tests (slow, requires live server):
+
+```bash
+uv run pytest tests/integration/ -m slow
+```
+
+## Coverage
+
+Configuration in `pyproject.toml`:
+
+- **Minimum**: 80% branch coverage (`fail_under = 80`)
+- **Source**: `unraid_mcp/` directory
+- **Excludes**: tests, `__pycache__`, `.venv`, abstract methods, type checking blocks
+- **Reports**: terminal, HTML (`.cache/htmlcov/`), XML (`.cache/coverage.xml`)
+
+```bash
+# Generate coverage report
+uv run pytest --cov=unraid_mcp --cov-report=html
+
+# View HTML report
+open .cache/htmlcov/index.html
+```
+
+## Test markers
+
+| Marker | Description |
+|--------|-------------|
+| `slow` | Long-running tests (deselect with `-m "not slow"`) |
+| `integration` | Integration tests requiring external services |
+| `unit` | Unit tests (fast, no external dependencies) |
+
+## Justfile recipes
+
+```bash
+just test          # Run all tests
+just test-live     # Run live integration tests
+just test-http     # HTTP e2e smoke test
+```
+
+## See Also
+
+- [MCPORTER.md](MCPORTER.md) -- End-to-end smoke testing
+- [CICD.md](CICD.md) -- CI test configuration
+- [SCHEMA.md](SCHEMA.md) -- Schema definitions tested by schema tests

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -1,0 +1,325 @@
+# MCP Tools Reference
+
+## Design Philosophy
+
+unraid-mcp exposes four MCP tools:
+
+| Tool | Purpose | Parameters |
+|------|---------|------------|
+| `unraid` | Primary tool -- action+subaction dispatch for 15 domains | `action`, `subaction`, plus domain-specific params |
+| `unraid_help` | Returns markdown reference for all actions | _(none)_ |
+| `diagnose_subscriptions` | Inspect WebSocket subscription states | _(none)_ |
+| `test_subscription_query` | Test a GraphQL subscription query | `query` (allowlisted fields only) |
+
+The consolidated action pattern keeps the MCP surface small (4 tools) while supporting 107 subactions across 15 domains. Clients call `unraid_help` first to discover available operations, then call `unraid` with the appropriate action and subaction.
+
+## Primary Tool: `unraid`
+
+### Input Schema
+
+```python
+unraid(
+    action: str,       # Domain (required)
+    subaction: str,    # Operation (required)
+    confirm: bool,     # True to bypass elicitation for destructive ops
+    # ... domain-specific parameters
+)
+```
+
+### Common Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `action` | `Literal[15 values]` | yes | Domain to operate on |
+| `subaction` | `str` | yes | Operation within the domain |
+| `confirm` | `bool` | no | Set `True` for destructive subactions (default: `False`) |
+| `container_id` | `str` | no | Docker container ID or name (fuzzy match supported) |
+| `vm_id` | `str` | no | VM identifier |
+| `disk_id` | `str` | no | Disk identifier |
+| `notification_id` | `str` | no | Single notification ID |
+| `notification_ids` | `list[str]` | no | Multiple notification IDs |
+| `key_id` | `str` | no | API key identifier |
+| `name` | `str` | no | Name for create/update operations |
+| `path` | `str` | no | Log file path (for `live/log_tail`) |
+| `collect_for` | `float` | no | WebSocket collection duration in seconds (default: 5.0) |
+| `limit` | `int` | no | Max items to return (default: 20) |
+| `offset` | `int` | no | Pagination offset (default: 0) |
+
+### Actions and Subactions
+
+#### `system` (18 subactions)
+
+Server information, metrics, network, and UPS management.
+
+| Subaction | Description | Extra params |
+|-----------|-------------|-------------|
+| `overview` | Complete system summary (recommended starting point) | -- |
+| `server` | Hostname, version, uptime | -- |
+| `servers` | All known Unraid servers | -- |
+| `array` | Array status and disk list | -- |
+| `network` | Network interfaces and config | -- |
+| `registration` | License and registration status | -- |
+| `variables` | Environment variables | -- |
+| `metrics` | Real-time CPU, memory, I/O usage | -- |
+| `services` | Running services status | -- |
+| `display` | Display settings | -- |
+| `config` | System configuration | -- |
+| `online` | Quick online status check | -- |
+| `owner` | Server owner information | -- |
+| `settings` | User settings and preferences | -- |
+| `flash` | USB flash drive details | -- |
+| `ups_devices` | List all UPS devices | -- |
+| `ups_device` | Single UPS device details | `device_id` |
+| `ups_config` | UPS configuration | -- |
+
+#### `health` (4 subactions)
+
+Health checks, connection testing, diagnostics, and credential setup.
+
+| Subaction | Description | Extra params |
+|-----------|-------------|-------------|
+| `check` | Comprehensive health check (connectivity, array, disks, containers, VMs, resources) | -- |
+| `test_connection` | Test API connectivity and authentication, returns latency | -- |
+| `diagnose` | Detailed diagnostic report with subscription status and middleware error stats | -- |
+| `setup` | Configure credentials interactively via elicitation (stores to `~/.unraid-mcp/.env`) | -- |
+
+#### `array` (13 subactions)
+
+Parity checks, array lifecycle, and disk operations.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `parity_status` | Current parity check progress and status | -- | -- |
+| `parity_history` | Historical parity check results | -- | -- |
+| `parity_start` | Start a parity check | `correct` (bool) | -- |
+| `parity_pause` | Pause a running parity check | -- | -- |
+| `parity_resume` | Resume a paused parity check | -- | -- |
+| `parity_cancel` | Cancel a running parity check | -- | -- |
+| `start_array` | Start the array | -- | -- |
+| `stop_array` | Stop the array | -- | Yes |
+| `add_disk` | Add a disk to the array | `slot`, `disk_id` | -- |
+| `remove_disk` | Remove a disk from the array | `slot` | Yes |
+| `mount_disk` | Mount a disk | `disk_id` | -- |
+| `unmount_disk` | Unmount a disk | `disk_id` | -- |
+| `clear_disk_stats` | Clear disk statistics permanently | -- | Yes |
+
+#### `disk` (6 subactions)
+
+Shares, physical disks, log files.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `shares` | List network shares | -- | -- |
+| `disks` | All physical disks with health and temperatures | -- | -- |
+| `disk_details` | Detailed info for a specific disk | `disk_id` | -- |
+| `log_files` | List available log files | -- | -- |
+| `logs` | Read log content | `log_path`, `tail_lines` | -- |
+| `flash_backup` | Trigger a flash backup | `remote_name`, `source_path`, `destination_path`, `backup_options` | Yes |
+
+#### `docker` (7 subactions)
+
+Container lifecycle and network inspection.
+
+| Subaction | Description | Extra params |
+|-----------|-------------|-------------|
+| `list` | All containers with status, image, state | -- |
+| `details` | Single container details | `container_id` |
+| `start` | Start a container | `container_id` |
+| `stop` | Stop a container | `container_id` |
+| `restart` | Restart a container | `container_id` |
+| `networks` | List Docker networks | -- |
+| `network_details` | Details for a specific network | `network_id` |
+
+Container identification supports name, ID, or partial name (fuzzy match).
+
+#### `vm` (9 subactions)
+
+Virtual machine lifecycle.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `list` | All VMs with state | -- | -- |
+| `details` | Single VM details | `vm_id` | -- |
+| `start` | Start a VM | `vm_id` | -- |
+| `stop` | Gracefully stop a VM | `vm_id` | -- |
+| `pause` | Pause a VM | `vm_id` | -- |
+| `resume` | Resume a paused VM | `vm_id` | -- |
+| `reboot` | Reboot a VM | `vm_id` | -- |
+| `force_stop` | Force stop a VM (no graceful shutdown) | `vm_id` | Yes |
+| `reset` | Hard reset a VM | `vm_id` | Yes |
+
+#### `notification` (12 subactions)
+
+System notification management.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `overview` | Notification counts (unread, archived by type) | -- | -- |
+| `list` | List notifications | `list_type`, `limit`, `offset` | -- |
+| `create` | Create a notification | `title`, `subject`, `description`, `importance` | -- |
+| `archive` | Archive a notification | `notification_id` | -- |
+| `mark_unread` | Mark a notification as unread | `notification_id` | -- |
+| `recalculate` | Recalculate notification counts | -- | -- |
+| `archive_all` | Archive all unread notifications | -- | -- |
+| `archive_many` | Archive multiple notifications | `notification_ids` | -- |
+| `unarchive_many` | Unarchive multiple notifications | `notification_ids` | -- |
+| `unarchive_all` | Unarchive all archived notifications | -- | -- |
+| `delete` | Delete a notification permanently | `notification_id`, `notification_type` | Yes |
+| `delete_archived` | Delete all archived notifications | -- | Yes |
+
+#### `key` (7 subactions)
+
+API key management.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `list` | All API keys | -- | -- |
+| `get` | Single key details | `key_id` | -- |
+| `create` | Create a new key | `name`, `roles`, `permissions` | -- |
+| `update` | Update a key | `key_id`, `name`, `roles`, `permissions` | -- |
+| `delete` | Delete a key permanently | `key_id` | Yes |
+| `add_role` | Add a role to a key | `key_id`, `roles` | -- |
+| `remove_role` | Remove a role from a key | `key_id`, `roles` | -- |
+
+#### `plugin` (3 subactions)
+
+Plugin management.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `list` | All installed plugins | `bundled` | -- |
+| `add` | Install plugins | `names` (list) | -- |
+| `remove` | Uninstall plugins | `names` (list), `restart` | Yes |
+
+#### `rclone` (4 subactions)
+
+Cloud storage remote management.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `list_remotes` | List configured rclone remotes | -- | -- |
+| `config_form` | Get configuration form for a remote type | `provider_type` | -- |
+| `create_remote` | Create a new remote | `name`, `provider_type`, `config_data` | -- |
+| `delete_remote` | Delete a remote | `name` | Yes |
+
+#### `setting` (2 subactions)
+
+System settings and UPS configuration.
+
+| Subaction | Description | Extra params | Destructive |
+|-----------|-------------|-------------|-------------|
+| `update` | Update system settings | `settings_input` | -- |
+| `configure_ups` | Configure UPS settings | `ups_config` | Yes |
+
+#### `customization` (5 subactions)
+
+Theme and UI customization.
+
+| Subaction | Description | Extra params |
+|-----------|-------------|-------------|
+| `theme` | Current theme settings | -- |
+| `public_theme` | Public-facing theme | -- |
+| `is_initial_setup` | Check if initial setup is complete | -- |
+| `sso_enabled` | Check SSO status | -- |
+| `set_theme` | Update theme | `theme_name` |
+
+#### `oidc` (5 subactions)
+
+OIDC/SSO provider management.
+
+| Subaction | Description | Extra params |
+|-----------|-------------|-------------|
+| `providers` | List configured OIDC providers | -- |
+| `provider` | Single provider details | `provider_id` |
+| `configuration` | OIDC configuration | -- |
+| `public_providers` | Public-facing provider list | -- |
+| `validate_session` | Validate current SSO session | `token` |
+
+#### `user` (1 subaction)
+
+| Subaction | Description |
+|-----------|-------------|
+| `me` | Current authenticated user info |
+
+#### `live` (11 subactions)
+
+Real-time WebSocket subscription snapshots. Returns a "connecting" placeholder on first call -- retry momentarily for live data.
+
+| Subaction | Description | Extra params |
+|-----------|-------------|-------------|
+| `cpu` | Live CPU utilization | `collect_for` |
+| `memory` | Live memory usage | `collect_for` |
+| `cpu_telemetry` | Detailed CPU telemetry (power, temp) | `collect_for` |
+| `array_state` | Live array state changes | `collect_for` |
+| `parity_progress` | Live parity check progress | `collect_for` |
+| `ups_status` | Live UPS status | `collect_for` |
+| `notifications_overview` | Live notification counts | `collect_for` |
+| `owner` | Live owner info | `collect_for` |
+| `server_status` | Live server status | `collect_for` |
+| `log_tail` | Live log tail stream | `path` (required), `collect_for` |
+| `notification_feed` | Live notification feed | `collect_for` |
+
+## Destructive Operations
+
+All destructive operations require `confirm=True`. Without it, interactive clients are prompted via MCP elicitation; non-interactive clients receive a `ToolError` instructing them to re-call with `confirm=True`.
+
+### Destructive subactions summary
+
+| Domain | Subaction | Risk |
+|--------|-----------|------|
+| `array` | `stop_array` | Stops array while containers/VMs may use shares |
+| `array` | `remove_disk` | Removes disk from array |
+| `array` | `clear_disk_stats` | Clears disk statistics permanently |
+| `vm` | `force_stop` | Hard kills VM without graceful shutdown |
+| `vm` | `reset` | Hard resets VM |
+| `notification` | `delete` | Permanently deletes a notification |
+| `notification` | `delete_archived` | Permanently deletes all archived notifications |
+| `rclone` | `delete_remote` | Removes a cloud storage remote |
+| `key` | `delete` | Permanently deletes an API key |
+| `disk` | `flash_backup` | Triggers flash backup operation |
+| `setting` | `configure_ups` | Modifies UPS configuration |
+| `plugin` | `remove` | Uninstalls a plugin |
+
+## Error Responses
+
+Errors use FastMCP's `ToolError` for user-facing messages:
+
+- **ToolError** -- invalid action, subaction, or missing required parameter
+- **CredentialsNotConfiguredError** -- triggers elicitation or setup instructions
+- **TimeoutError** -- upstream Unraid API did not respond in time
+- **GraphQL errors** -- converted to ToolError with descriptive messages
+
+## Example Tool Calls
+
+```python
+# System overview
+unraid(action="system", subaction="overview")
+
+# Health check
+unraid(action="health", subaction="check")
+
+# List Docker containers
+unraid(action="docker", subaction="list")
+
+# Restart a specific container
+unraid(action="docker", subaction="restart", container_id="plex")
+
+# Live CPU monitoring for 3 seconds
+unraid(action="live", subaction="cpu", collect_for=3.0)
+
+# Tail a log file
+unraid(action="live", subaction="log_tail", path="/var/log/syslog", collect_for=5.0)
+
+# Stop array (destructive)
+unraid(action="array", subaction="stop_array", confirm=True)
+
+# List notifications (paginated)
+unraid(action="notification", subaction="list", limit=10, list_type="UNREAD")
+```
+
+## See Also
+
+- [SCHEMA.md](SCHEMA.md) -- Schema definitions behind these tools
+- [AUTH.md](AUTH.md) -- Authentication required before tool calls
+- [ENV.md](ENV.md) -- Environment variable configuration
+- [ELICITATION.md](ELICITATION.md) -- Interactive credential and confirmation flows

--- a/docs/mcp/TRANSPORT.md
+++ b/docs/mcp/TRANSPORT.md
@@ -1,0 +1,106 @@
+# Transport Methods Reference
+
+## Overview
+
+unraid-mcp supports three transport methods for MCP communication:
+
+| Transport | Default | Auth required | Use case |
+|-----------|---------|--------------|----------|
+| `streamable-http` | Yes | Yes (bearer token) | Production HTTP deployments, remote access |
+| `stdio` | No | No | Claude Desktop, local process-based clients |
+| `sse` | No (deprecated) | Yes (bearer token) | Legacy clients that do not support streamable-http |
+
+Set the transport via `UNRAID_MCP_TRANSPORT` in `.env`.
+
+## streamable-http (default)
+
+The recommended transport for production deployments.
+
+```bash
+UNRAID_MCP_TRANSPORT=streamable-http
+UNRAID_MCP_HOST=0.0.0.0
+UNRAID_MCP_PORT=6970
+```
+
+The MCP endpoint is served at `/mcp`:
+```
+http://localhost:6970/mcp
+```
+
+### Authentication
+
+Bearer token required by default. See [AUTH.md](AUTH.md) for configuration.
+
+### Health endpoint
+
+`GET /health` returns `{"status":"ok"}` without authentication. Use for Docker healthchecks and monitoring.
+
+## stdio
+
+Process-based transport for local clients like Claude Desktop.
+
+```bash
+UNRAID_MCP_TRANSPORT=stdio
+```
+
+The server reads from stdin and writes to stdout. No HTTP server is started, no bearer token is needed.
+
+### Plugin manifest
+
+The `.claude-plugin/plugin.json` configures stdio transport:
+
+```json
+{
+  "mcpServers": {
+    "unraid": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "unraid-mcp-server"],
+      "env": {
+        "UNRAID_MCP_TRANSPORT": "stdio"
+      }
+    }
+  }
+}
+```
+
+## SSE (deprecated)
+
+Server-Sent Events transport. Supported but deprecated in favor of streamable-http.
+
+```bash
+UNRAID_MCP_TRANSPORT=sse
+```
+
+A deprecation warning is logged at startup.
+
+## Docker transport configuration
+
+The `docker-compose.yaml` healthcheck adapts to the configured transport:
+
+```yaml
+healthcheck:
+  test:
+    - "CMD-SHELL"
+    - |
+      if [ "${UNRAID_MCP_TRANSPORT:-streamable-http}" = "stdio" ]; then
+        exit 0
+      fi
+      wget -qO- "http://localhost:${UNRAID_MCP_PORT:-6970}/health" > /dev/null
+```
+
+For stdio transport, the healthcheck always passes (the process itself is the health indicator).
+
+## WebSocket subscriptions
+
+Regardless of MCP transport, the server maintains outbound WebSocket connections to the Unraid GraphQL API for live subscriptions. These use the `graphql-transport-ws` protocol with `connection_init` and `subscribe` messages.
+
+WebSocket URLs are derived from the `UNRAID_API_URL`:
+- `https://tower.local/graphql` becomes `wss://tower.local/graphql`
+- `http://tower.local/graphql` becomes `ws://tower.local/graphql`
+
+## See Also
+
+- [AUTH.md](AUTH.md) -- Bearer token setup for HTTP transports
+- [CONNECT.md](CONNECT.md) -- Client-specific connection guides
+- [DEPLOY.md](DEPLOY.md) -- Deployment patterns for each transport

--- a/docs/mcp/WEBMCP.md
+++ b/docs/mcp/WEBMCP.md
@@ -1,0 +1,86 @@
+# Web MCP Integration
+
+HTTP-accessible endpoints on the unraid-mcp server.
+
+## Endpoints
+
+### `/mcp` -- MCP protocol endpoint
+
+The primary MCP endpoint for tool calls and resource reads. Requires bearer token authentication (unless disabled).
+
+- **Transport**: streamable-http (POST with JSON-RPC)
+- **Auth**: `Authorization: Bearer <token>`
+- **Content-Type**: `application/json`
+
+### `/health` -- Health check
+
+Unauthenticated endpoint for liveness probes.
+
+- **Method**: GET
+- **Response**: `{"status":"ok"}` (200)
+- **Auth**: None (served before auth middleware)
+
+Used by:
+- Docker HEALTHCHECK directive
+- docker-compose healthcheck
+- External monitoring systems
+- Load balancer health probes
+
+### `/.well-known/oauth-protected-resource` -- OAuth discovery
+
+RFC 9728 OAuth 2.0 Protected Resource Metadata. Unauthenticated.
+
+- **Method**: GET
+- **Response**:
+  ```json
+  {
+    "resource": "http://localhost:6970",
+    "bearer_methods_supported": ["header"]
+  }
+  ```
+- **Purpose**: MCP clients probe this after receiving a 401 to discover authentication requirements. The empty `authorization_servers` list tells clients to use a pre-shared bearer token.
+
+Also served at `/.well-known/oauth-protected-resource/mcp` for MCP-specific discovery.
+
+## ASGI Middleware Stack
+
+Requests pass through middleware in this order (outermost first):
+
+1. **HealthMiddleware** -- intercepts `GET /health`
+2. **WellKnownMiddleware** -- intercepts `GET /.well-known/oauth-protected-resource`
+3. **BearerAuthMiddleware** -- validates bearer token for all other requests
+4. **FastMCP app** -- MCP protocol handling with its own middleware chain
+
+## CORS
+
+No CORS middleware is configured. The server is designed for server-to-server MCP communication, not browser access. If browser access is needed (e.g., MCP Inspector), configure CORS at the reverse proxy level.
+
+## WebSocket Support
+
+The `BearerAuthMiddleware` passes WebSocket scopes (`scope["type"] == "websocket"`) through without authentication, as WebSocket connections are initiated by the server itself (outbound to Unraid API), not by MCP clients.
+
+## Reverse Proxy Configuration
+
+For SWAG/nginx:
+
+```nginx
+location /mcp {
+    proxy_pass http://unraid-mcp:6970/mcp;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+location /health {
+    proxy_pass http://unraid-mcp:6970/health;
+}
+```
+
+See `docs/unraid.subdomain.conf` for a complete SWAG subdomain example.
+
+## See Also
+
+- [AUTH.md](AUTH.md) -- Bearer token configuration
+- [TRANSPORT.md](TRANSPORT.md) -- Transport method details
+- [DEPLOY.md](DEPLOY.md) -- Reverse proxy deployment

--- a/docs/plugin/AGENTS.md
+++ b/docs/plugin/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Definitions -- unraid-mcp
+
+## Status
+
+unraid-mcp does not currently define any agents. The `unraid` MCP tool with its 15 action domains provides sufficient coverage for all Unraid operations without requiring specialized agent behavior.
+
+## Symlinks
+
+The repository includes `AGENTS.md` and `GEMINI.md` as symlinks to `CLAUDE.md` for Codex and Gemini compatibility:
+
+```bash
+ln -sf CLAUDE.md AGENTS.md
+ln -sf CLAUDE.md GEMINI.md
+```
+
+These are not agent definitions -- they are development instruction files for AI coding assistants.
+
+## See Also
+
+- [SKILLS.md](SKILLS.md) -- Skill definitions
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- Tool reference

--- a/docs/plugin/CHANNELS.md
+++ b/docs/plugin/CHANNELS.md
@@ -1,0 +1,19 @@
+# Channel Integration -- unraid-mcp
+
+## Status
+
+unraid-mcp does not currently define any channel integrations. The server communicates exclusively through MCP protocol (stdio or HTTP transports).
+
+## Future considerations
+
+Channel integrations could enable:
+- Real-time Unraid alerts forwarded to Discord or Slack
+- Subscription data (parity progress, disk failures) pushed to messaging platforms
+- Interactive Unraid management from chat interfaces
+
+These would require the plugin to define channel configurations in the plugin manifest.
+
+## See Also
+
+- [../mcp/RESOURCES.md](../mcp/RESOURCES.md) -- Live subscription data that could feed channels
+- [../mcp/TRANSPORT.md](../mcp/TRANSPORT.md) -- Current transport methods

--- a/docs/plugin/CLAUDE.md
+++ b/docs/plugin/CLAUDE.md
@@ -1,0 +1,35 @@
+# Plugin Surface Documentation -- unraid-mcp
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [PLUGINS.md](PLUGINS.md) | Plugin manifest reference (plugin.json for Claude, Codex, Gemini) |
+| [SKILLS.md](SKILLS.md) | Skill definitions and SKILL.md format |
+| [HOOKS.md](HOOKS.md) | PostToolUse hook configuration |
+| [COMMANDS.md](COMMANDS.md) | Slash command definitions (none currently) |
+| [AGENTS.md](AGENTS.md) | Agent definitions (none currently) |
+| [CHANNELS.md](CHANNELS.md) | Channel integrations (none currently) |
+| [CONFIG.md](CONFIG.md) | Plugin settings and userConfig |
+| [MARKETPLACES.md](MARKETPLACES.md) | Marketplace publishing and discovery |
+| [OUTPUT-STYLES.md](OUTPUT-STYLES.md) | Output style definitions (none currently) |
+| [SCHEDULES.md](SCHEDULES.md) | Scheduled tasks (none currently) |
+
+## Plugin surface summary
+
+| Component | Count | Status |
+|-----------|-------|--------|
+| MCP servers | 1 (`unraid`) | Active |
+| Skills | 1 (`unraid`) | Active |
+| Hooks | 2 (PostToolUse) | Active |
+| Commands | 0 | -- |
+| Agents | 0 | -- |
+| Channels | 0 | -- |
+| Output styles | 0 | -- |
+| Schedules | 0 | -- |
+
+## Cross-References
+
+- [mcp/](../mcp/) -- MCP server tools, resources, and configuration
+- [repo/](../repo/) -- Repository structure
+- [stack/](../stack/) -- Technology stack details

--- a/docs/plugin/COMMANDS.md
+++ b/docs/plugin/COMMANDS.md
@@ -1,0 +1,20 @@
+# Slash Commands -- unraid-mcp
+
+## Status
+
+unraid-mcp does not currently define any slash commands. All operations are performed through the `unraid` MCP tool with action+subaction routing.
+
+## Future considerations
+
+If slash commands are added, they would be placed in a `commands/` directory and registered in the plugin manifest. Potential candidates:
+
+- `/unraid:setup` -- shortcut for `unraid(action="health", subaction="setup")`
+- `/unraid:health` -- shortcut for `unraid(action="health", subaction="check")`
+- `/unraid:overview` -- shortcut for `unraid(action="system", subaction="overview")`
+
+Currently, the `unraid` skill in `skills/unraid/SKILL.md` serves as the primary interface for Claude Code, making slash commands redundant.
+
+## See Also
+
+- [SKILLS.md](SKILLS.md) -- Skill definitions (primary interface)
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- MCP tool reference

--- a/docs/plugin/CONFIG.md
+++ b/docs/plugin/CONFIG.md
@@ -1,0 +1,43 @@
+# Plugin Settings -- unraid-mcp
+
+## userConfig (Claude Code)
+
+The `.claude-plugin/plugin.json` defines four user-configurable settings:
+
+| Key | Type | Sensitive | Default | Description |
+|-----|------|-----------|---------|-------------|
+| `unraid_mcp_url` | string | no | `https://unraid.tootie.tv/mcp` | URL of the MCP server |
+| `unraid_mcp_token` | string | yes | -- | Bearer token for MCP auth |
+| `unraid_api_url` | string | yes | -- | Unraid GraphQL API URL |
+| `unraid_api_key` | string | yes | -- | Unraid API key |
+
+### How settings are used
+
+- **Non-sensitive**: Available as literal values in skill templates (`${user_config.unraid_mcp_url}`)
+- **Sensitive**: Available ONLY as `$CLAUDE_PLUGIN_OPTION_*` environment variables in Bash subprocesses
+  - `$CLAUDE_PLUGIN_OPTION_UNRAID_MCP_TOKEN`
+  - `$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL`
+  - `$CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY`
+
+Attempting `${user_config.unraid_api_key}` in a template will not work for sensitive values.
+
+## Settings (Gemini CLI)
+
+The `gemini-extension.json` defines two settings:
+
+| Name | envVar | Sensitive |
+|------|--------|-----------|
+| Unraid API URL | `UNRAID_API_URL` | no |
+| Unraid API Key | `UNRAID_API_KEY` | yes |
+
+Gemini sets these as environment variables before launching the MCP server.
+
+## Codex CLI
+
+The `.codex-plugin/plugin.json` does not define explicit settings. Codex reads credentials from `~/.unraid-mcp/.env` via the standard loading chain.
+
+## See Also
+
+- [PLUGINS.md](PLUGINS.md) -- Full plugin manifest reference
+- [SKILLS.md](SKILLS.md) -- How skills reference userConfig
+- [../mcp/ENV.md](../mcp/ENV.md) -- Server-side environment variables

--- a/docs/plugin/HOOKS.md
+++ b/docs/plugin/HOOKS.md
@@ -1,0 +1,76 @@
+# Hook Configuration -- unraid-mcp
+
+## Overview
+
+unraid-mcp registers PostToolUse hooks that run after Write, Edit, MultiEdit, or Bash operations to enforce security invariants.
+
+## Hook definition
+
+**File**: `hooks/hooks.json`
+
+```json
+{
+  "description": "Enforce 600 permissions and keep gitignore aligned",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/fix-env-perms.sh",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scripts/ensure-ignore-files.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Hook scripts
+
+### fix-env-perms.sh
+
+**Purpose**: Ensures credential files maintain secure permissions after any file operation.
+
+- Sets `~/.unraid-mcp/.env` to mode 600
+- Sets `~/.unraid-mcp/` directory to mode 700
+- Runs silently (no output on success)
+- Timeout: 5 seconds
+
+### ensure-ignore-files.sh
+
+**Purpose**: Keeps `.gitignore` and `.dockerignore` aligned with security requirements.
+
+- Verifies sensitive patterns are present in ignore files
+- Prevents credential files from being committed or included in Docker images
+- Can run in check mode (`--check`) for CI validation
+- Timeout: 5 seconds
+
+### Other hook scripts
+
+| Script | Purpose |
+|--------|---------|
+| `ensure-gitignore.sh` | Gitignore-specific enforcement |
+| `sync-env.sh` | Environment file synchronization |
+
+## Trigger
+
+Hooks fire after every:
+- `Write` -- new file creation
+- `Edit` -- file modification
+- `MultiEdit` -- batch file modification
+- `Bash` -- shell command execution
+
+The 5-second timeout ensures hooks never block the development workflow.
+
+## See Also
+
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Security patterns enforced by hooks
+- [PLUGINS.md](PLUGINS.md) -- Plugin manifest that registers hooks

--- a/docs/plugin/MARKETPLACES.md
+++ b/docs/plugin/MARKETPLACES.md
@@ -1,0 +1,69 @@
+# Marketplace Publishing -- unraid-mcp
+
+## Distribution channels
+
+| Marketplace | Identifier | Install method |
+|-------------|-----------|----------------|
+| Claude Plugin Marketplace | `jmagar/unraid-mcp` (via `jmagar/claude-homelab`) | `/plugin install unraid-mcp @jmagar-claude-homelab` |
+| MCP Registry | `tv.tootie/unraid-mcp` | Auto-discovery by MCP clients |
+| PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
+| GitHub Container Registry | `ghcr.io/jmagar/unraid-mcp` | `docker pull ghcr.io/jmagar/unraid-mcp` |
+
+## Claude Plugin Marketplace
+
+unraid-mcp is an external plugin in the `jmagar/claude-homelab` marketplace:
+
+```json
+{
+  "unraid-mcp": {
+    "source": {
+      "type": "git",
+      "url": "https://github.com/jmagar/unraid-mcp"
+    },
+    "category": "infrastructure",
+    "description": "Query, monitor, and manage Unraid servers via GraphQL API."
+  }
+}
+```
+
+### Installation
+
+```bash
+# Add the marketplace (one-time)
+/plugin marketplace add jmagar/claude-homelab
+
+# Install the plugin
+/plugin install unraid-mcp @jmagar-claude-homelab
+```
+
+## MCP Registry
+
+Published via DNS-authenticated `mcp-publisher` using the `tootie.tv` domain.
+
+### Registry entry (`server.json`)
+
+- **Name**: `tv.tootie/unraid-mcp`
+- **Package**: PyPI `unraid-mcp`
+- **Runtime hint**: `uvx` (no install needed)
+- **Transport**: stdio
+- **Required env vars**: `UNRAID_API_URL`, `UNRAID_API_KEY`
+
+### Publishing flow
+
+Triggered by `publish-pypi.yml` workflow on `v*.*.*` tags:
+1. Build and publish to PyPI
+2. Update version in `server.json`
+3. Authenticate via DNS TXT record on `tootie.tv`
+4. Publish to MCP Registry
+
+## PyPI
+
+Published as `unraid-mcp` with:
+- Trusted publisher attestations
+- Source and wheel distributions
+- Python 3.12+ requirement
+
+## See Also
+
+- [PLUGINS.md](PLUGINS.md) -- Manifest details
+- [../mcp/PUBLISH.md](../mcp/PUBLISH.md) -- Full publishing workflow

--- a/docs/plugin/OUTPUT-STYLES.md
+++ b/docs/plugin/OUTPUT-STYLES.md
@@ -1,0 +1,20 @@
+# Output Style Definitions -- unraid-mcp
+
+## Status
+
+unraid-mcp does not currently define custom output styles. Tool responses use standard MCP text content blocks with markdown formatting for tables and structured data.
+
+## Response patterns
+
+Tool responses follow these conventions:
+
+- **Health check**: Structured dict with severity levels (`OK`, `WARNING`, `ERROR`) and recommendations
+- **List operations**: Array of dicts with relevant fields for the domain
+- **Detail operations**: Single dict with comprehensive field data
+- **Mutations**: Confirmation message with operation result
+- **Live data**: JSON with subscription data and `_fetched_at` timestamp
+
+## See Also
+
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- Tool response formats
+- [../mcp/MCPUI.md](../mcp/MCPUI.md) -- UI rendering patterns

--- a/docs/plugin/PLUGINS.md
+++ b/docs/plugin/PLUGINS.md
@@ -1,0 +1,104 @@
+# Plugin Manifest Reference -- unraid-mcp
+
+## Claude Code (`.claude-plugin/plugin.json`)
+
+```json
+{
+  "name": "unraid-mcp",
+  "displayName": "Unraid MCP",
+  "version": "1.2.3",
+  "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools.",
+  "mcpServers": {
+    "unraid": {
+      "type": "stdio",
+      "command": "uv",
+      "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}", "unraid-mcp-server"],
+      "env": { "UNRAID_MCP_TRANSPORT": "stdio" }
+    }
+  },
+  "userConfig": {
+    "unraid_mcp_url": { "type": "string", "sensitive": false },
+    "unraid_mcp_token": { "type": "string", "sensitive": true },
+    "unraid_api_url": { "type": "string", "sensitive": true },
+    "unraid_api_key": { "type": "string", "sensitive": true }
+  }
+}
+```
+
+### Key fields
+
+- **mcpServers.unraid**: stdio transport via `uv run`. The `${CLAUDE_PLUGIN_ROOT}` variable resolves to the plugin installation directory.
+- **userConfig**: Four settings collected at install time. Sensitive values are stored encrypted and exposed as `$CLAUDE_PLUGIN_OPTION_*` environment variables in Bash subprocesses.
+
+## Codex CLI (`.codex-plugin/plugin.json`)
+
+```json
+{
+  "name": "unraid-mcp",
+  "version": "1.2.3",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "apps": "./.app.json",
+  "interface": {
+    "displayName": "Unraid MCP",
+    "category": "Infrastructure",
+    "capabilities": ["Read", "Write"],
+    "brandColor": "#F59E0B"
+  }
+}
+```
+
+### Key fields
+
+- **skills**: Points to `./skills/` directory containing the unraid skill
+- **interface**: Rich metadata for Codex CLI display, including brand color and default prompts
+
+## Gemini CLI (`gemini-extension.json`)
+
+```json
+{
+  "name": "unraid-mcp",
+  "version": "1.2.3",
+  "mcpServers": {
+    "unraid-mcp": {
+      "command": "uv",
+      "args": ["run", "unraid-mcp-server"],
+      "cwd": "${extensionPath}"
+    }
+  },
+  "settings": [
+    { "name": "Unraid API URL", "envVar": "UNRAID_API_URL", "sensitive": false },
+    { "name": "Unraid API Key", "envVar": "UNRAID_API_KEY", "sensitive": true }
+  ]
+}
+```
+
+## MCP Registry (`server.json`)
+
+```json
+{
+  "name": "tv.tootie/unraid-mcp",
+  "packages": [{
+    "registryType": "pypi",
+    "identifier": "unraid-mcp",
+    "runtimeHint": "uvx",
+    "transport": { "type": "stdio" },
+    "environmentVariables": [
+      { "name": "UNRAID_API_URL", "isRequired": true },
+      { "name": "UNRAID_API_KEY", "isRequired": true, "isSecret": true }
+    ]
+  }]
+}
+```
+
+## Version sync
+
+All four manifest files must contain the same version string. This is enforced by:
+- CI `version-sync` job
+- `just publish` recipe (updates all files atomically)
+
+## See Also
+
+- [CONFIG.md](CONFIG.md) -- userConfig field details
+- [MARKETPLACES.md](MARKETPLACES.md) -- Publishing to marketplaces
+- [../mcp/CONNECT.md](../mcp/CONNECT.md) -- Client connection guides

--- a/docs/plugin/SCHEDULES.md
+++ b/docs/plugin/SCHEDULES.md
@@ -1,0 +1,22 @@
+# Scheduled Tasks -- unraid-mcp
+
+## Status
+
+unraid-mcp does not currently define scheduled tasks. The server runs continuously and maintains persistent WebSocket subscriptions for real-time data.
+
+## Built-in auto-start
+
+While not a scheduled task in the plugin sense, the server auto-starts WebSocket subscriptions on boot when `UNRAID_AUTO_START_SUBSCRIPTIONS=true` (default). This provides always-on live data without explicit scheduling.
+
+## Future considerations
+
+Scheduled tasks could enable:
+- Periodic health check reports
+- Scheduled parity check initiation
+- Automated notification archival
+- Regular backup triggers
+
+## See Also
+
+- [../mcp/RESOURCES.md](../mcp/RESOURCES.md) -- Live subscription data
+- [../mcp/ENV.md](../mcp/ENV.md) -- Auto-start configuration

--- a/docs/plugin/SKILLS.md
+++ b/docs/plugin/SKILLS.md
@@ -1,0 +1,50 @@
+# Skill Definitions -- unraid-mcp
+
+## Overview
+
+unraid-mcp ships one skill that provides client-facing documentation for all Unraid operations.
+
+## Skill: `unraid`
+
+**Location**: `skills/unraid/SKILL.md`
+
+### Frontmatter
+
+```yaml
+---
+name: unraid
+description: "This skill should be used when the user mentions Unraid, asks to check server health, monitor array or disk status, list or restart Docker containers, start or stop VMs, read system logs, check parity status, view notifications, manage API keys, configure rclone remotes, check UPS or power status, get live CPU or memory data, force stop a VM, check disk temperatures, or perform any operation on an Unraid NAS server."
+---
+```
+
+The description is a comprehensive trigger list that helps Claude Code match user intents to this skill.
+
+### Sections
+
+1. **Mode Detection**: MCP mode (preferred) vs HTTP fallback
+2. **Setup**: First-time credential configuration via `health/setup`
+3. **Calling Convention**: `unraid(action="<domain>", subaction="<operation>")`
+4. **All Domains and Subactions**: 15 domain tables with every subaction, description, and required parameters
+5. **Destructive Actions**: Summary table with risk descriptions
+6. **Common Workflows**: Multi-step examples for setup, monitoring, container management, logs, and VMs
+7. **Notes**: Rate limits, log path validation, known API bugs
+8. **HTTP Fallback Mode**: Direct GraphQL curl commands using `$CLAUDE_PLUGIN_OPTION_*` variables
+
+### HTTP fallback
+
+When MCP tools are unavailable, the skill documents direct GraphQL queries:
+
+```bash
+curl -s "$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL" \
+  -H "x-api-key: $CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ info { os { hostname uptime } } }"}'
+```
+
+Credentials are available as `$CLAUDE_PLUGIN_OPTION_*` environment variables (from plugin.json `userConfig`, sensitive fields).
+
+## See Also
+
+- [PLUGINS.md](PLUGINS.md) -- Plugin manifests that register the skill
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- Tool definitions the skill documents
+- [../mcp/ELICITATION.md](../mcp/ELICITATION.md) -- Setup wizard referenced by the skill

--- a/docs/repo/CLAUDE.md
+++ b/docs/repo/CLAUDE.md
@@ -1,0 +1,17 @@
+# Repository Documentation -- unraid-mcp
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [REPO.md](REPO.md) | Repository structure and directory layout |
+| [RECIPES.md](RECIPES.md) | Justfile recipes for development and operations |
+| [SCRIPTS.md](SCRIPTS.md) | Scripts reference for quality gates and utilities |
+| [RULES.md](RULES.md) | Coding rules and conventions |
+| [MEMORY.md](MEMORY.md) | Memory files and persistent knowledge |
+
+## Cross-References
+
+- [mcp/](../mcp/) -- MCP server documentation
+- [plugin/](../plugin/) -- Plugin surface documentation
+- [stack/](../stack/) -- Technology stack details

--- a/docs/repo/MEMORY.md
+++ b/docs/repo/MEMORY.md
@@ -1,0 +1,36 @@
+# Memory Files -- unraid-mcp
+
+## Overview
+
+This project uses `bd` (beads) for persistent knowledge instead of MEMORY.md files. Run `bd prime` for full context.
+
+## Key knowledge
+
+### Architecture
+
+- FastMCP server with consolidated `unraid` tool (15 action domains, 107 subactions)
+- 4-layer MCP middleware chain: logging, error handling, rate limiting, response limiting
+- 3-layer ASGI middleware: health bypass, well-known discovery, bearer auth
+- WebSocket subscription manager for 10 live data streams
+- Elicitation-based credential setup and destructive action gating
+
+### Critical gotchas
+
+- Mutation handlers MUST return before the domain query dict lookup (prevents `KeyError`)
+- Patch at tool module level for tests, not core module level
+- `ResponseCachingMiddleware` was removed because the consolidated tool mixes reads and mutations
+- Bearer tokens are removed from `os.environ` after startup
+- `arraySubscription` has a known Unraid API bug (may show "connecting" indefinitely)
+
+### Version files
+
+Four files must stay in sync: `pyproject.toml`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`.
+
+### Credential storage
+
+Canonical path: `~/.unraid-mcp/.env` (mode 600, directory mode 700). Override with `UNRAID_CREDENTIALS_DIR`.
+
+## See Also
+
+- Root `CLAUDE.md` -- Complete development instructions
+- [RULES.md](RULES.md) -- Coding conventions

--- a/docs/repo/RECIPES.md
+++ b/docs/repo/RECIPES.md
@@ -1,0 +1,70 @@
+# Justfile Recipes -- unraid-mcp
+
+## Development
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just dev` | `uv run python -m unraid_mcp` | Start development server |
+| `just test` | `uv run pytest tests/ -v` | Run all tests |
+| `just lint` | `uv run ruff check .` | Run linter |
+| `just fmt` | `uv run ruff format .` | Format code |
+| `just typecheck` | `uv run pyright` or `mypy` | Type check |
+| `just validate-skills` | Check `skills/*/SKILL.md` | Validate skill files exist |
+
+## Docker Compose
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just build` | `docker build -t unraid-mcp .` | Build Docker image |
+| `just up` | `docker compose up -d` | Start containers |
+| `just down` | `docker compose down` | Stop containers |
+| `just restart` | `docker compose restart` | Restart containers |
+| `just logs` | `docker compose logs -f` | Tail container logs |
+| `just health` | `curl /health` | Check health endpoint |
+
+## Live Testing
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just test-live` | `pytest -m live` | Run live integration tests |
+| `just test-http` | `test-http.sh` | HTTP e2e test with auth |
+| `just test-http-no-auth` | `test-http.sh --skip-auth` | HTTP e2e test without auth |
+| `just test-http-remote <url>` | `test-http.sh --url <url>` | HTTP e2e against remote URL |
+
+## Setup
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just setup` | Copy `.env.example` to `.env` | Create local env file |
+| `just gen-token` | `secrets.token_urlsafe(32)` | Generate a bearer token |
+
+## Quality Gates
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just check-contract` | Security check scripts | Docker security, no baked env, ignore files |
+
+## Cleanup
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just clean` | Remove caches and artifacts | dist/, __pycache__, .pytest_cache, .coverage |
+
+## Publishing
+
+| Recipe | Command | Description |
+|--------|---------|-------------|
+| `just publish patch` | Bump, tag, push | Patch release |
+| `just publish minor` | Bump, tag, push | Minor release |
+| `just publish major` | Bump, tag, push | Major release |
+
+The publish recipe:
+1. Verifies `main` branch with clean working tree
+2. Pulls latest from origin
+3. Bumps version in pyproject.toml and all manifest files
+4. Commits, tags, and pushes
+
+## See Also
+
+- [../mcp/DEV.md](../mcp/DEV.md) -- Development workflow
+- [SCRIPTS.md](SCRIPTS.md) -- Scripts called by recipes

--- a/docs/repo/REPO.md
+++ b/docs/repo/REPO.md
@@ -1,0 +1,140 @@
+# Repository Structure -- unraid-mcp
+
+## Directory layout
+
+```
+unraid-mcp/
++-- CLAUDE.md                          # Development instructions for AI coding assistants
++-- AGENTS.md -> CLAUDE.md             # Codex compatibility symlink
++-- GEMINI.md -> CLAUDE.md             # Gemini compatibility symlink
++-- CHANGELOG.md                       # Version history
++-- README.md                          # User-facing documentation
++-- LICENSE                            # MIT license
++-- pyproject.toml                     # Python project metadata, dependencies, tool config
++-- uv.lock                            # Locked dependency versions
++-- Justfile                           # Task runner recipes
++-- Dockerfile                         # Multi-stage Docker build
++-- docker-compose.yaml                # Container orchestration
++-- entrypoint.sh                      # Docker entrypoint with env validation
++-- server.json                        # MCP Registry manifest (tv.tootie/unraid-mcp)
++-- gemini-extension.json              # Gemini CLI manifest
++-- .env.example                       # Environment variable template
+|
++-- .claude-plugin/
+|   +-- plugin.json                    # Claude Code plugin manifest
+|   +-- marketplace.json               # Marketplace catalog entry
+|   +-- README.md                      # Plugin marketplace description
+|
++-- .codex-plugin/
+|   +-- plugin.json                    # Codex CLI plugin manifest
+|
++-- unraid_mcp/                        # Python source package
+|   +-- __init__.py
+|   +-- main.py                        # Entry point and shutdown cleanup
+|   +-- server.py                      # FastMCP server, middleware chain, ASGI auth
+|   +-- version.py                     # Version from package metadata
+|   +-- config/
+|   |   +-- __init__.py
+|   |   +-- settings.py                # Environment loading, configuration constants
+|   |   +-- logging.py                 # Structured logging setup
+|   +-- core/
+|   |   +-- __init__.py
+|   |   +-- auth.py                    # BearerAuthMiddleware, HealthMiddleware, WellKnownMiddleware
+|   |   +-- client.py                  # Async GraphQL HTTP client
+|   |   +-- exceptions.py              # ToolError, CredentialsNotConfiguredError
+|   |   +-- guards.py                  # Destructive action gating via elicitation
+|   |   +-- middleware_refs.py         # Circular import breaker for error middleware
+|   |   +-- setup.py                   # Elicitation-based credential setup
+|   |   +-- types.py                   # Shared type definitions
+|   |   +-- utils.py                   # safe_get, safe_display_url, path validation
+|   |   +-- validation.py             # Input validation helpers
+|   +-- subscriptions/
+|   |   +-- __init__.py
+|   |   +-- diagnostics.py            # Diagnostic tools for subscription debugging
+|   |   +-- manager.py                # WebSocket subscription manager singleton
+|   |   +-- queries.py                # GraphQL subscription query strings
+|   |   +-- resources.py              # MCP resource registration
+|   |   +-- snapshot.py               # One-shot subscribe_once fallback
+|   |   +-- utils.py                  # WebSocket URL building, SSL context, status analysis
+|   +-- tools/
+|       +-- __init__.py
+|       +-- unraid.py                  # Consolidated action router (15 domains)
+|       +-- _array.py                  # Array and parity operations
+|       +-- _customization.py          # Theme and UI customization
+|       +-- _disk.py                   # Shares, disks, logs, flash backup
+|       +-- _docker.py                # Container lifecycle and networks
+|       +-- _health.py                 # Health check, connection test
+|       +-- _key.py                    # API key management
+|       +-- _live.py                   # Live subscription snapshots
+|       +-- _notification.py           # Notification CRUD
+|       +-- _oidc.py                   # OIDC/SSO providers
+|       +-- _plugin.py                 # Plugin management
+|       +-- _rclone.py                 # Cloud storage remotes
+|       +-- _setting.py                # System settings and UPS
+|       +-- _system.py                 # Server info, metrics, network
+|       +-- _user.py                   # Current user
+|       +-- _vm.py                     # Virtual machine lifecycle
+|
++-- skills/
+|   +-- unraid/
+|       +-- SKILL.md                   # Client-facing skill documentation
+|
++-- hooks/
+|   +-- hooks.json                     # PostToolUse hook definitions
+|   +-- scripts/
+|       +-- fix-env-perms.sh           # Credential permission enforcement
+|       +-- ensure-ignore-files.sh     # Gitignore/dockerignore alignment
+|       +-- ensure-gitignore.sh        # Gitignore-specific checks
+|       +-- sync-env.sh               # Environment file synchronization
+|
++-- scripts/
+|   +-- check-docker-security.sh       # Dockerfile security audit
+|   +-- check-no-baked-env.sh          # No baked environment variables
+|   +-- check-outdated-deps.sh         # Dependency freshness
+|   +-- ensure-ignore-files.sh         # Ignore file validation
+|   +-- generate_unraid_api_reference.py  # GraphQL schema to docs
+|   +-- lint-plugin.sh                 # Plugin manifest validation
+|   +-- validate-marketplace.sh        # Marketplace JSON validation
+|
++-- tests/                             # Test suite (see mcp/TESTS.md)
+|   +-- conftest.py
+|   +-- test_*.py                      # 28 unit test files
+|   +-- contract/                      # Response shape tests
+|   +-- http_layer/                    # httpx layer tests
+|   +-- integration/                   # WebSocket lifecycle tests
+|   +-- mcporter/                      # End-to-end smoke tests
+|   +-- property/                      # Hypothesis property tests
+|   +-- safety/                        # Destructive guard tests
+|   +-- schema/                        # GraphQL validation tests
+|
++-- docs/                              # Documentation (this directory)
+|   +-- plans/                         # Development plans
+|   +-- reports/                       # Audit reports
+|   +-- sessions/                      # Session logs
+|   +-- superpowers/                   # Capability docs
+|   +-- AUTHENTICATION.md              # Auth reference
+|   +-- DESTRUCTIVE_ACTIONS.md         # Destructive action reference
+|   +-- MARKETPLACE.md                 # Marketplace guide
+|   +-- PUBLISHING.md                  # Publishing guide
+|   +-- UNRAID_API_*.md                # Unraid API documentation
+|   +-- unraid-schema.graphql          # Full GraphQL schema
+|   +-- unraid-api-introspection.json  # Schema introspection data
+|
++-- .github/
+|   +-- workflows/
+|       +-- ci.yml                     # CI pipeline
+|       +-- docker-publish.yml         # Docker image publishing
+|       +-- publish-pypi.yml           # PyPI and MCP registry publishing
+|
++-- assets/                            # Icons and logos
++-- backups/                           # Flash backup storage
++-- logs/                              # Application logs
+```
+
+## Key conventions
+
+- **Single source package**: `unraid_mcp/` contains all server code
+- **Domain modules**: Private `_<domain>.py` files in `tools/`, imported by `unraid.py`
+- **Config module**: `config/settings.py` loads all env vars at import time
+- **Symlinks**: `AGENTS.md` and `GEMINI.md` symlink to `CLAUDE.md`
+- **Credentials**: Never stored in repo; live at `~/.unraid-mcp/.env`

--- a/docs/repo/RULES.md
+++ b/docs/repo/RULES.md
@@ -1,0 +1,75 @@
+# Coding Rules -- unraid-mcp
+
+## Python style
+
+- **Version**: Python 3.12+
+- **Type hints**: All function signatures must have type annotations
+- **Docstrings**: Google style convention
+- **Line length**: 100 characters (enforced by Ruff)
+- **Imports**: isort with `unraid_mcp` as known first-party
+- **Async**: All tool handlers and GraphQL calls are `async`
+
+## Ruff rules
+
+Enabled rule sets: F, E, W, I, N, D, UP, YTT, B, Q, C4, SIM, TCH, PTH, ASYNC, RET, PERF, RUF, S (bandit security).
+
+Notable ignores:
+- `E501`: Line length (handled by formatter)
+- `D100-D107`: Missing docstrings (relaxed for modules and methods)
+- `D203/D213`: Docstring spacing conflicts
+
+Per-file relaxations:
+- `__init__.py`: F401 (unused imports), D104 (missing docstring)
+- `tests/`: D (docstrings), S101 (assert), S105-S107 (hardcoded passwords), N815 (camelCase for GraphQL response fields)
+
+## Architecture rules
+
+### Module organization
+
+- Domain tool modules are private: `_docker.py`, `_vm.py`, etc.
+- Only `unraid.py` is the public entry point for tool registration
+- Each domain module exports: queries dict, mutations dict (if any), destructive set (if any), handler function
+
+### Mutation handler ordering
+
+Mutation handlers MUST return before the domain query dict lookup. This is the most critical gotcha -- violating it causes `KeyError` at runtime.
+
+### Import patterns
+
+- `from ..config import settings as _settings` -- never `import settings` directly
+- `from ..core import client as _client` -- aliased to avoid name collisions
+- `from ..core.exceptions import ToolError, tool_error_handler` -- always use these for errors
+
+### Circular import prevention
+
+`middleware_refs.py` breaks the circular dependency between `server.py` (which imports `tools/unraid.py`) and health/diagnose (which needs error middleware stats).
+
+## Test rules
+
+- Patch at the **tool module level**: `unraid_mcp.tools.unraid.make_graphql_request`
+- Never patch at core module level for tool tests
+- Use `conftest.py`'s `make_tool_fn()` helper
+- Mark slow tests with `@pytest.mark.slow`
+- Mark integration tests with `@pytest.mark.integration`
+- camelCase allowed in test files for Pydantic fields mirroring GraphQL keys
+
+## Security rules
+
+- Never commit credentials
+- Never log sensitive values (even at DEBUG)
+- Always use `redact_sensitive()` for debug output
+- Destructive actions MUST use `gate_destructive_action()`
+- Credential files MUST be mode 600, directories mode 700
+- Bearer tokens MUST be removed from `os.environ` after startup
+
+## Version rules
+
+- All four manifest files must have the same version
+- `CHANGELOG.md` must have an entry for every version
+- Use `just publish` to bump all files atomically
+
+## See Also
+
+- [../mcp/PATTERNS.md](../mcp/PATTERNS.md) -- Code patterns
+- [../mcp/PRE-COMMIT.md](../mcp/PRE-COMMIT.md) -- Lint and format enforcement
+- [../GUARDRAILS.md](../GUARDRAILS.md) -- Security rules

--- a/docs/repo/SCRIPTS.md
+++ b/docs/repo/SCRIPTS.md
@@ -1,0 +1,102 @@
+# Scripts Reference -- unraid-mcp
+
+## Quality gate scripts (`scripts/`)
+
+### check-docker-security.sh
+
+Audits the Dockerfile for security best practices:
+- Non-root user verification
+- No hardcoded secrets
+- Proper permissions
+- Minimal base image
+
+```bash
+bash scripts/check-docker-security.sh Dockerfile
+```
+
+### check-no-baked-env.sh
+
+Verifies no environment variables are baked into Docker images or committed to version control:
+- Scans Dockerfile for `ENV` directives with secrets
+- Checks for `.env` files in tracked directories
+
+```bash
+bash scripts/check-no-baked-env.sh .
+```
+
+### check-outdated-deps.sh
+
+Checks for outdated Python dependencies:
+
+```bash
+bash scripts/check-outdated-deps.sh
+```
+
+### ensure-ignore-files.sh
+
+Validates `.gitignore` and `.dockerignore` contain required patterns:
+- Credential files
+- Cache directories
+- Build artifacts
+- Log files
+
+```bash
+# Check mode (CI)
+bash scripts/ensure-ignore-files.sh --check .
+
+# Fix mode (development)
+bash scripts/ensure-ignore-files.sh .
+```
+
+### lint-plugin.sh
+
+Validates plugin manifest files:
+- JSON syntax
+- Required fields
+- Version consistency
+- MCP server configuration
+
+```bash
+bash scripts/lint-plugin.sh
+```
+
+### validate-marketplace.sh
+
+Validates marketplace JSON configuration:
+
+```bash
+bash scripts/validate-marketplace.sh
+```
+
+## Utility scripts
+
+### generate_unraid_api_reference.py
+
+Generates API reference documentation from GraphQL schema introspection:
+
+```bash
+python scripts/generate_unraid_api_reference.py
+```
+
+Produces the docs in `docs/UNRAID_API_COMPLETE_REFERENCE.md`.
+
+## Hook scripts (`hooks/scripts/`)
+
+| Script | Purpose |
+|--------|---------|
+| `fix-env-perms.sh` | Enforce 600 permissions on credential files |
+| `ensure-ignore-files.sh` | Keep ignore files aligned |
+| `ensure-gitignore.sh` | Gitignore-specific checks |
+| `sync-env.sh` | Environment file synchronization |
+
+## CI usage
+
+Scripts are called by CI workflows:
+- `ci.yml` runs `check-docker-security.sh`, `check-no-baked-env.sh`, `ensure-ignore-files.sh --check`
+- `just check-contract` runs all three locally
+
+## See Also
+
+- [RECIPES.md](RECIPES.md) -- Justfile recipes that invoke scripts
+- [../mcp/CICD.md](../mcp/CICD.md) -- CI workflow configuration
+- [../plugin/HOOKS.md](../plugin/HOOKS.md) -- Hook scripts

--- a/docs/stack/ARCH.md
+++ b/docs/stack/ARCH.md
@@ -1,0 +1,140 @@
+# Architecture Overview -- unraid-mcp
+
+## Component diagram
+
+```
+MCP Client (Claude Code / Codex / Gemini / HTTP)
+    |
+    | MCP Protocol (stdio or streamable-http)
+    |
+    v
++----------------------------------------------+
+|  ASGI Middleware Stack                        |
+|  1. HealthMiddleware     (GET /health)        |
+|  2. WellKnownMiddleware  (OAuth discovery)    |
+|  3. BearerAuthMiddleware (RFC 6750)           |
++----------------------------------------------+
+    |
+    v
++----------------------------------------------+
+|  FastMCP Server                               |
+|  MCP Middleware Chain:                         |
+|  1. LoggingMiddleware    (request logging)     |
+|  2. ErrorHandlingMiddleware (exception wrap)   |
+|  3. RateLimitingMiddleware (540 req/min)       |
+|  4. ResponseLimitingMiddleware (512 KB cap)    |
++----------------------------------------------+
+    |
+    +----> Tools (4 registered)
+    |      +-- unraid (action+subaction router)
+    |      |   +-- _system.py    (18 subactions)
+    |      |   +-- _health.py    (4 subactions)
+    |      |   +-- _array.py     (13 subactions)
+    |      |   +-- _disk.py      (6 subactions)
+    |      |   +-- _docker.py    (7 subactions)
+    |      |   +-- _vm.py        (9 subactions)
+    |      |   +-- _notification (12 subactions)
+    |      |   +-- _key.py       (7 subactions)
+    |      |   +-- _plugin.py    (3 subactions)
+    |      |   +-- _rclone.py    (4 subactions)
+    |      |   +-- _setting.py   (2 subactions)
+    |      |   +-- _customization (5 subactions)
+    |      |   +-- _oidc.py      (5 subactions)
+    |      |   +-- _user.py      (1 subaction)
+    |      |   +-- _live.py      (11 subactions)
+    |      +-- unraid_help
+    |      +-- diagnose_subscriptions
+    |      +-- test_subscription_query
+    |
+    +----> Resources (10 registered)
+           +-- unraid://logs/stream
+           +-- unraid://live/{action} (9 subscriptions)
+                |
+                v
+        +---------------------------+
+        |  SubscriptionManager      |
+        |  (WebSocket connections)  |
+        +---------------------------+
+                |
+                | GraphQL-over-WebSocket
+                | (graphql-transport-ws)
+                |
+                v
+        +---------------------------+
+        |  Unraid GraphQL API       |
+        |  (upstream server)        |
+        +---------------------------+
+```
+
+## Data flow
+
+### Tool call (query)
+
+1. Client sends `tools/call` with `action` + `subaction`
+2. ASGI middleware validates bearer token (HTTP) or passes through (stdio)
+3. MCP middleware logs, handles errors, checks rate limit, caps response size
+4. `unraid()` routes to domain handler (e.g., `_handle_docker`)
+5. Handler looks up pre-built GraphQL query from domain `_*_QUERIES` dict
+6. `core/client.py` sends async HTTP request to Unraid API with `x-api-key`
+7. Response parsed, formatted, returned to client
+
+### Tool call (mutation with destructive gate)
+
+1. Client sends `tools/call` with destructive subaction
+2. `gate_destructive_action()` checks if subaction is in `_*_DESTRUCTIVE` set
+3. If `confirm=True`: proceed immediately
+4. If interactive client: send elicitation request with `_ConfirmAction` form
+5. If user confirms: proceed; otherwise raise `ToolError`
+6. Handler sends GraphQL mutation
+7. Response returned to client
+
+### Resource read (live data)
+
+1. Client reads `unraid://live/<action>`
+2. `ensure_subscriptions_started()` initializes WebSocket connections (once)
+3. Resource function checks `SubscriptionManager.resource_data` cache
+4. If data available: return with `_fetched_at` timestamp
+5. If connecting: return "connecting" placeholder
+6. If failed (terminal state): return error message
+7. If auto-start disabled: fall back to `subscribe_once` one-shot query
+
+### Credential setup (elicitation)
+
+1. Client calls `unraid(action="health", subaction="setup")`
+2. If credentials exist: probe connection, ask to reset via elicitation
+3. If resetting or first run: send `_UnraidCredentials` elicitation form
+4. User fills in API URL and key
+5. Write to `~/.unraid-mcp/.env` (atomic: tmp + `os.replace`)
+6. Apply to running process via `apply_runtime_config()`
+7. Return success message
+
+## Key design decisions
+
+### Consolidated tool pattern
+
+One `unraid` tool with 15 action domains instead of 15+ separate tools. This:
+- Reduces MCP context window usage (one tool description covers all operations)
+- Simplifies client tool selection
+- Enables shared parameters across domains
+
+**Tradeoff**: Caching is disabled because the single tool mixes reads and mutations.
+
+### Pre-built query dicts
+
+GraphQL queries are pre-defined in Python dicts, not constructed dynamically. This:
+- Prevents GraphQL injection
+- Makes queries discoverable and testable
+- Enables schema validation tests (119 tests)
+
+### Persistent subscription manager
+
+WebSocket connections are maintained as long-running async tasks. This:
+- Provides instant access to live data via MCP resources
+- Reduces latency compared to on-demand connections
+- Supports automatic reconnection with exponential backoff
+
+## See Also
+
+- [TECH.md](TECH.md) -- Technology choices
+- [../mcp/PATTERNS.md](../mcp/PATTERNS.md) -- Code patterns
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- Tool reference

--- a/docs/stack/CLAUDE.md
+++ b/docs/stack/CLAUDE.md
@@ -1,0 +1,30 @@
+# Technology Stack Documentation -- unraid-mcp
+
+## Files
+
+| File | Description |
+|------|-------------|
+| [TECH.md](TECH.md) | Technology choices and rationale |
+| [ARCH.md](ARCH.md) | Architecture overview and component diagram |
+| [PRE-REQS.md](PRE-REQS.md) | Prerequisites and system requirements |
+
+## Stack summary
+
+- **Language**: Python 3.12+
+- **MCP framework**: FastMCP 3.0+
+- **HTTP client**: httpx (async)
+- **WebSocket**: websockets 15.0+
+- **Web framework**: FastAPI + Uvicorn (via FastMCP)
+- **Validation**: Pydantic (via FastMCP)
+- **Package manager**: uv
+- **Build system**: Hatchling
+- **Linting**: Ruff
+- **Type checking**: ty (Astral)
+- **Testing**: pytest + pytest-asyncio + respx + hypothesis
+- **Container**: Docker (multi-stage, Python 3.12 slim)
+
+## Cross-References
+
+- [mcp/](../mcp/) -- MCP server specifics
+- [repo/](../repo/) -- Repository structure
+- [upstream/](../upstream/) -- Unraid GraphQL API details

--- a/docs/stack/PRE-REQS.md
+++ b/docs/stack/PRE-REQS.md
@@ -1,0 +1,77 @@
+# Prerequisites -- unraid-mcp
+
+## Runtime requirements
+
+### Local development
+
+| Requirement | Version | Purpose |
+|-------------|---------|---------|
+| Python | 3.12+ | Runtime |
+| uv | latest | Package management, virtual environments, script execution |
+| An Unraid server | 6.12+ | GraphQL API endpoint |
+
+### Docker deployment
+
+| Requirement | Version | Purpose |
+|-------------|---------|---------|
+| Docker | 20.10+ | Container runtime |
+| Docker Compose | v2+ | Container orchestration |
+
+### CI
+
+| Requirement | Provided by | Purpose |
+|-------------|------------|---------|
+| Python 3.12 | `uv` setup action | Build and test |
+| uv 0.9.25+ | `astral-sh/setup-uv@v5` | Dependency management |
+| Docker Buildx | `docker/setup-buildx-action` | Multi-arch builds |
+
+## Unraid server requirements
+
+- **API enabled**: Settings > Management Access > Allow API access
+- **API key generated**: Settings > Management Access > API Keys
+- **Network accessible**: The MCP server must be able to reach the Unraid server's GraphQL endpoint
+- **WebSocket support**: For live subscriptions, the endpoint must support WebSocket upgrades
+
+## Python dependencies
+
+### Runtime
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `python-dotenv` | >=1.1.1 | Environment file loading |
+| `fastmcp` | >=3.0.0 | MCP server framework |
+| `httpx` | >=0.28.1 | Async HTTP client for GraphQL |
+| `fastapi` | >=0.115.0 | ASGI web framework (via FastMCP) |
+| `uvicorn[standard]` | >=0.35.0 | ASGI server with HTTP/2 and WebSocket |
+| `websockets` | >=15.0.1 | WebSocket connections for subscriptions |
+| `rich` | >=14.1.0 | Terminal output enhancement |
+
+### Development
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `pytest` | >=8.4.2 | Test runner |
+| `pytest-asyncio` | >=1.2.0 | Async test support |
+| `pytest-cov` | >=7.0.0 | Coverage reporting |
+| `respx` | >=0.22.0 | httpx mock library |
+| `ty` | >=0.0.15 | Type checker |
+| `ruff` | >=0.12.8 | Linter and formatter |
+| `build` | >=1.2.2 | Package builder |
+| `twine` | >=6.0.1 | PyPI upload tool |
+| `graphql-core` | >=3.2.0 | GraphQL schema validation in tests |
+| `hypothesis` | >=6.151.9 | Property-based testing |
+
+## Optional tools
+
+| Tool | Purpose |
+|------|---------|
+| `just` | Task runner (Justfile recipes) |
+| `openssl` | Bearer token generation |
+| `jq` | JSON processing for health checks |
+| `wget` | Docker health check command |
+
+## See Also
+
+- [TECH.md](TECH.md) -- Technology rationale
+- [../mcp/DEPLOY.md](../mcp/DEPLOY.md) -- Deployment methods
+- [../SETUP.md](../SETUP.md) -- Setup guide

--- a/docs/stack/TECH.md
+++ b/docs/stack/TECH.md
@@ -1,0 +1,105 @@
+# Technology Choices -- unraid-mcp
+
+## Language: Python 3.12
+
+- Type hints with `str | None` union syntax
+- `match`/`case` support (not used, but available)
+- `asyncio` for concurrent WebSocket and HTTP operations
+- `importlib.metadata` for version reading
+
+## MCP framework: FastMCP 3.0+
+
+- Unified tool and resource registration via decorators
+- Built-in middleware support (logging, error handling, rate limiting, response limiting)
+- ASGI integration for HTTP transports
+- Elicitation protocol support for interactive flows
+- Context object for tool metadata and client capabilities
+
+## HTTP client: httpx
+
+- Async HTTP/2 support
+- Configurable timeout per request
+- SSL verification control
+- Used for all GraphQL queries and mutations to the Unraid API
+
+## WebSocket: websockets 15.0+
+
+- GraphQL-over-WebSocket protocol (`graphql-transport-ws`)
+- `connection_init` with API key authentication
+- Subprotocol negotiation
+- Used for persistent live subscriptions
+
+## Web framework: FastAPI + Uvicorn
+
+- Provided through FastMCP's HTTP transport
+- ASGI middleware stack for auth and health endpoints
+- Uvicorn with `standard` extras for HTTP/2 and WebSocket support
+
+## Validation: Pydantic
+
+- Used for elicitation response types (`_ConfirmAction` model)
+- FastMCP uses Pydantic for tool parameter validation
+- `BaseModel` with `Field` for schema generation
+
+## Package manager: uv
+
+- Fast dependency resolution and installation
+- Lock file (`uv.lock`) for reproducible builds
+- Dependency groups (`[dependency-groups]` in pyproject.toml)
+- Build integration (`uv build` for sdist and wheel)
+- Script execution (`uv run`)
+
+## Build system: Hatchling
+
+- `pyproject.toml`-native build backend
+- Wheel-only includes `unraid_mcp/` package
+- sdist includes tests, skills, commands, docs
+
+## Linting: Ruff
+
+- Replaces flake8, isort, pycodestyle, pydocstyle, bandit
+- 100-character line length
+- Google-style docstrings
+- Security rules (bandit) enabled
+- Cache in `.cache/.ruff_cache`
+
+## Type checking: ty
+
+- Astral's fast type checker (alternative to mypy/pyright)
+- Python 3.12 target
+- Respects `type: ignore` comments
+
+## Testing
+
+| Tool | Purpose |
+|------|---------|
+| pytest | Test runner with markers and strict config |
+| pytest-asyncio | Async test support (auto mode) |
+| pytest-cov | Coverage reporting (80% minimum) |
+| respx | httpx request mocking |
+| hypothesis | Property-based testing |
+| graphql-core | GraphQL query validation |
+
+## Container: Docker
+
+- Multi-stage build: `uv:python3.12-bookworm-slim` (builder) + `python:3.12-slim-bookworm` (runtime)
+- Non-root user (`mcp:1000`)
+- uv cache mount for fast builds
+- Health check via wget
+- Multi-arch: amd64, arm64
+
+## Environment management: python-dotenv
+
+- `.env` file loading with priority chain
+- In-place key updates via `set_key` (preserves comments)
+- Used for both initial loading and runtime credential writes
+
+## Rich terminal output
+
+- `rich` library for enhanced logging and debug output
+- Not used in MCP responses (plain text/JSON only)
+
+## See Also
+
+- [ARCH.md](ARCH.md) -- How these technologies fit together
+- [PRE-REQS.md](PRE-REQS.md) -- Installation requirements

--- a/docs/upstream/CLAUDE.md
+++ b/docs/upstream/CLAUDE.md
@@ -1,0 +1,132 @@
+# Upstream Service Integration -- unraid-mcp
+
+## Unraid GraphQL API
+
+unraid-mcp communicates with the Unraid server via its GraphQL API over HTTP and WebSocket.
+
+### Endpoint
+
+The Unraid GraphQL endpoint is typically:
+```
+https://<unraid-ip-or-hostname>/graphql
+```
+
+For MyUnraid.net remote access:
+```
+https://10-1-0-2.xxx.myunraid.net:31337
+```
+
+### Authentication
+
+All requests include the `x-api-key` header:
+```
+x-api-key: <UNRAID_API_KEY>
+```
+
+API keys are generated in: Unraid > Settings > Management Access > API Keys.
+
+### HTTP queries and mutations
+
+The `core/client.py` module sends async HTTP POST requests via httpx:
+
+```python
+async with httpx.AsyncClient(verify=UNRAID_VERIFY_SSL) as client:
+    response = await client.post(
+        UNRAID_API_URL,
+        json={"query": query_string, "variables": variables},
+        headers={"x-api-key": UNRAID_API_KEY, "User-Agent": f"unraid-mcp/{VERSION}"},
+        timeout=timeout,
+    )
+```
+
+### WebSocket subscriptions
+
+Live data uses the `graphql-transport-ws` WebSocket protocol:
+
+1. Connect to `wss://<unraid-host>/graphql` (or `ws://` for non-SSL)
+2. Send `connection_init` with `{"x-api-key": "<key>"}` payload
+3. Receive `connection_ack`
+4. Send `subscribe` with query and variables
+5. Receive `next` messages with subscription data
+6. Handle `complete` and `error` messages
+
+The `subscriptions/utils.py` module handles:
+- URL scheme conversion (http/https to ws/wss)
+- SSL context building for self-signed certificates
+- `connection_init` message construction with API key
+
+### Rate limits
+
+The Unraid API enforces approximately 100 requests per 10 seconds. The MCP server's rate limiter is set to 540 requests per 60-second sliding window to stay under this ceiling.
+
+### Known API issues
+
+- **arraySubscription**: May not emit data reliably. The `live/array_state` subaction may show "connecting" indefinitely.
+- **Event-driven subscriptions**: `notifications_overview`, `owner`, `server_status`, `ups_status`, and `parity_progress` only emit when state changes. A timeout is normal and does not indicate an error.
+- **Type overflow**: Some complex queries can trigger GraphQL type resolution issues. The server uses selective field queries to avoid this.
+
+## GraphQL schema reference
+
+The full Unraid GraphQL schema is available in:
+- `docs/unraid-schema.graphql` -- Complete schema definition (74 KB)
+- `docs/unraid-api-introspection.json` -- Introspection result (236 KB)
+- `docs/UNRAID_API_COMPLETE_REFERENCE.md` -- Human-readable reference (73 KB)
+- `docs/UNRAID_API_OPERATIONS.md` -- All supported operations with examples
+- `docs/UNRAID_API_REFERENCE.md` -- Condensed reference
+
+### Query organization
+
+Queries are organized into domain dicts in each `tools/_<domain>.py` module:
+
+| Domain | Queries dict | Mutations dict |
+|--------|-------------|----------------|
+| system | `_SYSTEM_QUERIES` (18 entries) | -- |
+| array | `_ARRAY_QUERIES` | `_ARRAY_MUTATIONS` |
+| disk | `_DISK_QUERIES` | `_DISK_MUTATIONS` |
+| docker | `_DOCKER_QUERIES` | `_DOCKER_MUTATIONS` |
+| vm | `_VM_QUERIES` | `_VM_MUTATIONS` |
+| notification | `_NOTIFICATION_QUERIES` | `_NOTIFICATION_MUTATIONS` |
+| key | `_KEY_QUERIES` | `_KEY_MUTATIONS` |
+| plugin | `_PLUGIN_QUERIES` | `_PLUGIN_MUTATIONS` |
+| rclone | `_RCLONE_QUERIES` | `_RCLONE_MUTATIONS` |
+| setting | -- | `_SETTING_MUTATIONS` |
+| customization | `_CUSTOMIZATION_QUERIES` | `_CUSTOMIZATION_MUTATIONS` |
+| oidc | `_OIDC_QUERIES` | -- |
+| user | `_USER_QUERIES` | -- |
+
+### Subscription queries
+
+Defined in `subscriptions/queries.py`:
+
+**Snapshot subscriptions** (continuous data):
+- `systemMetricsCpu` -- CPU utilization per core
+- `systemMetricsMemory` -- Memory, swap, buffer/cache
+- `systemMetricsCpuTelemetry` -- CPU power and temperature
+- `arraySubscription` -- Array state, capacity, parity status
+
+**Event-driven subscriptions** (state changes only):
+- `parityHistorySubscription` -- Parity check events
+- `upsUpdates` -- UPS status changes
+- `notificationsOverview` -- Notification count changes
+- `ownerSubscription` -- Owner info changes
+- `serversSubscription` -- Server status changes
+
+**Collect subscriptions** (accumulate over time):
+- `notificationAdded` -- New notification events
+- `logFile` -- Log file tail (requires `path` variable)
+
+## Generating API docs
+
+The `scripts/generate_unraid_api_reference.py` script generates documentation from GraphQL introspection:
+
+```bash
+python scripts/generate_unraid_api_reference.py
+```
+
+This queries the Unraid API's introspection endpoint and produces structured documentation of all types, queries, mutations, and subscriptions.
+
+## See Also
+
+- [../mcp/TOOLS.md](../mcp/TOOLS.md) -- How queries map to tool actions
+- [../mcp/RESOURCES.md](../mcp/RESOURCES.md) -- How subscriptions map to resources
+- [../mcp/SCHEMA.md](../mcp/SCHEMA.md) -- Query dict organization

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "unraid-mcp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools. Supports system info, Docker, VMs, array/parity, notifications, plugins, and live telemetry.",
   "mcpServers": {
     "unraid-mcp": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # ============================================================================
 [project]
 name = "unraid-mcp"
-version = "1.2.2"
+version = "1.2.4"
 description = "MCP Server for Unraid API - provides tools to interact with an Unraid server's GraphQL API"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/TEST_COVERAGE.md
+++ b/tests/TEST_COVERAGE.md
@@ -1,0 +1,932 @@
+# TEST_COVERAGE.md — `tests/test_live.sh`
+
+Canonical live integration test for the `unraid-mcp` server. This document is the authoritative
+reference for what the script tests, how every assertion is structured, and how to run each mode.
+A QA engineer should be able to verify correctness of the script without executing it.
+
+---
+
+## 1. Overview
+
+| Field | Value |
+|---|---|
+| Script | `tests/test_live.sh` |
+| Service under test | Unraid home-server OS (NAS / hypervisor) |
+| MCP server exercised | `unraid-mcp` — Python MCP server that proxies Unraid's GraphQL API |
+| Transport protocols covered | Streamable-HTTP (primary), Docker container (build + run), stdio (subprocess) |
+| Test approach | Direct JSON-RPC 2.0 over HTTP — no mcporter or secondary proxy dependency |
+| Total tool subactions exercised | 47 (45 read-only + 2 destructive-guard bypass) |
+| Destructive operations | None — all state-changing tools are invoked only with `confirm=true` to verify the guard bypasses correctly, not to execute the operation |
+
+### What the script is not
+
+- It is not a unit test. It requires (or optionally skips) a live Unraid API.
+- It does not verify response _values_ beyond structural presence — it checks that the tool
+  returned HTTP 200 with `isError != true`, not that specific field values match expected
+  business data.
+- It does not test write operations (container start/stop, VM actions beyond force_stop guard
+  check, array operations, etc.) to avoid causing data loss or service disruption.
+
+---
+
+## 2. Prerequisites
+
+The script checks for these binaries at startup and exits with code `2` if either is absent:
+
+- `curl` — HTTP client for all network requests
+- `jq` — JSON parsing for all assertions
+
+For Docker mode: `docker` must be in `PATH` (soft requirement — skipped with `SKIP` if absent).
+
+For stdio mode: `uv` must be in `PATH` (soft requirement — skipped with `SKIP` if absent).
+
+---
+
+## 3. How to Run
+
+### 3.1 Modes and flags
+
+```bash
+# Default: runs all three modes sequentially (http → docker → stdio)
+./tests/test_live.sh
+
+# HTTP only — fastest, requires a running server
+./tests/test_live.sh --mode http
+
+# Docker only — builds image, starts container, tests, tears down
+./tests/test_live.sh --mode docker
+
+# Stdio only — spawns server subprocess via uvx
+./tests/test_live.sh --mode stdio
+
+# All three modes explicitly
+./tests/test_live.sh --mode all
+
+# Override endpoint and token
+./tests/test_live.sh --url http://myhost:6970/mcp --token mytoken
+
+# Skip auth tests (use when behind an OAuth gateway that handles auth)
+./tests/test_live.sh --skip-auth
+
+# Skip tool smoke tests (no live Unraid API available — tests MCP protocol only)
+./tests/test_live.sh --skip-tools
+
+# Show raw HTTP response bodies alongside test output
+./tests/test_live.sh --verbose
+```
+
+### 3.2 Environment variables
+
+| Variable | Required for | Default | Description |
+|---|---|---|---|
+| `UNRAID_API_URL` | docker, stdio | `http://127.0.0.1:1` (dummy) | Unraid GraphQL API base URL |
+| `UNRAID_API_KEY` | docker, stdio | `ci-fake-key` (dummy) | Unraid API key |
+| `UNRAID_MCP_BEARER_TOKEN` | http, docker | auto-read from `~/.unraid-mcp/.env` | MCP bearer token for authenticated requests |
+| `TOKEN` | http, docker | alias for above | Alternate env var for the bearer token |
+| `PORT` | all | `6970` | Override the server port |
+
+### 3.3 Token auto-detection
+
+If `TOKEN` / `UNRAID_MCP_BEARER_TOKEN` is not set on the command line or in the environment,
+the script reads `~/.unraid-mcp/.env` and extracts `UNRAID_MCP_BEARER_TOKEN=...` from it.
+If the file does not exist or the variable is absent, `TOKEN` remains empty and auth tests
+are silently skipped.
+
+### 3.4 Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All tests passed (or intentionally skipped) |
+| `1` | One or more tests failed |
+| `2` | Prerequisite check failed (`curl` or `jq` missing, or invalid `--mode`) |
+
+---
+
+## 4. Test Phases
+
+The script is structured into four numbered phases, run in order within each mode. Phases 1–4
+share common implementation functions; each mode (http, docker, stdio) calls them after
+establishing its own transport.
+
+### Phase 1 — Middleware (no auth)
+
+**Purpose:** Verify that unauthenticated HTTP endpoints respond correctly. These endpoints must
+be publicly accessible without a bearer token (RFC 8414 / OAuth protected resource metadata).
+
+**Runs in:** HTTP mode and Docker mode. Not run in stdio mode.
+
+### Phase 2 — Auth enforcement
+
+**Purpose:** Verify that the MCP endpoint enforces bearer token authentication — rejecting
+requests with no token (401), rejecting requests with a wrong token (401), and accepting
+requests with the correct token.
+
+**Runs in:** HTTP mode and Docker mode. Not run in stdio mode.
+
+### Phase 3 — MCP Protocol
+
+**Purpose:** Verify the MCP JSON-RPC handshake (`initialize`, `tools/list`, `ping`) works
+correctly and returns well-formed responses with the expected structure.
+
+**Runs in:** HTTP mode, Docker mode, and stdio mode (stdio has its own Phase 3 implementation).
+
+### Phase 4 — Tool smoke-tests (non-destructive)
+
+**Purpose:** Call every read-only `unraid` tool subaction and verify it returns HTTP 200 with
+`isError != true`. No assertions are made on response field values — this phase proves
+connectivity and basic API reachability.
+
+**Runs in:** HTTP mode and Docker mode only. Skipped with `--skip-tools`.
+
+### Phase 4b — Destructive action guards
+
+**Purpose:** Verify that destructive operations do NOT require the user to re-confirm when
+`confirm=true` is passed — i.e., `confirm=true` correctly bypasses the guard prompt.
+
+---
+
+## 5. Phase 1 — Middleware (no auth)
+
+### 5.1 `/health` endpoint
+
+| Field | Value |
+|---|---|
+| URL | `GET {base_url}/health` |
+| Auth | None (unauthenticated) |
+| Expected HTTP status | `200` |
+| jq assertion | `.status == "ok"` |
+| PASS | HTTP 200 AND body contains `{"status":"ok"}` |
+| FAIL | Any other status code, or status field is not `"ok"` |
+
+The base URL is derived from `MCP_URL` by stripping the trailing `/mcp` path segment
+(e.g., `http://localhost:6970/mcp` → `http://localhost:6970`).
+
+### 5.2 `/.well-known/oauth-protected-resource`
+
+| Field | Value |
+|---|---|
+| URL | `GET {base_url}/.well-known/oauth-protected-resource` |
+| Auth | None |
+| Expected HTTP status | `200` |
+| PASS | HTTP 200 |
+| FAIL | Any other status |
+
+On HTTP 200, two sub-assertions are evaluated:
+
+**Sub-assertion A — `bearer_methods_supported` present:**
+
+| Field | Value |
+|---|---|
+| jq filter | `.bearer_methods_supported \| length > 0` |
+| PASS | Array is non-empty |
+| FAIL | Array is absent, null, or empty |
+| SKIP | Parent assertion (HTTP 200) failed |
+
+**Sub-assertion B — `resource` field present:**
+
+| Field | Value |
+|---|---|
+| jq filter | `.resource \| length > 0` |
+| PASS | String is non-empty |
+| FAIL | Field is absent, null, or empty |
+| SKIP | Parent assertion (HTTP 200) failed |
+
+### 5.3 `/.well-known/oauth-protected-resource/mcp`
+
+| Field | Value |
+|---|---|
+| URL | `GET {base_url}/.well-known/oauth-protected-resource/mcp` |
+| Auth | None |
+| Expected HTTP status | `200` |
+| PASS | HTTP 200 |
+| FAIL | Any other status |
+
+No sub-assertions — presence of the endpoint is sufficient.
+
+---
+
+## 6. Phase 2 — Auth enforcement
+
+Phase 2 is skipped entirely if `--skip-auth` is passed, or if no token is configured (in which
+case auth is assumed to be disabled). All three tests are marked `SKIP` with a reason string.
+
+### 6.1 No-token request
+
+**What it does:** Sends a `POST` to `MCP_URL` with a valid JSON-RPC `ping` payload but with
+no `Authorization` header.
+
+```
+POST /mcp HTTP/1.1
+Content-Type: application/json
+Accept: application/json, text/event-stream
+
+{"jsonrpc":"2.0","id":99,"method":"ping","params":null}
+```
+
+| Field | Value |
+|---|---|
+| Expected HTTP status | `401` |
+| PASS | HTTP status is exactly `"401"` |
+| FAIL | Any other status (e.g., `200` would indicate auth is disabled) |
+
+### 6.2 Wrong-token request
+
+**What it does:** Sends the same `ping` payload with a deliberately incorrect bearer token:
+`Bearer this-is-the-wrong-token-intentionally`.
+
+| Field | Value |
+|---|---|
+| Expected HTTP status | `401` |
+| PASS (preferred) | HTTP 401 AND `.error == "invalid_token"` in response body |
+| PASS (fallback) | HTTP 401 with any error field value (or absent) |
+| FAIL | Any non-401 status |
+
+The test inspects the response body's `.error` field. If it equals `"invalid_token"` the label
+reads `"bad-token → 401 invalid_token"`; otherwise it reads `"bad-token → 401 (error field: …)"`.
+Both are recorded as PASS — the sub-check on the error field value is informational.
+
+### 6.3 Good-token request
+
+**What it does:** Sends a full MCP `initialize` request with the configured valid bearer token.
+
+```
+POST /mcp HTTP/1.1
+Content-Type: application/json
+Accept: application/json, text/event-stream
+Authorization: Bearer <TOKEN>
+
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+  "protocolVersion":"2024-11-05",
+  "capabilities":{},
+  "clientInfo":{"name":"test_live","version":"0"}
+}}
+```
+
+| Field | Value |
+|---|---|
+| Condition for PASS | HTTP status is NOT `401` AND NOT `403` |
+| PASS | Any status other than 401 or 403 (typically 200) |
+| FAIL | HTTP 401 or 403 |
+
+This test does not assert a specific status — it only proves the server does not reject a
+valid token.
+
+---
+
+## 7. Phase 3 — MCP Protocol
+
+### 7.1 `initialize`
+
+**What it does:** Posts MCP protocol initialization request.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {"name": "test_live", "version": "0"}
+  }
+}
+```
+
+| Field | Value |
+|---|---|
+| Expected HTTP status | `200` |
+| PASS | HTTP 200 |
+| FAIL | Any other status (with body excerpt in label) |
+
+On HTTP 200, two sub-assertions:
+
+**`serverInfo.name` present:**
+
+| jq filter | `.result.serverInfo.name \| length > 0` |
+|---|---|
+| PASS | Name string is non-empty |
+| FAIL | Field absent, null, or empty |
+| SKIP | `initialize` returned non-200 |
+
+**`protocolVersion` present:**
+
+| jq filter | `.result.protocolVersion \| length > 0` |
+|---|---|
+| PASS | Version string is non-empty |
+| FAIL | Field absent, null, or empty |
+| SKIP | `initialize` returned non-200 |
+
+The `mcp_post` helper extracts the `Mcp-Session-Id` response header and stores it in
+`MCP_SESSION_ID`. Subsequent requests in the same mode run include this header automatically.
+
+SSE response handling: if the response body contains lines starting with `data:`, the helper
+extracts the first `data:` line and strips the prefix before parsing JSON.
+
+### 7.2 `tools/list`
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"tools/list","params":null}
+```
+
+| Field | Value |
+|---|---|
+| Expected HTTP status | `200` |
+| PASS | HTTP 200 |
+| FAIL | Any other status |
+
+The tool count (`jq '.result.tools \| length'`) is printed in the PASS label for informational
+purposes but not asserted against a minimum.
+
+On HTTP 200, two sub-assertions:
+
+**`unraid` tool present:**
+
+| jq filter | `.result.tools[] \| select(.name == "unraid") \| .name` |
+|---|---|
+| PASS | Filter returns non-empty, non-null string |
+| FAIL | No tool named `"unraid"` found |
+| SKIP | `tools/list` returned non-200 |
+
+**`diagnose_subscriptions` tool present:**
+
+| jq filter | `.result.tools[] \| select(.name == "diagnose_subscriptions") \| .name` |
+|---|---|
+| PASS | Filter returns non-empty, non-null string |
+| FAIL | No tool named `"diagnose_subscriptions"` found |
+| SKIP | `tools/list` returned non-200 |
+
+These two assertions confirm the server exposes exactly the two expected top-level tools.
+
+### 7.3 `ping`
+
+```json
+{"jsonrpc":"2.0","id":3,"method":"ping","params":null}
+```
+
+| Field | Value |
+|---|---|
+| Expected HTTP status | `200` |
+| PASS | HTTP 200 |
+| SKIP (not FAIL) | Any non-200 status — `ping` is treated as optional |
+
+Ping is not a required MCP method; the test tolerates absence.
+
+---
+
+## 8. Phase 4 — Tool Smoke Tests
+
+All smoke tests use the `call_unraid` helper, which:
+
+1. Builds a `tools/call` JSON-RPC request targeting the `unraid` tool with the given
+   `action` and `subaction` arguments.
+2. Sends it via `mcp_post`.
+3. PASS condition: HTTP 200 AND `.result.isError != true`.
+4. FAIL condition: HTTP status other than 200, OR `.result.isError == true`.
+   When `isError` is true, the first 100 characters of `.result.content[0].text` are appended
+   to the FAIL label.
+
+The JSON-RPC payload structure for each call:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <N>,
+  "method": "tools/call",
+  "params": {
+    "name": "unraid",
+    "arguments": {
+      "action": "<action>",
+      "subaction": "<subaction>"
+    }
+  }
+}
+```
+
+Extra arguments (e.g., `provider_type`) are merged into the `arguments` object via jq.
+
+### 8.1 Complete list of smoke-tested subactions
+
+#### `health` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid health/check` | `health` | `check` | — | Basic connectivity check to Unraid API |
+| `unraid health/test_connection` | `health` | `test_connection` | — | Tests GraphQL API reachability |
+| `unraid health/diagnose` | `health` | `diagnose` | — | Detailed health diagnostic |
+
+#### `system` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid system/overview` | `system` | `overview` | — | Full system overview |
+| `unraid system/network` | `system` | `network` | — | Network interfaces and configuration |
+| `unraid system/array` | `system` | `array` | — | Disk array state |
+| `unraid system/registration` | `system` | `registration` | — | License/registration info |
+| `unraid system/variables` | `system` | `variables` | — | Unraid system variables |
+| `unraid system/metrics` | `system` | `metrics` | — | Performance metrics |
+| `unraid system/services` | `system` | `services` | — | Running services |
+| `unraid system/display` | `system` | `display` | — | Display/UI settings |
+| `unraid system/config` | `system` | `config` | — | System configuration |
+| `unraid system/online` | `system` | `online` | — | Online/connectivity status |
+| `unraid system/owner` | `system` | `owner` | — | Server owner information |
+| `unraid system/settings` | `system` | `settings` | — | System settings |
+| `unraid system/server` | `system` | `server` | — | Single server info |
+| `unraid system/servers` | `system` | `servers` | — | All known servers |
+| `unraid system/flash` | `system` | `flash` | — | USB flash device info |
+| `unraid system/ups_devices` | `system` | `ups_devices` | — | UPS device list |
+
+#### `array` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid array/parity_status` | `array` | `parity_status` | — | Current parity check status |
+| `unraid array/parity_history` | `array` | `parity_history` | — | Historical parity check records |
+
+#### `disk` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid disk/shares` | `disk` | `shares` | — | User shares list |
+| `unraid disk/disks` | `disk` | `disks` | — | All disk devices |
+| `unraid disk/log_files` | `disk` | `log_files` | — | Available log files |
+
+#### `docker` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid docker/list` | `docker` | `list` | — | All Docker containers |
+| `unraid docker/networks` | `docker` | `networks` | — | Docker networks |
+
+#### `vm` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid vm/list` | `vm` | `list` | — | All virtual machines |
+
+#### `notification` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid notification/overview` | `notification` | `overview` | — | Notification summary counts |
+| `unraid notification/list` | `notification` | `list` | — | Full notification list |
+| `unraid notification/recalculate` | `notification` | `recalculate` | — | Trigger notification recalculation |
+
+#### `user` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid user/me` | `user` | `me` | — | Current authenticated user info |
+
+#### `key` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid key/list` | `key` | `list` | — | API keys list |
+
+#### `rclone` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid rclone/list_remotes` | `rclone` | `list_remotes` | — | Configured rclone remotes |
+| `unraid rclone/config_form` | `rclone` | `config_form` | `{"provider_type":"s3"}` | Config form for S3 provider |
+
+`rclone/config_form` is the only smoke test that passes extra arguments — `provider_type` is
+set to `"s3"` to exercise argument merging.
+
+#### `plugin` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid plugin/list` | `plugin` | `list` | — | Installed Unraid plugins |
+
+#### `customization` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid customization/theme` | `customization` | `theme` | — | Active UI theme |
+| `unraid customization/public_theme` | `customization` | `public_theme` | — | Public-facing theme settings |
+| `unraid customization/sso_enabled` | `customization` | `sso_enabled` | — | SSO enabled flag |
+| `unraid customization/is_initial_setup` | `customization` | `is_initial_setup` | — | Whether initial setup is complete |
+
+#### `oidc` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid oidc/providers` | `oidc` | `providers` | — | Configured OIDC providers |
+| `unraid oidc/public_providers` | `oidc` | `public_providers` | — | Public OIDC provider list |
+| `unraid oidc/configuration` | `oidc` | `configuration` | — | OIDC server configuration |
+
+#### `live` action
+
+| Test label | action | subaction | Extra args | Notes |
+|---|---|---|---|---|
+| `unraid live/cpu` | `live` | `cpu` | — | Real-time CPU usage |
+| `unraid live/memory` | `live` | `memory` | — | Real-time memory usage |
+| `unraid live/cpu_telemetry` | `live` | `cpu_telemetry` | — | Detailed CPU telemetry |
+| `unraid live/notifications_overview` | `live` | `notifications_overview` | — | Live notification overview |
+
+### 8.2 What "PASS" means for each smoke test
+
+For all 45 subactions listed above, PASS means:
+
+1. The MCP server returned HTTP `200`.
+2. The response body does NOT have `.result.isError == true`.
+
+PASS does NOT mean:
+- The Unraid API returned useful data.
+- Any specific field is present in the response.
+- The response matches a schema.
+
+These tests are "did it blow up" smoke tests, not field-level validation tests.
+
+---
+
+## 9. Phase 4b — Destructive Action Guards
+
+This sub-phase tests that the `confirm=true` flag correctly bypasses the safety guard that
+would otherwise tell the user to re-run the command with `confirm=true`.
+
+The guard check logic: if the tool response body (`.result.content[0].text`) contains the
+string `"re-run with confirm"` (case-insensitive), the guard did NOT accept `confirm=true`
+and the test fails.
+
+### 9.1 `notification/delete` guard bypass
+
+```json
+{
+  "name": "unraid",
+  "arguments": {
+    "action": "notification",
+    "subaction": "delete",
+    "confirm": true,
+    "notification_id": "test-guard-check-nonexistent"
+  }
+}
+```
+
+| Field | Value |
+|---|---|
+| Test label | `notification/delete guard bypass` |
+| `notification_id` | `"test-guard-check-nonexistent"` — deliberately nonexistent ID |
+| FAIL (guard rejected) | Response text matches `/re-run with confirm/i` |
+| PASS | HTTP 200 AND guard text not present (even if deletion fails due to nonexistent ID) |
+| FAIL (other) | HTTP status other than 200 |
+
+The nonexistent ID ensures no actual notification is deleted. The test only verifies that
+`confirm=true` was accepted by the guard layer.
+
+### 9.2 `vm/force_stop` guard bypass
+
+```json
+{
+  "name": "unraid",
+  "arguments": {
+    "action": "vm",
+    "subaction": "force_stop",
+    "confirm": true
+  }
+}
+```
+
+| Field | Value |
+|---|---|
+| Test label | `vm/force_stop guard bypass` |
+| Extra args | None beyond `confirm=true` |
+| FAIL (guard rejected) | Response text matches `/re-run with confirm/i` |
+| PASS | HTTP 200 AND guard text not present |
+| FAIL (other) | HTTP status other than 200 |
+
+No VM ID is supplied, so the actual force-stop operation is expected to fail at the API level
+(no target) rather than succeed. The guard bypass test passes regardless of whether the
+underlying operation succeeds.
+
+---
+
+## 10. Skipped Tests and Why
+
+| Test / Section | Skip condition | Reason |
+|---|---|---|
+| Phase 2 (all three auth tests) | `--skip-auth` flag | OAuth gateway handles auth externally; MCP server may not enforce tokens |
+| Phase 2 (all three auth tests) | No token configured | Auth appears disabled; can't meaningfully test 401 behavior |
+| Phase 4 and 4b (all tool tests) | `--skip-tools` flag | No live Unraid API available; Phase 3 protocol tests remain active |
+| Docker mode (all) | `docker` not in `PATH` | Docker unavailable in this environment |
+| Stdio mode (all) | `uv` not in `PATH` | `uv` Python runner unavailable |
+| `ping → 200` | Server returns non-200 | `ping` is optional in MCP; treated as non-fatal |
+| `serverInfo.name` / `protocolVersion` | `initialize` returned non-200 | Parent test failed; child tests skipped with `"initialize failed"` |
+| `unraid tool present` / `diagnose_subscriptions present` | `tools/list` returned non-200 | Parent test failed; child tests skipped with `"tools/list failed"` |
+| `bearer_methods_supported` / `resource` | `/.well-known/…` returned non-200 | Parent test failed; child tests skipped with `"parent failed"` |
+| Container teardown | Container already removed | Marked SKIP (not FAIL) — idempotent teardown |
+
+**Why write operations are excluded from Phase 4:**
+
+The script's design philosophy is "non-destructive" smoke testing. Operations that create,
+modify, or delete state on the Unraid server (array operations, container start/stop, VM
+create/delete, user management writes, plugin install/uninstall, etc.) are not called in
+Phase 4 to avoid data loss, service disruption, or hard-to-reverse side effects in a CI or
+production environment.
+
+The only partial exception is Phase 4b, which calls two destructive subactions
+(`notification/delete`, `vm/force_stop`) but does so with a nonexistent ID / no ID, ensuring
+the underlying API operation cannot succeed even if the guard is bypassed.
+
+---
+
+## 11. Docker Mode — Full Lifecycle
+
+Docker mode does a complete lifecycle: build image → start container → health poll →
+run all four phases → tear down.
+
+### 11.1 Prerequisites
+
+- `docker` in `PATH` (otherwise entire docker mode is `SKIP`).
+- `UNRAID_API_URL` and `UNRAID_API_KEY` env vars (defaults to dummy values if unset).
+
+### 11.2 Build
+
+```bash
+docker build -t unraid-mcp-test <REPO_DIR>
+```
+
+| Field | Value |
+|---|---|
+| Image name | `unraid-mcp-test` |
+| Build context | Repository root (`$REPO_DIR`) — uses `Dockerfile` at repo root |
+| stdout/stderr | Suppressed (`>/dev/null 2>&1`) |
+| PASS | Build exits 0 |
+| FAIL | Build exits non-zero — all subsequent docker tests are skipped (early return) |
+
+### 11.3 Container start
+
+```bash
+docker run -d \
+  --name unraid-mcp-test-<PID> \
+  -p <PORT>:6970 \
+  -e UNRAID_MCP_TRANSPORT=streamable-http \
+  -e UNRAID_MCP_BEARER_TOKEN=ci-integration-token \
+  -e UNRAID_MCP_DISABLE_HTTP_AUTH=false \
+  -e UNRAID_API_URL=<UNRAID_API_URL or http://127.0.0.1:1> \
+  -e UNRAID_API_KEY=<UNRAID_API_KEY or ci-fake-key> \
+  unraid-mcp-test
+```
+
+Key environment variables injected into the container:
+
+| Variable | Value |
+|---|---|
+| `UNRAID_MCP_TRANSPORT` | `streamable-http` |
+| `UNRAID_MCP_BEARER_TOKEN` | `ci-integration-token` (hardcoded test token) |
+| `UNRAID_MCP_DISABLE_HTTP_AUTH` | `false` (auth is enabled) |
+| `UNRAID_API_URL` | From env or dummy `http://127.0.0.1:1` |
+| `UNRAID_API_KEY` | From env or dummy `ci-fake-key` |
+
+After `docker run`, `TOKEN` is set to `"ci-integration-token"` so Phase 2 auth tests use
+the correct token. `MCP_URL` is updated to `http://localhost:<PORT>/mcp`.
+
+Container name includes the shell PID (`$$`) to avoid name collisions in parallel CI runs.
+
+### 11.4 Health poll
+
+```bash
+# Polls up to 30 times, 1 second apart
+curl -sf -H "Accept: application/json, text/event-stream" \
+  http://localhost:<PORT>/health
+```
+
+| Field | Value |
+|---|---|
+| Poll interval | 1 second |
+| Max attempts | 30 (30 second timeout) |
+| PASS | Server responds to `/health` within 30 seconds |
+| FAIL | No healthy response after 30 seconds — last 20 lines of container logs printed |
+
+On FAIL, the container is removed and the function returns 1 (aborting docker mode).
+
+### 11.5 Test phases
+
+Runs `run_phase1`, `run_phase2`, `run_phase3`, `run_phase4` against the container's endpoint.
+`MCP_SESSION_ID` is reset to empty before Phase 1.
+
+### 11.6 Teardown
+
+```bash
+docker rm -f unraid-mcp-test-<PID>
+```
+
+| Field | Value |
+|---|---|
+| PASS | Container removed successfully |
+| SKIP | `docker rm -f` fails (container already gone — treated as idempotent) |
+
+Teardown runs regardless of test phase outcomes (no `trap` but the teardown call is
+unconditional in the function body).
+
+---
+
+## 12. Stdio Mode — Subprocess Protocol Handshake
+
+Stdio mode bypasses HTTP entirely. It spawns the MCP server as a subprocess, writes JSON-RPC
+requests to stdin, and reads responses from stdout.
+
+### 12.1 Prerequisites
+
+- `uv` in `PATH` (otherwise entire stdio mode is `SKIP`).
+- `UNRAID_API_URL` and `UNRAID_API_KEY` env vars (defaults to dummy values if unset).
+
+### 12.2 Server invocation
+
+```bash
+printf '%s\n%s\n' "$init_req" "$list_req" \
+  | UNRAID_MCP_TRANSPORT=stdio \
+    UNRAID_API_URL=<...> \
+    UNRAID_API_KEY=<...> \
+    uv run --directory <REPO_DIR> --from . unraid-mcp-server \
+    2>/dev/null \
+  | head -c 16384
+```
+
+Key details:
+- Transport is set to `stdio` via `UNRAID_MCP_TRANSPORT=stdio`.
+- `uv run` is used to launch the server from the repository root without a separate install step.
+- The entry point is the `unraid-mcp-server` console script defined in `pyproject.toml`.
+- stderr is discarded (`2>/dev/null`) — only stdout (JSON-RPC responses) is captured.
+- Output is capped at 16 KiB (`head -c 16384`) to prevent runaway output.
+- The subprocess exits naturally when stdin is closed (end of `printf` pipe).
+
+### 12.3 Two requests sent
+
+**Request 1 — `initialize`:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {"name": "test_live_stdio", "version": "0"}
+  }
+}
+```
+
+**Request 2 — `tools/list`:**
+```json
+{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": null}
+```
+
+### 12.4 Response parsing
+
+The server is expected to write one JSON object per line (newline-delimited JSON). The script
+parses:
+- Line 1 = `initialize` response
+- Line 2 = `tools/list` response
+
+**Initialize response assertions:**
+
+| Assertion | jq filter | PASS | FAIL |
+|---|---|---|---|
+| Response received | `.result.serverInfo.name \| length > 0` | Non-empty name | No response or invalid JSON |
+| `serverInfo.name` logged | `jq -r '.result.serverInfo.name'` | Prints name in label | (informational — no separate pass/fail) |
+
+Note: the `serverInfo.name` value is extracted and embedded in the PASS label string
+(e.g., `"stdio: serverInfo.name = unraid-mcp"`). Both are recorded as separate PASS entries.
+
+**`tools/list` response assertions:**
+
+| Assertion | jq filter | PASS | FAIL |
+|---|---|---|---|
+| Response received with tools | `.result.tools \| length > 0` | At least 1 tool | Empty or missing |
+| `unraid` tool present | `.result.tools[] \| select(.name == "unraid")` | Match found | No `unraid` tool |
+
+The tool count is embedded in the PASS label (e.g., `"stdio: tools/list response (2 tools)"`).
+
+### 12.5 What stdio mode does NOT test
+
+- Auth (no bearer token in stdio mode — transport is direct)
+- Phase 1 middleware endpoints (no HTTP server running)
+- Phase 4 tool calls (no HTTP mode infrastructure)
+- SSE response format (stdio uses plain newline-delimited JSON)
+
+---
+
+## 13. Output Format and Interpretation
+
+### 13.1 Per-test lines
+
+Each test produces one line:
+
+```
+  <label padded to 62 chars>                                    PASS   (green)
+  <label padded to 62 chars>                                    FAIL   (red)
+  <label padded to 62 chars>                                    SKIP   (yellow, with reason in dim)
+```
+
+Color codes are stripped when stdout is not a TTY (e.g., CI log files).
+
+### 13.2 Section headers
+
+```
+━━━ Phase 1 · Middleware (no auth) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+### 13.3 Summary block
+
+```
+Results: 47 passed  0 failed  3 skipped  (50 total)
+```
+
+On any failures, a bullet list of failed test labels follows:
+
+```
+Failed tests:
+  • /health → 200 {status:ok}
+  • initialize → 200
+```
+
+### 13.4 Verbose mode
+
+With `--verbose`, raw HTTP response bodies are printed in dim text after each request.
+jq filter and truncated body (first 300 chars) are also printed after each failed
+`assert_jq` call.
+
+### 13.5 Interpreting results
+
+| Result | Meaning |
+|---|---|
+| All PASS | Server is correctly implementing the MCP protocol and all Unraid API endpoints are reachable |
+| FAIL on Phase 1 | Server not running, wrong port, or middleware misconfigured |
+| FAIL on Phase 2 | Auth layer broken — token not being enforced or correct token being rejected |
+| FAIL on Phase 3 | MCP protocol handler broken — `initialize` or `tools/list` not returning correct structure |
+| FAIL on Phase 4 | Specific Unraid API action/subaction failing — check Unraid API connectivity and API key |
+| FAIL on Phase 4b | Guard layer broken — `confirm=true` not being recognized |
+| SKIP (most) | Expected in CI without live Unraid API — use `--skip-tools` |
+| SKIP on Docker | Docker not available in this environment |
+| SKIP on stdio | `uv` not available in this environment |
+
+---
+
+## 14. Internal Helper Reference
+
+### `mcp_post METHOD [PARAMS_JSON]`
+
+Posts a JSON-RPC 2.0 request to `MCP_URL`. Sets globals:
+- `HTTP_STATUS` — curl HTTP status code string (e.g., `"200"`)
+- `HTTP_BODY` — response body (SSE `data:` prefix stripped if present)
+- `MCP_RESULT` — `.result` field from body (may be empty)
+- `MCP_ERROR` — `.error` field from body (may be empty)
+- `MCP_SESSION_ID` — updated if `Mcp-Session-Id` header present in response
+
+### `assert_jq LABEL JSON_INPUT JQ_FILTER`
+
+Evaluates `jq -r "$filter"` against `$body`. PASS if result is non-empty, non-null, and
+non-false. FAIL otherwise.
+
+### `call_unraid LABEL ACTION SUBACTION [EXTRA_ARGS_JSON]`
+
+Builds and posts a `tools/call` for the `unraid` tool. PASS if HTTP 200 and `isError != true`.
+Extra args JSON is merged into the `arguments` object.
+
+### `http_get URL [extra_curl_args...]`
+
+Simple GET request. Sets `HTTP_STATUS` and `HTTP_BODY`. No auth headers added.
+
+### `_guard_bypass_test LABEL ACTION SUBACTION [ARGS_JSON]`
+
+Internal function for Phase 4b. Sends `tools/call` with `confirm: true`. Checks response text
+does NOT contain `"re-run with confirm"`. PASS means the guard accepted `confirm=true`.
+
+---
+
+## 15. Coverage Summary
+
+| Category | Subactions tested | Destructive? |
+|---|---|---|
+| health | 3 (check, test_connection, diagnose) | No |
+| system | 16 (overview, network, array, registration, variables, metrics, services, display, config, online, owner, settings, server, servers, flash, ups_devices) | No |
+| array | 2 (parity_status, parity_history) | No |
+| disk | 3 (shares, disks, log_files) | No |
+| docker | 2 (list, networks) | No |
+| vm | 1 (list) | No |
+| notification | 3 (overview, list, recalculate) | No |
+| user | 1 (me) | No |
+| key | 1 (list) | No |
+| rclone | 2 (list_remotes, config_form) | No |
+| plugin | 1 (list) | No |
+| customization | 4 (theme, public_theme, sso_enabled, is_initial_setup) | No |
+| oidc | 3 (providers, public_providers, configuration) | No |
+| live | 4 (cpu, memory, cpu_telemetry, notifications_overview) | No |
+| **Guard bypass** | 2 (notification/delete, vm/force_stop) | Guarded (confirm=true) |
+| **Total** | **48** | — |
+
+**Not tested (by design):**
+
+- `docker/start`, `docker/stop`, `docker/restart`, `docker/remove` — container state changes
+- `vm/start`, `vm/stop`, `vm/restart`, `vm/remove` — VM state changes
+- `array/start`, `array/stop`, `array/mount`, `array/unmount` — array state changes
+- `notification/delete` (actual execution) — tested as guard bypass only
+- `vm/force_stop` (actual execution) — tested as guard bypass only
+- `user/create`, `user/delete`, `user/update` — user management writes
+- `plugin/install`, `plugin/uninstall`, `plugin/update` — plugin management writes
+- `key/create`, `key/delete` — API key management
+- `rclone/create_remote`, `rclone/delete_remote` — rclone configuration writes
+- `customization/update` — UI customization writes
+- Any SSE subscription or long-polling endpoints

--- a/tests/integration/test_subscriptions.py
+++ b/tests/integration/test_subscriptions.py
@@ -369,7 +369,6 @@ class TestDataReception:
 
             assert "test_sub" in mgr.resource_data
             assert mgr.resource_data["test_sub"].data == {"test": {"value": 42}}
-            assert mgr.resource_data["test_sub"].subscription_type == "test_sub"
 
     async def test_data_message_for_legacy_protocol(self) -> None:
         mgr = SubscriptionManager()
@@ -756,20 +755,19 @@ class TestResourceData:
         mgr.resource_data["test"] = SubscriptionData(
             data={"key": "value"},
             last_updated=datetime.now(UTC),
-            subscription_type="test",
         )
         result = await mgr.get_resource_data("test")
         assert result == {"key": "value"}
 
-    def test_list_active_subscriptions_empty(self) -> None:
+    async def test_list_active_subscriptions_empty(self) -> None:
         mgr = SubscriptionManager()
-        assert mgr.list_active_subscriptions() == []
+        assert await mgr.list_active_subscriptions() == []
 
-    def test_list_active_subscriptions_returns_names(self) -> None:
+    async def test_list_active_subscriptions_returns_names(self) -> None:
         mgr = SubscriptionManager()
         mgr.active_subscriptions["sub_a"] = MagicMock()
         mgr.active_subscriptions["sub_b"] = MagicMock()
-        result = mgr.list_active_subscriptions()
+        result = await mgr.list_active_subscriptions()
         assert sorted(result) == ["sub_a", "sub_b"]
 
 
@@ -804,7 +802,6 @@ class TestSubscriptionStatus:
         mgr.resource_data["logFileSubscription"] = SubscriptionData(
             data={"log": "content"},
             last_updated=datetime.now(UTC),
-            subscription_type="logFileSubscription",
         )
         status = await mgr.get_subscription_status()
         assert status["logFileSubscription"]["data"]["available"] is True

--- a/tests/schema/test_query_validation.py
+++ b/tests/schema/test_query_validation.py
@@ -217,6 +217,8 @@ class TestInfoQueries:
             "ups_devices",
             "ups_device",
             "ups_config",
+            "server_time",
+            "timezones",
         }
         assert set(QUERIES.keys()) == expected_actions
 
@@ -470,16 +472,17 @@ class TestVmQueries:
         errors = _validate_operation(schema, QUERIES["list"])
         assert not errors, f"list query validation failed: {errors}"
 
-    def test_details_query(self, schema: GraphQLSchema) -> None:
-        from unraid_mcp.tools._vm import _VM_QUERIES as QUERIES
+    def test_details_uses_list_query(self, schema: GraphQLSchema) -> None:
+        """details reuses the list query — VmDomain has no richer fields."""
+        from unraid_mcp.tools._vm import _VM_LIST_QUERY
 
-        errors = _validate_operation(schema, QUERIES["details"])
-        assert not errors, f"details query validation failed: {errors}"
+        errors = _validate_operation(schema, _VM_LIST_QUERY)
+        assert not errors, f"list query (used by details) validation failed: {errors}"
 
     def test_all_vm_queries_covered(self, schema: GraphQLSchema) -> None:
         from unraid_mcp.tools._vm import _VM_QUERIES as QUERIES
 
-        assert set(QUERIES.keys()) == {"list", "details"}
+        assert set(QUERIES.keys()) == {"list"}
 
 
 class TestVmMutations:
@@ -626,6 +629,7 @@ class TestNotificationMutations:
 
         expected = {
             "create",
+            "notify_if_unique",
             "archive",
             "mark_unread",
             "delete",
@@ -723,7 +727,7 @@ class TestKeysQueries:
     def test_all_keys_queries_covered(self, schema: GraphQLSchema) -> None:
         from unraid_mcp.tools._key import _KEY_QUERIES as QUERIES
 
-        assert set(QUERIES.keys()) == {"list", "get"}
+        assert set(QUERIES.keys()) == {"list", "get", "possible_roles"}
 
 
 class TestKeysMutations:

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -137,26 +137,16 @@ def test_collect_actions_all_handled():
     If this test fails, a new key was added to COLLECT_ACTIONS in
     subscriptions/queries.py without adding a corresponding if-branch in
     tools/_live.py — which would cause a ToolError('this is a bug') at runtime.
-    Fix: add an if-branch in _handle_live AND add the key to
-    _HANDLED_COLLECT_SUBACTIONS.
+    Fix: add an if-branch in _handle_live for the new key.
     """
-    from unraid_mcp.subscriptions.queries import COLLECT_ACTIONS
-    from unraid_mcp.tools._live import _HANDLED_COLLECT_SUBACTIONS
+    import inspect
 
-    unhandled = set(COLLECT_ACTIONS) - _HANDLED_COLLECT_SUBACTIONS
+    from unraid_mcp.subscriptions.queries import COLLECT_ACTIONS
+    from unraid_mcp.tools._live import _handle_live
+
+    source = inspect.getsource(_handle_live)
+    unhandled = {key for key in COLLECT_ACTIONS if f'"{key}"' not in source}
     assert not unhandled, (
         f"COLLECT_ACTIONS keys without handlers in _handle_live: {unhandled}. "
-        "Add an if-branch in unraid_mcp/tools/_live.py and update _HANDLED_COLLECT_SUBACTIONS."
+        "Add an if-branch in unraid_mcp/tools/_live.py."
     )
-
-
-def test_collect_actions_rejects_stale_handled_keys(monkeypatch):
-    import unraid_mcp.tools._live as live_module
-
-    monkeypatch.setattr(
-        live_module,
-        "_HANDLED_COLLECT_SUBACTIONS",
-        frozenset({"log_tail", "notification_feed", "stale_key"}),
-    )
-    with pytest.raises(RuntimeError, match="stale"):
-        live_module._assert_collect_subactions_complete()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -43,12 +43,15 @@ class TestLiveResourcesUseManagerCache:
     @pytest.mark.usefixtures("_mock_ensure_started")
     async def test_resource_returns_cached_data(self, action: str) -> None:
         cached = {"systemMetricsCpu": {"percentTotal": 12.5}}
+        ts = "2026-04-04T12:00:00+00:00"
         with patch("unraid_mcp.subscriptions.resources.subscription_manager") as mock_mgr:
-            mock_mgr.get_resource_data = AsyncMock(return_value=cached)
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=(cached, ts))
             mcp = _make_resources()
             resource = _get_resource(mcp, f"unraid://live/{action}")
             result = await resource.fn()
-        assert json.loads(result) == cached
+        parsed = json.loads(result)
+        assert parsed["_fetched_at"] == ts
+        assert parsed["systemMetricsCpu"] == cached["systemMetricsCpu"]
 
     @pytest.mark.parametrize("action", list(SNAPSHOT_ACTIONS.keys()))
     @pytest.mark.usefixtures("_mock_ensure_started")
@@ -56,7 +59,7 @@ class TestLiveResourcesUseManagerCache:
         self, action: str
     ) -> None:
         with patch("unraid_mcp.subscriptions.resources.subscription_manager") as mock_mgr:
-            mock_mgr.get_resource_data = AsyncMock(return_value=None)
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=None)
             mock_mgr.get_error_state = AsyncMock(return_value=(None, ""))
             mock_mgr.auto_start_enabled = True
             mcp = _make_resources()
@@ -69,7 +72,7 @@ class TestLiveResourcesUseManagerCache:
     @pytest.mark.usefixtures("_mock_ensure_started")
     async def test_resource_returns_error_status_on_permanent_failure(self, action: str) -> None:
         with patch("unraid_mcp.subscriptions.resources.subscription_manager") as mock_mgr:
-            mock_mgr.get_resource_data = AsyncMock(return_value=None)
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=None)
             mock_mgr.get_error_state = AsyncMock(
                 return_value=("WebSocket auth failed", "auth_failed")
             )
@@ -107,7 +110,7 @@ class TestLogsStreamResource:
     @pytest.mark.usefixtures("_mock_ensure_started")
     async def test_logs_stream_no_data(self) -> None:
         with patch("unraid_mcp.subscriptions.resources.subscription_manager") as mock_mgr:
-            mock_mgr.get_resource_data = AsyncMock(return_value=None)
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=None)
             mcp = _make_resources()
             resource = _get_resource(mcp, "unraid://logs/stream")
             result = await resource.fn()
@@ -116,13 +119,15 @@ class TestLogsStreamResource:
 
     @pytest.mark.usefixtures("_mock_ensure_started")
     async def test_logs_stream_returns_data_with_empty_dict(self) -> None:
-        """Empty dict cache hit must return data, not 'connecting' status."""
+        """Empty dict cache hit must return data with _fetched_at timestamp."""
+        ts = "2026-04-04T12:00:00+00:00"
         with patch("unraid_mcp.subscriptions.resources.subscription_manager") as mock_mgr:
-            mock_mgr.get_resource_data = AsyncMock(return_value={})
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=({}, ts))
             mcp = _make_resources()
             resource = _get_resource(mcp, "unraid://logs/stream")
             result = await resource.fn()
-            assert json.loads(result) == {}
+            parsed = json.loads(result)
+            assert parsed["_fetched_at"] == ts
 
 
 class TestAutoStartDisabledFallback:
@@ -139,7 +144,7 @@ class TestAutoStartDisabledFallback:
                 new=AsyncMock(return_value=fallback_data),
             ),
         ):
-            mock_mgr.get_resource_data = AsyncMock(return_value=None)
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=None)
             mock_mgr.get_error_state = AsyncMock(return_value=(None, ""))
             mock_mgr.auto_start_enabled = False
             mcp = _make_resources()
@@ -158,7 +163,7 @@ class TestAutoStartDisabledFallback:
                 new=AsyncMock(side_effect=Exception("WebSocket failed")),
             ),
         ):
-            mock_mgr.get_resource_data = AsyncMock(return_value=None)
+            mock_mgr.get_resource_data_with_timestamp = AsyncMock(return_value=None)
             mock_mgr.get_error_state = AsyncMock(return_value=(None, ""))
             mock_mgr.auto_start_enabled = False
             mcp = _make_resources()

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -22,16 +22,15 @@ def test_container_configs_use_runtime_port_variable() -> None:
     compose = (PROJECT_ROOT / "docker-compose.yaml").read_text()
     dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
     assert "${UNRAID_MCP_PORT:-6970}:${UNRAID_MCP_PORT:-6970}" in compose
-    assert "os.getenv('UNRAID_MCP_PORT', '6970')" in compose
-    assert "os.getenv('UNRAID_MCP_PORT', '6970')" in dockerfile
+    assert "${UNRAID_MCP_PORT:-6970}" in compose
+    assert "${UNRAID_MCP_PORT:-6970}" in dockerfile
 
 
 def test_test_live_script_uses_safe_counters_and_resource_failures() -> None:
     script = (PROJECT_ROOT / "tests" / "test_live.sh").read_text()
-    assert "((++PASS))" in script
-    assert "((++FAIL))" in script
-    assert "((++SKIP))" in script
-    assert 'fail "resources/list" "$resources_output"' in script
+    assert "(( PASS++ ))" in script
+    assert "(( FAIL++ ))" in script
+    assert "(( SKIP++ ))" in script
 
 
 def test_sync_env_rejects_multiline_values(tmp_path: Path) -> None:
@@ -51,7 +50,8 @@ def test_sync_env_rejects_multiline_values(tmp_path: Path) -> None:
     assert "control characters" in result.stderr
 
 
-def test_sync_env_regenerates_empty_bearer_token(tmp_path: Path) -> None:
+def test_sync_env_rejects_empty_bearer_token(tmp_path: Path) -> None:
+    """sync-env must fail when no bearer token is provided — auto-generation was removed."""
     env_file = tmp_path / ".env"
     env_file.write_text("UNRAID_MCP_BEARER_TOKEN=\n")
 
@@ -66,10 +66,8 @@ def test_sync_env_regenerates_empty_bearer_token(tmp_path: Path) -> None:
         text=True,
     )
 
-    assert result.returncode == 0
-    lines = env_file.read_text().splitlines()
-    token_line = next(line for line in lines if line.startswith("UNRAID_MCP_BEARER_TOKEN="))
-    assert token_line != "UNRAID_MCP_BEARER_TOKEN="
+    assert result.returncode != 0
+    assert "UNRAID_MCP_BEARER_TOKEN is not set" in result.stderr
 
 
 def test_ensure_gitignore_preserves_ignore_before_negation(tmp_path: Path) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -51,27 +51,16 @@ def test_settings_apply_runtime_config_updates_module_globals():
 
     original_url = settings.UNRAID_API_URL
     original_key = settings.UNRAID_API_KEY
-    original_env_url = os.environ.get("UNRAID_API_URL")
-    original_env_key = os.environ.get("UNRAID_API_KEY")
     try:
         settings.apply_runtime_config("https://newurl.com/graphql", "newkey")
         assert settings.UNRAID_API_URL == "https://newurl.com/graphql"
         assert settings.UNRAID_API_KEY == "newkey"
-        assert os.environ["UNRAID_API_URL"] == "https://newurl.com/graphql"
-        assert os.environ["UNRAID_API_KEY"] == "newkey"
+        # Credentials must NOT leak to os.environ (security fix: unraid-mcp-cbc)
+        assert os.environ.get("UNRAID_API_URL") != "https://newurl.com/graphql"
+        assert os.environ.get("UNRAID_API_KEY") != "newkey"
     finally:
-        # Reset module globals
         settings.UNRAID_API_URL = original_url
         settings.UNRAID_API_KEY = original_key
-        # Reset os.environ
-        if original_env_url is None:
-            os.environ.pop("UNRAID_API_URL", None)
-        else:
-            os.environ["UNRAID_API_URL"] = original_env_url
-        if original_env_key is None:
-            os.environ.pop("UNRAID_API_KEY", None)
-        else:
-            os.environ["UNRAID_API_KEY"] = original_env_key
 
 
 def test_run_server_does_not_exit_when_creds_missing(monkeypatch):

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -31,8 +31,8 @@ class TestValidateSubscriptionQueryAllowed:
         assert _validate_subscription_query(query) == "memory"
 
     def test_multiline_query_accepted(self) -> None:
-        query = "subscription {\n  logFile {\n    content\n  }\n}"
-        assert _validate_subscription_query(query) == "logFile"
+        query = "subscription {\n  cpu {\n    used\n  }\n}"
+        assert _validate_subscription_query(query) == "cpu"
 
     def test_case_insensitive_subscription_keyword(self) -> None:
         """'SUBSCRIPTION' should be accepted (regex uses IGNORECASE)."""
@@ -121,6 +121,12 @@ class TestValidateSubscriptionQueryUnknownName:
 
     def test_arbitrary_field_name_rejected(self) -> None:
         query = "subscription { users { id email } }"
+        with pytest.raises(ToolError, match="not allowed"):
+            _validate_subscription_query(query)
+
+    def test_logfile_rejected_security(self) -> None:
+        """logFile allows arbitrary file reads via path argument — must be blocked."""
+        query = 'subscription { logFile(path: "/etc/shadow") { content } }'
         with pytest.raises(ToolError, match="not allowed"):
             _validate_subscription_query(query)
 

--- a/unraid_mcp/config/logging.py
+++ b/unraid_mcp/config/logging.py
@@ -7,16 +7,9 @@ that cap at 10MB and start over (no rotation) for consistent use across all modu
 import logging
 from pathlib import Path
 
+from fastmcp.utilities.logging import get_logger as get_fastmcp_logger
 from rich.console import Console
 from rich.logging import RichHandler
-
-
-try:
-    from fastmcp.utilities.logging import get_logger as get_fastmcp_logger
-
-    FASTMCP_AVAILABLE = True
-except ImportError:
-    FASTMCP_AVAILABLE = False
 
 from .settings import LOG_FILE_PATH, LOG_LEVEL_STR
 
@@ -55,27 +48,28 @@ class OverwriteFileHandler(logging.FileHandler):
                 base_path = Path(self.baseFilename)
                 file_size = base_path.stat().st_size if base_path.exists() else 0
                 if file_size >= self.max_bytes:
-                    old_stream = self.stream
-                    self.stream = None
+                    # Open new file FIRST, then swap — self.stream is never None.
                     try:
-                        old_stream.close()
                         base_path.unlink(missing_ok=True)
-                        self.stream = self._open()
+                        new_stream = self._open()
                     except OSError:
-                        # Recovery: attempt to reopen even if unlink failed
                         try:
-                            self.stream = self._open()
+                            new_stream = self._open()
                         except OSError:
-                            # old_stream is already closed — do NOT restore it.
-                            # Leave self.stream = None so super().emit() skips output
-                            # rather than writing to a closed file descriptor.
                             import sys
 
                             print(
                                 "WARNING: Failed to reopen log file after rotation. "
-                                "File logging suspended until next successful open.",
+                                "File logging continues on old stream.",
                                 file=sys.stderr,
                             )
+                            new_stream = None
+
+                    if new_stream is not None:
+                        old_stream = self.stream
+                        self.stream = new_stream  # atomic swap
+                        if old_stream is not None:
+                            old_stream.close()
 
                     if self.stream is not None:
                         reset_record = logging.LogRecord(
@@ -161,11 +155,8 @@ def setup_logger(name: str = "UnraidMCPServer") -> logging.Logger:
     return logger
 
 
-def configure_fastmcp_logger_with_rich() -> logging.Logger | None:
+def configure_fastmcp_logger_with_rich() -> logging.Logger:
     """Configure FastMCP logger to use Rich formatting with Nordic colors."""
-    if not FASTMCP_AVAILABLE:
-        return None
-
     # Get numeric log level
     numeric_log_level = getattr(logging, LOG_LEVEL_STR, logging.INFO)
 
@@ -238,10 +229,4 @@ def log_configuration_status(logger: logging.Logger) -> None:
 
 
 # Global logger instance - modules can import this directly
-if FASTMCP_AVAILABLE:
-    # Use FastMCP logger with Rich formatting
-    _fastmcp_logger = configure_fastmcp_logger_with_rich()
-    logger = _fastmcp_logger if _fastmcp_logger is not None else setup_logger()
-else:
-    # Fallback to our custom logger if FastMCP is not available
-    logger = setup_logger()
+logger = configure_fastmcp_logger_with_rich()

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -41,6 +41,10 @@ for dotenv_path in dotenv_paths:
         break
 
 # Core API Configuration
+# IMPORTANT: UNRAID_API_URL and UNRAID_API_KEY are mutated at runtime by apply_runtime_config().
+# Never import these names at module level in code that runs after startup.
+# Instead, use a local import: from ..config import settings as _settings; _settings.UNRAID_API_URL
+# Or call get_api_credentials() which always returns the current values.
 UNRAID_API_URL = os.getenv("UNRAID_API_URL")
 UNRAID_API_KEY = os.getenv("UNRAID_API_KEY")
 
@@ -128,14 +132,19 @@ def is_configured() -> bool:
 def apply_runtime_config(api_url: str, api_key: str) -> None:
     """Update module-level credential globals at runtime (post-elicitation).
 
-    Also sets matching environment variables so submodules that read
-    os.getenv() after import see the new values.
+    Credentials are intentionally NOT written to os.environ to prevent
+    leaking secrets to subprocesses or error reporters that capture
+    environment snapshots.  All internal consumers read from this module's
+    globals via ``from ..config import settings as _settings``.
     """
     global UNRAID_API_URL, UNRAID_API_KEY
     UNRAID_API_URL = api_url
     UNRAID_API_KEY = api_key
-    os.environ["UNRAID_API_URL"] = api_url
-    os.environ["UNRAID_API_KEY"] = api_key
+
+
+def get_api_credentials() -> tuple[str | None, str | None]:
+    """Return current (UNRAID_API_URL, UNRAID_API_KEY) — safe to call after apply_runtime_config."""
+    return UNRAID_API_URL, UNRAID_API_KEY
 
 
 def apply_bearer_token(token: str) -> None:

--- a/unraid_mcp/core/auth.py
+++ b/unraid_mcp/core/auth.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import hmac
 import json
+import posixpath
 import re
 import time
 from collections import deque
@@ -41,6 +42,9 @@ _RATE_MAX_FAILURES = 60
 
 # Log throttle: emit at most one warning per IP per this many seconds
 _LOG_THROTTLE_SECS = 30.0
+
+# Maximum number of unique IPs to track — prevents memory exhaustion DoS
+_MAX_IP_TRACKING = 10_000
 
 
 class BearerAuthMiddleware:
@@ -172,6 +176,14 @@ class BearerAuthMiddleware:
     def _record_failure(self, ip: str) -> None:
         """Record one failed auth attempt for this IP."""
         self._prune_ip_state(ip)
+        # Evict oldest-activity IP when tracking dict is full
+        if ip not in self._ip_failures and len(self._ip_failures) >= _MAX_IP_TRACKING:
+            oldest_ip = min(
+                self._ip_failures,
+                key=lambda k: self._ip_failures[k][0] if self._ip_failures[k] else 0,
+            )
+            del self._ip_failures[oldest_ip]
+            self._ip_last_warn.pop(oldest_ip, None)
         if ip not in self._ip_failures:
             self._ip_failures[ip] = deque()
         self._ip_failures[ip].append(time.monotonic())
@@ -242,7 +254,12 @@ class HealthMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         # scope["path"] is always present in ASGI HTTP scopes (required field).
-        if scope["type"] == "http" and scope["path"] == "/health" and scope["method"] == "GET":
+        # Normalize to prevent bypasses like "/health/" or "//health".
+        if (
+            scope["type"] == "http"
+            and posixpath.normpath(scope["path"]) == "/health"
+            and scope["method"] == "GET"
+        ):
             await send({"type": "http.response.start", "status": 200, "headers": self._HEADERS})
             await send({"type": "http.response.body", "body": self._BODY, "more_body": False})
             return
@@ -282,7 +299,7 @@ class WellKnownMiddleware:
             await self.app(scope, receive, send)
             return
 
-        path: str = scope.get("path", "")
+        path: str = posixpath.normpath(scope.get("path", ""))
         method: str = scope.get("method", "").upper()
 
         if method != "GET" or path not in self._WELL_KNOWN_PATHS:

--- a/unraid_mcp/core/client.py
+++ b/unraid_mcp/core/client.py
@@ -24,27 +24,34 @@ from .utils import safe_display_url
 
 
 # Sensitive keys to redact from debug logs (frozenset — immutable, Final — no accidental reassignment)
-_SENSITIVE_KEYS: Final[frozenset[str]] = frozenset(
+# Exact-match keys: short words that over-redact when used as substrings
+# (e.g. "key" would match "keyFile", "monkey", "turkey")
+_EXACT_SENSITIVE_KEYS: Final[frozenset[str]] = frozenset({"key", "pin"})
+# Substring-match keys: compound terms safe for substring matching
+_SUBSTRING_SENSITIVE_KEYS: Final[frozenset[str]] = frozenset(
     {
         "password",
-        "key",
         "secret",
         "token",
         "apikey",
         "authorization",
-        "cookie",
-        "session",
         "credential",
         "passphrase",
         "jwt",
+        "cookie",
+        "session",
     }
 )
 
 
 def _is_sensitive_key(key: str) -> bool:
-    """Check if a key name contains any sensitive substring."""
-    key_lower = key.lower()
-    return any(s in key_lower for s in _SENSITIVE_KEYS)
+    """Check if a key name is sensitive (exact match or substring match).
+
+    Normalizes by stripping underscores/hyphens so "api_key_value" matches "apikey".
+    """
+    k = key.lower()
+    k_normalized = k.replace("_", "").replace("-", "")
+    return k in _EXACT_SENSITIVE_KEYS or any(s in k_normalized for s in _SUBSTRING_SENSITIVE_KEYS)
 
 
 def redact_sensitive(obj: Any) -> Any:

--- a/unraid_mcp/core/setup.py
+++ b/unraid_mcp/core/setup.py
@@ -7,8 +7,10 @@ them to ~/.unraid-mcp/.env with restricted permissions.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
 
 
 if TYPE_CHECKING:
@@ -23,10 +25,11 @@ from ..config.settings import (
 )
 
 
-@dataclass
-class _UnraidCredentials:
-    api_url: str
-    api_key: str
+class _UnraidCredentials(BaseModel):
+    """Credentials model for MCP elicitation form rendering."""
+
+    api_url: str = Field(..., description="Unraid GraphQL endpoint URL")
+    api_key: str = Field(..., description="Unraid API key")
 
 
 async def elicit_reset_confirmation(ctx: Context | None, current_url: str) -> bool:
@@ -161,6 +164,15 @@ def _write_env(api_url: str, api_key: str) -> None:
     if not key_written:
         new_lines.append(f"UNRAID_API_KEY={api_key}")
 
-    CREDENTIALS_ENV_PATH.write_text("\n".join(new_lines) + "\n")
-    CREDENTIALS_ENV_PATH.chmod(0o600)
+    # Atomic write: write to tmp file, set permissions, then rename into place.
+    # os.replace is atomic on POSIX — prevents a crash from leaving a partial .env.
+    tmp_path = CREDENTIALS_ENV_PATH.with_suffix(".tmp")
+    try:
+        tmp_path.write_text("\n".join(new_lines) + "\n")
+        tmp_path.chmod(0o600)
+        os.replace(tmp_path, CREDENTIALS_ENV_PATH)
+    finally:
+        # Clean up tmp on failure (may not exist if os.replace succeeded)
+        if tmp_path.exists():
+            tmp_path.unlink()
     logger.info("Credentials written to %s (mode 600)", CREDENTIALS_ENV_PATH)

--- a/unraid_mcp/core/types.py
+++ b/unraid_mcp/core/types.py
@@ -18,10 +18,7 @@ class SubscriptionData:
 
     data: dict[str, Any]
     last_updated: datetime  # Must be timezone-aware (UTC)
-    subscription_type: str
 
     def __post_init__(self) -> None:
         if self.last_updated.tzinfo is None:
             raise ValueError("last_updated must be timezone-aware; use datetime.now(UTC)")
-        if not self.subscription_type.strip():
-            raise ValueError("subscription_type must be a non-empty string")

--- a/unraid_mcp/core/utils.py
+++ b/unraid_mcp/core/utils.py
@@ -92,3 +92,19 @@ def format_kb(k: Any) -> str:
     except (ValueError, TypeError):
         return "N/A"
     return format_bytes(kb * 1024)
+
+
+def validate_subaction(subaction: str, valid_set: set[str], domain: str) -> None:
+    """Raise ToolError if subaction is not in the valid set.
+
+    Args:
+        subaction: The subaction string to validate.
+        valid_set: Set of valid subaction names.
+        domain: The domain name for error messages (e.g. "docker").
+    """
+    from .exceptions import ToolError
+
+    if subaction not in valid_set:
+        raise ToolError(
+            f"Invalid subaction '{subaction}' for {domain}. Must be one of: {sorted(valid_set)}"
+        )

--- a/unraid_mcp/core/validation.py
+++ b/unraid_mcp/core/validation.py
@@ -5,6 +5,9 @@ _rclone.py, _setting.py) so they share a single source of truth.
 """
 
 import re
+from typing import Any
+
+from .exceptions import ToolError
 
 
 # Maximum string length for individual config/settings values
@@ -22,3 +25,47 @@ MAX_VALUE_LENGTH: int = 4096
 DANGEROUS_KEY_PATTERN: re.Pattern[str] = re.compile(
     r"\.\.|[/\\;|`$(){}&<>\"'#\x20\x7f]|[\x00-\x1f]"
 )
+
+
+def validate_scalar_mapping(
+    data: dict[str, Any],
+    label: str,
+    *,
+    max_keys: int = 100,
+    stringify: bool = False,
+) -> dict[str, Any]:
+    """Validate a flat scalar key-value mapping.
+
+    Enforces key count cap, rejects dangerous key names, accepts only scalar
+    values (str, int, float, bool), and enforces MAX_VALUE_LENGTH.
+
+    Args:
+        data: The mapping to validate.
+        label: Human-readable label for error messages (e.g. "config_data").
+        max_keys: Maximum number of keys allowed.
+        stringify: If True, convert all values to str (rclone style).
+                   If False, preserve original types (settings style).
+
+    Returns:
+        Validated mapping with the same or stringified values.
+    """
+    if len(data) > max_keys:
+        raise ToolError(f"{label} has {len(data)} keys (max {max_keys})")
+    validated: dict[str, Any] = {}
+    for key, value in data.items():
+        if not isinstance(key, str) or not key.strip():
+            raise ToolError(f"{label} keys must be non-empty strings, got: {type(key).__name__}")
+        if DANGEROUS_KEY_PATTERN.search(key):
+            raise ToolError(f"{label} key '{key}' contains disallowed characters")
+        if not isinstance(value, (str, int, float, bool)):
+            raise ToolError(
+                f"{label}['{key}'] must be a string, number, or boolean"
+                + (f", got: {type(value).__name__}" if not stringify else "")
+            )
+        str_value = str(value)
+        if len(str_value) > MAX_VALUE_LENGTH:
+            raise ToolError(
+                f"{label}['{key}'] value exceeds max length ({len(str_value)} > {MAX_VALUE_LENGTH})"
+            )
+        validated[key] = str_value if stringify else value
+    return validated

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -152,13 +152,15 @@ def ensure_token_exists() -> None:
     CREDENTIALS_DIR.mkdir(parents=True, exist_ok=True)
     _chmod_safe(CREDENTIALS_DIR, 0o700, strict=True)
 
-    # Touch the file first so set_key has a target (no-op if already exists)
+    # Touch the file and restrict permissions BEFORE writing the token.
+    # This closes the window where the file has default umask permissions.
     if not CREDENTIALS_ENV_PATH.exists():
-        CREDENTIALS_ENV_PATH.touch()
-
-    # In-place .env write — preserves comments and existing keys
-    set_key(str(CREDENTIALS_ENV_PATH), "UNRAID_MCP_BEARER_TOKEN", token, quote_mode="auto")
+        CREDENTIALS_ENV_PATH.touch(mode=0o600)
     _chmod_safe(CREDENTIALS_ENV_PATH, 0o600, strict=True)
+
+    # In-place .env write — preserves comments and existing keys.
+    # File is already 0o600 so the token is never world-readable.
+    set_key(str(CREDENTIALS_ENV_PATH), "UNRAID_MCP_BEARER_TOKEN", token, quote_mode="auto")
 
     print(
         f"\n[unraid-mcp] Generated HTTP bearer token and saved it to {CREDENTIALS_ENV_PATH}.\n"

--- a/unraid_mcp/subscriptions/diagnostics.py
+++ b/unraid_mcp/subscriptions/diagnostics.py
@@ -35,13 +35,14 @@ from .utils import (
 # NOT the operation-level names (e.g. "logFileSubscription").
 _ALLOWED_SUBSCRIPTION_FIELDS = frozenset(
     {
-        "logFile",
         "containerStats",
         "cpu",
+        "dockerContainerStats",
         "memory",
         "array",
         "network",
         "docker",
+        "systemMetricsTemperature",
         "vm",
     }
 )
@@ -72,7 +73,7 @@ def _validate_subscription_query(query: str) -> str:
     if not match:
         raise ToolError(
             "Query rejected: must start with 'subscription' and contain a valid "
-            'subscription field. Example: subscription { logFile(path: "/var/log/syslog") { content } }'
+            "subscription field. Example: subscription { cpu { used idle system } }"
         )
 
     field_name = match.group(1)
@@ -97,7 +98,7 @@ def register_diagnostic_tools(mcp: FastMCP) -> None:
         """Test a GraphQL subscription query directly to debug schema issues.
 
         Use this to find working subscription field names and structure.
-        Only whitelisted schema fields are permitted (logFile, containerStats,
+        Only whitelisted schema fields are permitted (containerStats,
         cpu, memory, array, network, docker, vm).
 
         Args:

--- a/unraid_mcp/subscriptions/manager.py
+++ b/unraid_mcp/subscriptions/manager.py
@@ -29,17 +29,6 @@ _MAX_RESOURCE_DATA_LINES = 5_000
 # Minimum stable connection duration (seconds) before resetting reconnect counter
 _STABLE_CONNECTION_SECONDS = 30
 
-# Track last GraphQL error per subscription to deduplicate log spam.
-# Key: subscription name, Value: first error message seen in the current burst.
-_last_graphql_error: dict[str, str] = {}
-_graphql_error_count: dict[str, int] = {}
-
-
-def _clear_graphql_error_burst(subscription_name: str) -> None:
-    """Reset deduplicated GraphQL error tracking for one subscription."""
-    _last_graphql_error.pop(subscription_name, None)
-    _graphql_error_count.pop(subscription_name, None)
-
 
 def _preview(message: str | bytes, n: int = 200) -> str:
     """Return the first *n* characters of *message* as a UTF-8 string.
@@ -126,6 +115,10 @@ class SubscriptionManager:
         self.connection_states: dict[str, str] = {}  # Track connection state per subscription
         self.last_error: dict[str, str] = {}  # Track last error per subscription
         self._connection_start_times: dict[str, float] = {}  # Track when connections started
+        # Track last GraphQL error per subscription to deduplicate log spam.
+        # Key: subscription name, Value: first error message seen in the current burst.
+        self._last_graphql_error: dict[str, str] = {}
+        self._graphql_error_count: dict[str, int] = {}
 
         # Define subscription configurations
         from .queries import SNAPSHOT_ACTIONS
@@ -160,6 +153,22 @@ class SubscriptionManager:
         logger.debug(
             f"[SUBSCRIPTION_MANAGER] Available subscriptions: {list(self.subscription_configs.keys())}"
         )
+
+    def _clear_graphql_error_burst(self, subscription_name: str) -> None:
+        """Reset deduplicated GraphQL error tracking for one subscription."""
+        self._last_graphql_error.pop(subscription_name, None)
+        self._graphql_error_count.pop(subscription_name, None)
+
+    def _set_connection_state(self, name: str, state: str, error: str | None = None) -> None:
+        """Atomically update connection state and optionally last_error.
+
+        Must NOT contain any ``await`` — paired writes rely on asyncio
+        cooperative scheduling to stay consistent (no interleaving at
+        non-await points).
+        """
+        self.connection_states[name] = state
+        if error is not None:
+            self.last_error[name] = error
 
     async def auto_start_all_subscriptions(self) -> None:
         """Auto-start all subscriptions marked for auto-start.
@@ -233,7 +242,7 @@ class SubscriptionManager:
             raise ValueError(
                 f"subscription_name must contain only [a-zA-Z0-9_], got: {subscription_name!r}"
             )
-        _clear_graphql_error_burst(subscription_name)
+        self._clear_graphql_error_burst(subscription_name)
         logger.info(f"[SUBSCRIPTION:{subscription_name}] Starting subscription...")
 
         # Guard must be inside the lock to prevent a TOCTOU race where two
@@ -248,7 +257,7 @@ class SubscriptionManager:
             # Reset connection tracking inside the lock so state is consistent
             # with the task creation that follows immediately.
             self.reconnect_attempts[subscription_name] = 0
-            self.connection_states[subscription_name] = "starting"
+            self._set_connection_state(subscription_name, "starting")
             self._connection_start_times.pop(subscription_name, None)
 
             try:
@@ -259,13 +268,12 @@ class SubscriptionManager:
                 logger.info(
                     f"[SUBSCRIPTION:{subscription_name}] Subscription task created and started"
                 )
-                self.connection_states[subscription_name] = "active"
+                self._set_connection_state(subscription_name, "active")
             except Exception as e:
                 logger.error(
                     f"[SUBSCRIPTION:{subscription_name}] Failed to start subscription task: {e}"
                 )
-                self.connection_states[subscription_name] = "failed"
-                self.last_error[subscription_name] = str(e)
+                self._set_connection_state(subscription_name, "failed", str(e))
                 raise
 
     async def stop_subscription(self, subscription_name: str) -> None:
@@ -283,7 +291,7 @@ class SubscriptionManager:
             if task is None:
                 logger.warning(f"[SUBSCRIPTION:{subscription_name}] No active subscription to stop")
                 return
-            self.connection_states[subscription_name] = "stopped"
+            self._set_connection_state(subscription_name, "stopped")
             self._connection_start_times.pop(subscription_name, None)
 
         # Await cancellation OUTSIDE the lock — _subscription_loop cleanup path
@@ -294,8 +302,8 @@ class SubscriptionManager:
             await task
         except asyncio.CancelledError:
             logger.debug(f"[SUBSCRIPTION:{subscription_name}] Task cancelled successfully")
-        self.connection_states[subscription_name] = "stopped"
-        _clear_graphql_error_burst(subscription_name)
+        self._set_connection_state(subscription_name, "stopped")
+        self._clear_graphql_error_burst(subscription_name)
         logger.info(f"[SUBSCRIPTION:{subscription_name}] Subscription stopped")
 
     async def stop_all(self) -> None:
@@ -328,7 +336,7 @@ class SubscriptionManager:
                 logger.error(
                     f"[WEBSOCKET:{subscription_name}] Max reconnection attempts ({self.max_reconnect_attempts}) exceeded, stopping"
                 )
-                self.connection_states[subscription_name] = "max_retries_exceeded"
+                self._set_connection_state(subscription_name, "max_retries_exceeded")
                 break
 
             try:
@@ -359,7 +367,7 @@ class SubscriptionManager:
                     logger.info(
                         f"[WEBSOCKET:{subscription_name}] Connected! Protocol: {selected_proto}"
                     )
-                    self.connection_states[subscription_name] = "connected"
+                    self._set_connection_state(subscription_name, "connected")
 
                     # Track connection start time — only reset retry counter
                     # after the connection proves stable (>30s connected)
@@ -410,16 +418,17 @@ class SubscriptionManager:
                         logger.info(
                             f"[PROTOCOL:{subscription_name}] Connection acknowledged successfully"
                         )
-                        self.connection_states[subscription_name] = "authenticated"
+                        self._set_connection_state(subscription_name, "authenticated")
                     elif init_data.get("type") == "connection_error":
                         error_payload = init_data.get("payload", {})
                         logger.error(
                             f"[AUTH:{subscription_name}] Authentication failed: {error_payload}"
                         )
-                        self.last_error[subscription_name] = (
-                            f"Authentication error: {error_payload}"
+                        self._set_connection_state(
+                            subscription_name,
+                            "auth_failed",
+                            f"Authentication error: {error_payload}",
                         )
-                        self.connection_states[subscription_name] = "auth_failed"
                         break
                     else:
                         logger.warning(
@@ -452,7 +461,7 @@ class SubscriptionManager:
                     logger.info(
                         f"[SUBSCRIPTION:{subscription_name}] Subscription started successfully"
                     )
-                    self.connection_states[subscription_name] = "subscribed"
+                    self._set_connection_state(subscription_name, "subscribed")
 
                     # Listen for subscription data
                     message_count = 0
@@ -464,7 +473,10 @@ class SubscriptionManager:
                             message_type = data.get("type", "unknown")
 
                             logger.debug(
-                                f"[DATA:{subscription_name}] Message #{message_count}: {message_type}"
+                                "[DATA:%s] Message #%d: %s",
+                                subscription_name,
+                                message_count,
+                                message_type,
                             )
 
                             # Handle different message types
@@ -480,9 +492,10 @@ class SubscriptionManager:
 
                                 if payload.get("data"):
                                     logger.info(
-                                        f"[DATA:{subscription_name}] Received subscription data update"
+                                        "[DATA:%s] Received subscription data update",
+                                        subscription_name,
                                     )
-                                    _clear_graphql_error_burst(subscription_name)
+                                    self._clear_graphql_error_burst(subscription_name)
                                     capped_data = (
                                         _cap_log_content(payload["data"])
                                         if isinstance(payload["data"], dict)
@@ -492,22 +505,22 @@ class SubscriptionManager:
                                     new_entry = SubscriptionData(
                                         data=capped_data,
                                         last_updated=datetime.now(UTC),
-                                        subscription_type=subscription_name,
                                     )
                                     async with self._data_lock:
                                         self.resource_data[subscription_name] = new_entry
                                     logger.debug(
-                                        f"[RESOURCE:{subscription_name}] Resource data updated successfully"
+                                        "[RESOURCE:%s] Resource data updated successfully",
+                                        subscription_name,
                                     )
                                 elif payload.get("errors"):
                                     err_msg = str(payload["errors"])
-                                    prev = _last_graphql_error.get(subscription_name)
-                                    count = _graphql_error_count.get(subscription_name, 0) + 1
-                                    _graphql_error_count[subscription_name] = count
+                                    prev = self._last_graphql_error.get(subscription_name)
+                                    count = self._graphql_error_count.get(subscription_name, 0) + 1
+                                    self._graphql_error_count[subscription_name] = count
                                     if prev != err_msg:
                                         # First occurrence of this error — log as warning
-                                        _last_graphql_error[subscription_name] = err_msg
-                                        _graphql_error_count[subscription_name] = 1
+                                        self._last_graphql_error[subscription_name] = err_msg
+                                        self._graphql_error_count[subscription_name] = 1
                                         logger.warning(
                                             "[DATA:%s] GraphQL error (will suppress repeats): %s",
                                             subscription_name,
@@ -532,47 +545,64 @@ class SubscriptionManager:
                                     )
                                 else:
                                     logger.warning(
-                                        f"[DATA:{subscription_name}] Empty or invalid data payload: {payload}"
+                                        "[DATA:%s] Empty or invalid data payload: %s",
+                                        subscription_name,
+                                        payload,
                                     )
 
                             elif data.get("type") == "ping":
                                 logger.debug(
-                                    f"[PROTOCOL:{subscription_name}] Received ping, sending pong"
+                                    "[PROTOCOL:%s] Received ping, sending pong",
+                                    subscription_name,
                                 )
                                 await websocket.send(json.dumps({"type": "pong"}))
 
                             elif data.get("type") == "error":
                                 error_payload = data.get("payload", {})
                                 logger.error(
-                                    f"[SUBSCRIPTION:{subscription_name}] Subscription error: {error_payload}"
+                                    "[SUBSCRIPTION:%s] Subscription error: %s",
+                                    subscription_name,
+                                    error_payload,
                                 )
-                                self.last_error[subscription_name] = (
-                                    f"Subscription error: {error_payload}"
+                                self._set_connection_state(
+                                    subscription_name,
+                                    "error",
+                                    f"Subscription error: {error_payload}",
                                 )
-                                self.connection_states[subscription_name] = "error"
 
                             elif data.get("type") == "complete":
                                 logger.info(
-                                    f"[SUBSCRIPTION:{subscription_name}] Subscription completed by server"
+                                    "[SUBSCRIPTION:%s] Subscription completed by server",
+                                    subscription_name,
                                 )
-                                self.connection_states[subscription_name] = "completed"
+                                self._set_connection_state(subscription_name, "completed")
                                 break
 
                             elif data.get("type") in ["ka", "pong"]:
                                 logger.debug(
-                                    f"[PROTOCOL:{subscription_name}] Keepalive message: {message_type}"
+                                    "[PROTOCOL:%s] Keepalive message: %s",
+                                    subscription_name,
+                                    message_type,
                                 )
 
                             else:
                                 logger.debug(
-                                    f"[PROTOCOL:{subscription_name}] Unhandled message type: {message_type}"
+                                    "[PROTOCOL:%s] Unhandled message type: %s",
+                                    subscription_name,
+                                    message_type,
                                 )
 
                         except json.JSONDecodeError as e:
                             logger.error(
-                                f"[PROTOCOL:{subscription_name}] Failed to decode message: {_preview(message)}..."
+                                "[PROTOCOL:%s] Failed to decode message: %s...",
+                                subscription_name,
+                                _preview(message),
                             )
-                            logger.error(f"[PROTOCOL:{subscription_name}] JSON decode error: {e}")
+                            logger.error(
+                                "[PROTOCOL:%s] JSON decode error: %s",
+                                subscription_name,
+                                e,
+                            )
                         except Exception as e:
                             logger.error(
                                 f"[DATA:{subscription_name}] Error processing message: {e}",
@@ -585,35 +615,30 @@ class SubscriptionManager:
             except TimeoutError:
                 error_msg = "Connection or authentication timeout"
                 logger.error(f"[WEBSOCKET:{subscription_name}] {error_msg}")
-                self.last_error[subscription_name] = error_msg
-                self.connection_states[subscription_name] = "timeout"
+                self._set_connection_state(subscription_name, "timeout", error_msg)
 
             except websockets.exceptions.ConnectionClosed as e:
                 error_msg = f"WebSocket connection closed: {e}"
                 logger.warning(f"[WEBSOCKET:{subscription_name}] {error_msg}")
-                self.last_error[subscription_name] = error_msg
-                self.connection_states[subscription_name] = "disconnected"
+                self._set_connection_state(subscription_name, "disconnected", error_msg)
 
             except websockets.exceptions.InvalidURI as e:
                 error_msg = f"Invalid WebSocket URI: {e}"
                 logger.error(f"[WEBSOCKET:{subscription_name}] {error_msg}")
-                self.last_error[subscription_name] = error_msg
-                self.connection_states[subscription_name] = "invalid_uri"
+                self._set_connection_state(subscription_name, "invalid_uri", error_msg)
                 break  # Don't retry on invalid URI
 
             except ValueError as e:
                 # Non-retryable configuration error (e.g. UNRAID_API_URL not set)
                 error_msg = f"Configuration error: {e}"
                 logger.error(f"[WEBSOCKET:{subscription_name}] {error_msg}")
-                self.last_error[subscription_name] = error_msg
-                self.connection_states[subscription_name] = "error"
+                self._set_connection_state(subscription_name, "error", error_msg)
                 break  # Don't retry on configuration errors
 
             except Exception as e:
                 error_msg = f"Unexpected error: {e}"
                 logger.error(f"[WEBSOCKET:{subscription_name}] {error_msg}", exc_info=True)
-                self.last_error[subscription_name] = error_msg
-                self.connection_states[subscription_name] = "error"
+                self._set_connection_state(subscription_name, "error", error_msg)
 
             # Check if connection was stable before deciding on retry behavior
             start_time = self._connection_start_times.pop(subscription_name, None)
@@ -642,7 +667,7 @@ class SubscriptionManager:
             logger.info(
                 f"[WEBSOCKET:{subscription_name}] Reconnecting in {retry_delay:.1f} seconds..."
             )
-            self.connection_states[subscription_name] = "reconnecting"
+            self._set_connection_state(subscription_name, "reconnecting")
             await asyncio.sleep(retry_delay)
 
         # The while loop exited (via break or max_retries exceeded).
@@ -657,21 +682,35 @@ class SubscriptionManager:
 
     async def get_resource_data(self, resource_name: str) -> dict[str, Any] | None:
         """Get current resource data with enhanced logging."""
-        logger.debug(f"[RESOURCE:{resource_name}] Resource data requested")
+        logger.debug("[RESOURCE:%s] Resource data requested", resource_name)
 
         async with self._data_lock:
             if resource_name in self.resource_data:
                 data = self.resource_data[resource_name]
                 age_seconds = (datetime.now(UTC) - data.last_updated).total_seconds()
-                logger.debug(f"[RESOURCE:{resource_name}] Data found, age: {age_seconds:.1f}s")
+                logger.debug("[RESOURCE:%s] Data found, age: %.1fs", resource_name, age_seconds)
                 return data.data
-        logger.debug(f"[RESOURCE:{resource_name}] No data available")
+        logger.debug("[RESOURCE:%s] No data available", resource_name)
         return None
 
-    def list_active_subscriptions(self) -> list[str]:
+    async def get_resource_data_with_timestamp(
+        self, resource_name: str
+    ) -> tuple[dict[str, Any], str] | None:
+        """Get resource data along with its last-updated ISO timestamp.
+
+        Returns (data_dict, iso_timestamp) or None if no data is available.
+        """
+        async with self._data_lock:
+            if resource_name in self.resource_data:
+                entry = self.resource_data[resource_name]
+                return entry.data, entry.last_updated.isoformat()
+        return None
+
+    async def list_active_subscriptions(self) -> list[str]:
         """List all active subscriptions."""
-        active = list(self.active_subscriptions.keys())
-        logger.debug(f"[SUBSCRIPTION_MANAGER] Active subscriptions: {active}")
+        async with self._task_lock:
+            active = list(self.active_subscriptions.keys())
+        logger.debug("[SUBSCRIPTION_MANAGER] Active subscriptions: %s", active)
         return active
 
     async def get_error_state(self, name: str) -> tuple[str | None, str]:
@@ -681,12 +720,10 @@ class SubscriptionManager:
         private lock attributes directly.
 
         Consistency note: _subscription_loop writes connection_states and
-        last_error without holding _task_lock (it runs as an asyncio Task with
-        no await between the two writes). The pair is consistent because asyncio
-        cooperative scheduling prevents interleaving at non-await points — not
-        because of the lock. _task_lock here prevents two *readers* from racing
-        each other, not writers. If an await is ever introduced between the two
-        write sites in _subscription_loop, this guarantee breaks.
+        last_error together via _set_connection_state() which contains no
+        ``await``, so asyncio cooperative scheduling guarantees the pair is
+        consistent. _task_lock here prevents two *readers* from racing each
+        other, not writers.
         """
         async with self._task_lock:
             return (

--- a/unraid_mcp/subscriptions/queries.py
+++ b/unraid_mcp/subscriptions/queries.py
@@ -40,6 +40,12 @@ SNAPSHOT_ACTIONS = {
     "server_status": """
         subscription { serversSubscription { id name status guid wanip lanip localurl remoteurl } }
     """,
+    "docker_container_stats": """
+        subscription { dockerContainerStats { id cpuPercent memUsage memPercent netIO blockIO } }
+    """,
+    "temperature": """
+        subscription { systemMetricsTemperature { id sensors { id name type location current { value unit status } } summary { average hottest { id name current { value unit status } } coolest { id name current { value unit status } } warningCount criticalCount } } }
+    """,
 }
 
 COLLECT_ACTIONS = {

--- a/unraid_mcp/subscriptions/resources.py
+++ b/unraid_mcp/subscriptions/resources.py
@@ -97,9 +97,10 @@ def register_subscription_resources(mcp: FastMCP) -> None:
     async def logs_stream_resource() -> str:
         """Real-time log stream data from subscription."""
         await ensure_subscriptions_started()
-        data = await subscription_manager.get_resource_data("logFileSubscription")
-        if data is not None:
-            return json.dumps(data, indent=2)
+        result = await subscription_manager.get_resource_data_with_timestamp("logFileSubscription")
+        if result is not None:
+            data, fetched_at = result
+            return json.dumps({**data, "_fetched_at": fetched_at}, indent=2)
         return json.dumps(
             {
                 "status": "No subscription data yet",
@@ -110,9 +111,10 @@ def register_subscription_resources(mcp: FastMCP) -> None:
     def _make_resource_fn(action: str) -> Callable[[], Coroutine[Any, Any, str]]:
         async def _live_resource() -> str:
             await ensure_subscriptions_started()
-            data = await subscription_manager.get_resource_data(action)
-            if data is not None:
-                return json.dumps(data, indent=2)
+            result = await subscription_manager.get_resource_data_with_timestamp(action)
+            if result is not None:
+                data, fetched_at = result
+                return json.dumps({**data, "_fetched_at": fetched_at}, indent=2)
             # Surface permanent errors only when the connection is in a terminal failure
             # state — if the subscription has since reconnected, ignore the stale error.
             # Use the public get_error_state() accessor so we never touch private

--- a/unraid_mcp/subscriptions/snapshot.py
+++ b/unraid_mcp/subscriptions/snapshot.py
@@ -13,6 +13,7 @@ Use the SubscriptionManager for long-lived monitoring resources.
 
 import asyncio
 import json
+from contextlib import asynccontextmanager
 from typing import Any
 
 import websockets
@@ -23,14 +24,19 @@ from ..core.exceptions import ToolError
 from .utils import build_connection_init, build_ws_ssl_context, build_ws_url
 
 
-async def subscribe_once(
+_SUB_ID = "snapshot-1"
+
+
+@asynccontextmanager
+async def _ws_handshake(
     query: str,
     variables: dict[str, Any] | None = None,
-    timeout: float = 10.0,  # noqa: ASYNC109
-) -> dict[str, Any]:
-    """Open a WebSocket subscription, receive the first data event, close, return it.
+    timeout: float = 10.0,
+):
+    """Connect, authenticate, and subscribe over WebSocket.
 
-    Raises ToolError on auth failure, GraphQL errors, or timeout.
+    Yields (ws, proto, expected_type) after the subscription is active.
+    The caller iterates on ws for data events.
     """
     ws_url = build_ws_url()
     ssl_context = build_ws_ssl_context(ws_url)
@@ -44,7 +50,6 @@ async def subscribe_once(
         ssl=ssl_context,
     ) as ws:
         proto = ws.subprotocol or "graphql-transport-ws"
-        sub_id = "snapshot-1"
 
         # Handshake
         await ws.send(json.dumps(build_connection_init()))
@@ -61,16 +66,27 @@ async def subscribe_once(
         await ws.send(
             json.dumps(
                 {
-                    "id": sub_id,
+                    "id": _SUB_ID,
                     "type": start_type,
                     "payload": {"query": query, "variables": variables or {}},
                 }
             )
         )
 
-        # Await first matching data event
         expected_type = "next" if proto == "graphql-transport-ws" else "data"
+        yield ws, expected_type
 
+
+async def subscribe_once(
+    query: str,
+    variables: dict[str, Any] | None = None,
+    timeout: float = 10.0,  # noqa: ASYNC109
+) -> dict[str, Any]:
+    """Open a WebSocket subscription, receive the first data event, close, return it.
+
+    Raises ToolError on auth failure, GraphQL errors, or timeout.
+    """
+    async with _ws_handshake(query, variables, timeout) as (ws, expected_type):
         try:
             async with asyncio.timeout(timeout):
                 async for raw_msg in ws:
@@ -78,19 +94,19 @@ async def subscribe_once(
                     if msg.get("type") == "ping":
                         await ws.send(json.dumps({"type": "pong"}))
                         continue
-                    if msg.get("type") == expected_type and msg.get("id") == sub_id:
+                    if msg.get("type") == expected_type and msg.get("id") == _SUB_ID:
                         payload = msg.get("payload", {})
                         if errors := payload.get("errors"):
                             msgs = "; ".join(e.get("message", str(e)) for e in errors)
                             raise ToolError(f"Subscription errors: {msgs}")
                         if data := payload.get("data"):
                             return data
-                    elif msg.get("type") == "error" and msg.get("id") == sub_id:
+                    elif msg.get("type") == "error" and msg.get("id") == _SUB_ID:
                         raise ToolError(f"Subscription error: {msg.get('payload')}")
         except TimeoutError:
             raise ToolError(f"Subscription timed out after {timeout:.0f}s") from None
 
-        raise ToolError("WebSocket closed before receiving subscription data")
+    raise ToolError("WebSocket closed before receiving subscription data")
 
 
 async def subscribe_collect(
@@ -104,43 +120,9 @@ async def subscribe_collect(
     Returns an empty list if no events arrive within the window.
     Always closes the connection after the window expires.
     """
-    ws_url = build_ws_url()
-    ssl_context = build_ws_ssl_context(ws_url)
     events: list[dict[str, Any]] = []
 
-    async with websockets.connect(
-        ws_url,
-        subprotocols=[Subprotocol("graphql-transport-ws"), Subprotocol("graphql-ws")],
-        open_timeout=timeout,
-        ping_interval=20,
-        ping_timeout=10,
-        ssl=ssl_context,
-    ) as ws:
-        proto = ws.subprotocol or "graphql-transport-ws"
-        sub_id = "snapshot-1"
-
-        await ws.send(json.dumps(build_connection_init()))
-
-        raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
-        ack = json.loads(raw)
-        if ack.get("type") == "connection_error":
-            raise ToolError(f"Subscription auth failed: {ack.get('payload')}")
-        if ack.get("type") != "connection_ack":
-            raise ToolError(f"Unexpected handshake response: {ack.get('type')}")
-
-        start_type = "subscribe" if proto == "graphql-transport-ws" else "start"
-        await ws.send(
-            json.dumps(
-                {
-                    "id": sub_id,
-                    "type": start_type,
-                    "payload": {"query": query, "variables": variables or {}},
-                }
-            )
-        )
-
-        expected_type = "next" if proto == "graphql-transport-ws" else "data"
-
+    async with _ws_handshake(query, variables, timeout) as (ws, expected_type):
         try:
             async with asyncio.timeout(collect_for):
                 async for raw_msg in ws:
@@ -148,7 +130,7 @@ async def subscribe_collect(
                     if msg.get("type") == "ping":
                         await ws.send(json.dumps({"type": "pong"}))
                         continue
-                    if msg.get("type") == expected_type and msg.get("id") == sub_id:
+                    if msg.get("type") == expected_type and msg.get("id") == _SUB_ID:
                         payload = msg.get("payload", {})
                         if errors := payload.get("errors"):
                             msgs = "; ".join(e.get("message", str(e)) for e in errors)
@@ -158,5 +140,5 @@ async def subscribe_collect(
         except TimeoutError:
             pass  # Collection window expired — return whatever was collected
 
-    logger.debug(f"[SNAPSHOT] Collected {len(events)} events in {collect_for}s window")
+    logger.debug("Collected %d events in %.1fs window", len(events), collect_for)
     return events

--- a/unraid_mcp/tools/_array.py
+++ b/unraid_mcp/tools/_array.py
@@ -12,6 +12,7 @@ from fastmcp import Context
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import validate_subaction
 from ..core.guards import gate_destructive_action
 
 
@@ -50,10 +51,7 @@ async def _handle_array(
     ctx: Context | None,
     confirm: bool,
 ) -> dict[str, Any]:
-    if subaction not in _ARRAY_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for array. Must be one of: {sorted(_ARRAY_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _ARRAY_SUBACTIONS, "array")
 
     await gate_destructive_action(
         ctx,

--- a/unraid_mcp/tools/_customization.py
+++ b/unraid_mcp/tools/_customization.py
@@ -8,6 +8,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import safe_get, validate_subaction
 
 
 # ===========================================================================
@@ -29,10 +30,7 @@ _CUSTOMIZATION_SUBACTIONS: set[str] = set(_CUSTOMIZATION_QUERIES) | set(_CUSTOMI
 
 
 async def _handle_customization(subaction: str, theme_name: str | None) -> dict[str, Any]:
-    if subaction not in _CUSTOMIZATION_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for customization. Must be one of: {sorted(_CUSTOMIZATION_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _CUSTOMIZATION_SUBACTIONS, "customization")
 
     with tool_error_handler("customization", subaction, logger):
         logger.info(f"Executing unraid action=customization subaction={subaction}")
@@ -54,7 +52,7 @@ async def _handle_customization(subaction: str, theme_name: str | None) -> dict[
             return {
                 "success": True,
                 "subaction": "set_theme",
-                "data": (data.get("customization") or {}).get("setTheme"),
+                "data": safe_get(data, "customization", "setTheme"),
             }
 
         raise ToolError(f"Unhandled customization subaction '{subaction}' — this is a bug")

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -13,7 +13,7 @@ from ..core import client as _client
 from ..core.client import DISK_TIMEOUT
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
-from ..core.utils import format_bytes
+from ..core.utils import format_bytes, validate_subaction
 
 
 # ===========================================================================
@@ -75,10 +75,7 @@ async def _handle_disk(
     ctx: Context | None,
     confirm: bool,
 ) -> dict[str, Any]:
-    if subaction not in _DISK_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for disk. Must be one of: {sorted(_DISK_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _DISK_SUBACTIONS, "disk")
 
     await gate_destructive_action(
         ctx,
@@ -88,52 +85,54 @@ async def _handle_disk(
         f"Back up flash drive to **{remote_name}:{destination_path}**. Existing backups will be overwritten.",
     )
 
-    if subaction == "disk_details" and not disk_id:
-        raise ToolError("disk_id is required for disk/disk_details")
+    with tool_error_handler("disk", subaction, logger):
+        if subaction == "disk_details" and not disk_id:
+            raise ToolError("disk_id is required for disk/disk_details")
 
-    if subaction == "logs":
-        if tail_lines < 1 or tail_lines > _MAX_TAIL_LINES:
-            raise ToolError(f"tail_lines must be between 1 and {_MAX_TAIL_LINES}, got {tail_lines}")
-        if not log_path:
-            raise ToolError("log_path is required for disk/logs")
-        log_path = _validate_path(log_path, _ALLOWED_LOG_PREFIXES, "log_path")
+        if subaction == "logs":
+            if tail_lines < 1 or tail_lines > _MAX_TAIL_LINES:
+                raise ToolError(
+                    f"tail_lines must be between 1 and {_MAX_TAIL_LINES}, got {tail_lines}"
+                )
+            if not log_path:
+                raise ToolError("log_path is required for disk/logs")
+            log_path = _validate_path(log_path, _ALLOWED_LOG_PREFIXES, "log_path")
 
-    if subaction == "flash_backup":
-        if not remote_name:
-            raise ToolError("remote_name is required for disk/flash_backup")
-        if not source_path:
-            raise ToolError("source_path is required for disk/flash_backup")
-        if not destination_path:
-            raise ToolError("destination_path is required for disk/flash_backup")
-        # Validate paths — flash backup source must come from /boot/ only.
-        # NOTE: _validate_path is not reused here because its prefix check uses
-        # startswith(), which would allow '/bootleg/...' to pass '/boot' prefix.
-        # The correct check is (normalized == "/boot" or startswith("/boot/")),
-        # which requires an inline implementation.
-        if "\x00" in source_path:
-            raise ToolError("source_path must not contain null bytes")
-        # Normalize BEFORE checking '..' — raw-string check is bypassable via
-        # encoded sequences like 'foo/bar/../..'.
-        normalized = posixpath.normpath(source_path)
-        if ".." in normalized.split("/"):
-            raise ToolError("source_path must not contain path traversal sequences (../)")
-        if not (normalized == "/boot" or normalized.startswith("/boot/")):
-            raise ToolError("source_path must start with /boot/ (flash drive only)")
-        source_path = normalized
-        if "\x00" in destination_path:
-            raise ToolError("destination_path must not contain null bytes")
-        normalized_dest = posixpath.normpath(destination_path)
-        if ".." in normalized_dest.split("/"):
-            raise ToolError("destination_path must not contain path traversal sequences (../)")
-        destination_path = normalized_dest
-        input_data: dict[str, Any] = {
-            "remoteName": remote_name,
-            "sourcePath": source_path,
-            "destinationPath": destination_path,
-        }
-        if backup_options is not None:
-            input_data["options"] = backup_options
-        with tool_error_handler("disk", subaction, logger):
+        if subaction == "flash_backup":
+            if not remote_name:
+                raise ToolError("remote_name is required for disk/flash_backup")
+            if not source_path:
+                raise ToolError("source_path is required for disk/flash_backup")
+            if not destination_path:
+                raise ToolError("destination_path is required for disk/flash_backup")
+            # Validate paths — flash backup source must come from /boot/ only.
+            # NOTE: _validate_path is not reused here because its prefix check uses
+            # startswith(), which would allow '/bootleg/...' to pass '/boot' prefix.
+            # The correct check is (normalized == "/boot" or startswith("/boot/")),
+            # which requires an inline implementation.
+            if "\x00" in source_path:
+                raise ToolError("source_path must not contain null bytes")
+            # Normalize BEFORE checking '..' �� raw-string check is bypassable via
+            # encoded sequences like 'foo/bar/../..'.
+            normalized = posixpath.normpath(source_path)
+            if ".." in normalized.split("/"):
+                raise ToolError("source_path must not contain path traversal sequences (../)")
+            if not (normalized == "/boot" or normalized.startswith("/boot/")):
+                raise ToolError("source_path must start with /boot/ (flash drive only)")
+            source_path = normalized
+            if "\x00" in destination_path:
+                raise ToolError("destination_path must not contain null bytes")
+            normalized_dest = posixpath.normpath(destination_path)
+            if ".." in normalized_dest.split("/"):
+                raise ToolError("destination_path must not contain path traversal sequences (../)")
+            destination_path = normalized_dest
+            input_data: dict[str, Any] = {
+                "remoteName": remote_name,
+                "sourcePath": source_path,
+                "destinationPath": destination_path,
+            }
+            if backup_options is not None:
+                input_data["options"] = backup_options
             logger.info(
                 f"Executing unraid action=disk subaction={subaction} remote={remote_name!r} source={source_path!r} dest={destination_path!r}"
             )
@@ -145,14 +144,13 @@ async def _handle_disk(
                 raise ToolError("Failed to start flash backup: no confirmation from server")
             return {"success": True, "subaction": "flash_backup", "data": backup}
 
-    custom_timeout = DISK_TIMEOUT if subaction in ("disks", "disk_details") else None
-    variables: dict[str, Any] | None = None
-    if subaction == "disk_details":
-        variables = {"id": disk_id}
-    elif subaction == "logs":
-        variables = {"path": log_path, "lines": tail_lines}
+        custom_timeout = DISK_TIMEOUT if subaction in ("disks", "disk_details") else None
+        variables: dict[str, Any] | None = None
+        if subaction == "disk_details":
+            variables = {"id": disk_id}
+        elif subaction == "logs":
+            variables = {"path": log_path, "lines": tail_lines}
 
-    with tool_error_handler("disk", subaction, logger):
         logger.info(f"Executing unraid action=disk subaction={subaction}")
         data = await _client.make_graphql_request(
             _DISK_QUERIES[subaction], variables, custom_timeout=custom_timeout

--- a/unraid_mcp/tools/_docker.py
+++ b/unraid_mcp/tools/_docker.py
@@ -9,6 +9,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import validate_subaction
 from ..core.utils import safe_get
 
 
@@ -101,10 +102,7 @@ async def _resolve_container_id(container_id: str, *, strict: bool = False) -> s
 async def _handle_docker(
     subaction: str, container_id: str | None, network_id: str | None
 ) -> dict[str, Any]:
-    if subaction not in _DOCKER_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for docker. Must be one of: {sorted(_DOCKER_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _DOCKER_SUBACTIONS, "docker")
     if subaction in _DOCKER_NEEDS_CONTAINER_ID and not container_id:
         raise ToolError(f"container_id is required for docker/{subaction}")
     if subaction == "network_details" and not network_id:

--- a/unraid_mcp/tools/_health.py
+++ b/unraid_mcp/tools/_health.py
@@ -14,6 +14,7 @@ import httpx
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import CredentialsNotConfiguredError
+from ..core.utils import safe_get
 
 
 # Import system online query to avoid duplication — used by setup and test_connection
@@ -85,8 +86,8 @@ async def _comprehensive_health_check() -> dict[str, Any]:
                 "status": "connected",
                 "url": safe_display_url(UNRAID_API_URL),
                 "machine_id": info.get("machineId"),
-                "version": ((info.get("versions") or {}).get("core") or {}).get("unraid"),
-                "uptime": (info.get("os") or {}).get("uptime"),
+                "version": safe_get(info, "versions", "core", "unraid"),
+                "uptime": safe_get(info, "os", "uptime"),
             }
         else:
             _escalate("degraded")

--- a/unraid_mcp/tools/_key.py
+++ b/unraid_mcp/tools/_key.py
@@ -1,6 +1,6 @@
 """Key domain handler for the Unraid MCP tool.
 
-Covers: list, get, create, update, delete*, add_role, remove_role (7 subactions).
+Covers: list, get, possible_roles, create, update, delete*, add_role, remove_role (8 subactions).
 """
 
 from typing import Any
@@ -11,6 +11,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.utils import safe_get, validate_subaction
 
 
 # ===========================================================================
@@ -20,6 +21,7 @@ from ..core.guards import gate_destructive_action
 _KEY_QUERIES: dict[str, str] = {
     "list": "query ListApiKeys { apiKeys { id name roles permissions { resource actions } createdAt } }",
     "get": "query GetApiKey($id: PrefixedID!) { apiKey(id: $id) { id name roles permissions { resource actions } createdAt } }",
+    "possible_roles": "query GetPossibleRoles { apiKeyPossibleRoles }",
 }
 
 _KEY_MUTATIONS: dict[str, str] = {
@@ -43,10 +45,7 @@ async def _handle_key(
     ctx: Context | None,
     confirm: bool,
 ) -> dict[str, Any]:
-    if subaction not in _KEY_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for key. Must be one of: {sorted(_KEY_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _KEY_SUBACTIONS, "key")
 
     await gate_destructive_action(
         ctx,
@@ -63,6 +62,11 @@ async def _handle_key(
             data = await _client.make_graphql_request(_KEY_QUERIES["list"])
             keys = data.get("apiKeys", [])
             return {"keys": list(keys) if isinstance(keys, list) else []}
+
+        if subaction == "possible_roles":
+            data = await _client.make_graphql_request(_KEY_QUERIES["possible_roles"])
+            roles_list = data.get("apiKeyPossibleRoles", [])
+            return {"roles": list(roles_list) if isinstance(roles_list, list) else []}
 
         if subaction == "get":
             if not key_id:
@@ -81,7 +85,7 @@ async def _handle_key(
             data = await _client.make_graphql_request(
                 _KEY_MUTATIONS["create"], {"input": input_data}
             )
-            created_key = (data.get("apiKey") or {}).get("create")
+            created_key = safe_get(data, "apiKey", "create")
             if not created_key:
                 raise ToolError("Failed to create API key: no data returned from server")
             return {"success": True, "key": created_key}
@@ -99,7 +103,7 @@ async def _handle_key(
             data = await _client.make_graphql_request(
                 _KEY_MUTATIONS["update"], {"input": input_data}
             )
-            updated_key = (data.get("apiKey") or {}).get("update")
+            updated_key = safe_get(data, "apiKey", "update")
             if not updated_key:
                 raise ToolError("Failed to update API key: no data returned from server")
             return {"success": True, "key": updated_key}
@@ -110,7 +114,7 @@ async def _handle_key(
             data = await _client.make_graphql_request(
                 _KEY_MUTATIONS["delete"], {"input": {"ids": [key_id]}}
             )
-            if not (data.get("apiKey") or {}).get("delete"):
+            if not safe_get(data, "apiKey", "delete"):
                 raise ToolError(f"Failed to delete API key '{key_id}': no confirmation from server")
             return {"success": True, "message": f"API key '{key_id}' deleted"}
 

--- a/unraid_mcp/tools/_live.py
+++ b/unraid_mcp/tools/_live.py
@@ -1,7 +1,8 @@
 """Live (subscriptions) domain handler for the Unraid MCP tool.
 
 Covers: cpu, memory, cpu_telemetry, array_state, parity_progress, ups_status,
-notifications_overview, notification_feed, log_tail, owner, server_status (11 subactions).
+notifications_overview, notification_feed, log_tail, owner, server_status,
+docker_container_stats, temperature (13 subactions).
 """
 
 from typing import Any
@@ -15,37 +16,6 @@ from ._disk import _ALLOWED_LOG_PREFIXES, _validate_path
 # LIVE (subscriptions)
 # ===========================================================================
 
-# Tracks which COLLECT_ACTIONS keys have explicit handlers in _handle_live below.
-# IMPORTANT: Every key in COLLECT_ACTIONS must appear here AND have a matching
-# if-branch in _handle_live. Adding to COLLECT_ACTIONS without updating both
-# this set and the function body causes a ToolError("this is a bug") at runtime.
-_HANDLED_COLLECT_SUBACTIONS: frozenset[str] = frozenset({"log_tail", "notification_feed"})
-
-
-def _assert_collect_subactions_complete() -> None:
-    """Raise RuntimeError at import time if collect subactions drift.
-
-    Every key in COLLECT_ACTIONS must appear in _HANDLED_COLLECT_SUBACTIONS AND
-    have a matching if-branch in _handle_live. This assertion catches the former
-    at import time so the omission is caught before reaching the runtime ToolError.
-    """
-    from ..subscriptions.queries import COLLECT_ACTIONS
-
-    missing = set(COLLECT_ACTIONS) - _HANDLED_COLLECT_SUBACTIONS
-    stale = _HANDLED_COLLECT_SUBACTIONS - set(COLLECT_ACTIONS)
-    if missing:
-        raise RuntimeError(
-            f"_HANDLED_COLLECT_SUBACTIONS is missing keys from COLLECT_ACTIONS: {missing}. "
-            "Add a handler branch in _handle_live and update _HANDLED_COLLECT_SUBACTIONS."
-        )
-    if stale:
-        raise RuntimeError(
-            f"_HANDLED_COLLECT_SUBACTIONS contains stale keys not present in COLLECT_ACTIONS: {stale}."
-        )
-
-
-_assert_collect_subactions_complete()
-
 
 async def _handle_live(
     subaction: str,
@@ -53,16 +23,14 @@ async def _handle_live(
     collect_for: float,
     timeout: float,  # noqa: ASYNC109
 ) -> dict[str, Any]:
+    # IMPORTANT: Every key in COLLECT_ACTIONS must have an explicit handler in _handle_live below.
+    # Adding to COLLECT_ACTIONS without updating this function causes a ToolError at runtime.
+    from ..core.utils import validate_subaction
     from ..subscriptions.queries import COLLECT_ACTIONS, EVENT_DRIVEN_ACTIONS, SNAPSHOT_ACTIONS
     from ..subscriptions.snapshot import subscribe_collect, subscribe_once
 
-    # IMPORTANT: Every key in COLLECT_ACTIONS must have an explicit handler in _handle_live below.
-    # Adding to COLLECT_ACTIONS without updating this function causes a ToolError at runtime.
     all_live = set(SNAPSHOT_ACTIONS) | set(COLLECT_ACTIONS)
-    if subaction not in all_live:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for live. Must be one of: {sorted(all_live)}"
-        )
+    validate_subaction(subaction, all_live, "live")
 
     if subaction == "log_tail":
         if not path:

--- a/unraid_mcp/tools/_notification.py
+++ b/unraid_mcp/tools/_notification.py
@@ -1,7 +1,7 @@
 """Notification domain handler for the Unraid MCP tool.
 
-Covers: overview, list, create, archive, mark_unread, recalculate, archive_all,
-archive_many, unarchive_many, unarchive_all, delete*, delete_archived* (12 subactions).
+Covers: overview, list, create, notify_if_unique, archive, mark_unread, recalculate,
+archive_all, archive_many, unarchive_many, unarchive_all, delete*, delete_archived* (13 subactions).
 """
 
 from typing import Any
@@ -12,6 +12,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.utils import safe_get, validate_subaction
 
 
 # ===========================================================================
@@ -34,6 +35,7 @@ _NOTIFICATION_MUTATIONS: dict[str, str] = {
     "unarchive_many": "mutation UnarchiveNotifications($ids: [PrefixedID!]!) { unarchiveNotifications(ids: $ids) { unread { info warning alert total } archive { info warning alert total } } }",
     "unarchive_all": "mutation UnarchiveAll($importance: NotificationImportance) { unarchiveAll(importance: $importance) { unread { info warning alert total } archive { info warning alert total } } }",
     "recalculate": "mutation RecalculateOverview { recalculateOverview { unread { info warning alert total } archive { info warning alert total } } }",
+    "notify_if_unique": "mutation NotifyIfUnique($input: NotificationData!) { notifyIfUnique(input: $input) { id title importance } }",
 }
 
 _NOTIFICATION_SUBACTIONS: set[str] = set(_NOTIFICATION_QUERIES) | set(_NOTIFICATION_MUTATIONS)
@@ -57,10 +59,7 @@ async def _handle_notification(
     subject: str | None,
     description: str | None,
 ) -> dict[str, Any]:
-    if subaction not in _NOTIFICATION_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for notification. Must be one of: {sorted(_NOTIFICATION_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _NOTIFICATION_SUBACTIONS, "notification")
 
     await gate_destructive_action(
         ctx,
@@ -91,7 +90,7 @@ async def _handle_notification(
 
         if subaction == "overview":
             data = await _client.make_graphql_request(_NOTIFICATION_QUERIES["overview"])
-            return dict((data.get("notifications") or {}).get("overview") or {})
+            return dict(safe_get(data, "notifications", "overview", default={}))
 
         if subaction == "list":
             filter_vars: dict[str, Any] = {
@@ -104,7 +103,7 @@ async def _handle_notification(
             data = await _client.make_graphql_request(
                 _NOTIFICATION_QUERIES["list"], {"filter": filter_vars}
             )
-            return {"notifications": (data.get("notifications", {}) or {}).get("list", [])}
+            return {"notifications": safe_get(data, "notifications", "list", default=[])}
 
         if subaction == "create":
             if title is None or subject is None or description is None or importance is None:
@@ -132,6 +131,39 @@ async def _handle_notification(
             if notif is None:
                 raise ToolError("Notification creation failed: server returned no data")
             return {"success": True, "notification": notif}
+
+        if subaction == "notify_if_unique":
+            if title is None or subject is None or description is None or importance is None:
+                raise ToolError(
+                    "notify_if_unique requires title, subject, description, and importance"
+                )
+            if len(title) > 200:
+                raise ToolError(f"title must be at most 200 characters (got {len(title)})")
+            if len(subject) > 500:
+                raise ToolError(f"subject must be at most 500 characters (got {len(subject)})")
+            if len(description) > 2000:
+                raise ToolError(
+                    f"description must be at most 2000 characters (got {len(description)})"
+                )
+            data = await _client.make_graphql_request(
+                _NOTIFICATION_MUTATIONS["notify_if_unique"],
+                {
+                    "input": {
+                        "title": title,
+                        "subject": subject,
+                        "description": description,
+                        "importance": importance.upper(),
+                    }
+                },
+            )
+            notif = data.get("notifyIfUnique")
+            if notif is None:
+                return {
+                    "success": True,
+                    "duplicate": True,
+                    "message": "Equivalent unread notification already exists",
+                }
+            return {"success": True, "duplicate": False, "notification": notif}
 
         if subaction in ("archive", "mark_unread"):
             if not notification_id:

--- a/unraid_mcp/tools/_oidc.py
+++ b/unraid_mcp/tools/_oidc.py
@@ -8,6 +8,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import validate_subaction
 
 
 # ===========================================================================
@@ -28,10 +29,7 @@ _OIDC_SUBACTIONS: set[str] = set(_OIDC_QUERIES)
 async def _handle_oidc(
     subaction: str, provider_id: str | None, token: str | None
 ) -> dict[str, Any]:
-    if subaction not in _OIDC_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for oidc. Must be one of: {sorted(_OIDC_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _OIDC_SUBACTIONS, "oidc")
 
     if subaction == "provider" and not provider_id:
         raise ToolError("provider_id is required for oidc/provider")

--- a/unraid_mcp/tools/_plugin.py
+++ b/unraid_mcp/tools/_plugin.py
@@ -10,6 +10,7 @@ from fastmcp import Context
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import validate_subaction
 from ..core.guards import gate_destructive_action
 
 
@@ -38,10 +39,7 @@ async def _handle_plugin(
     ctx: Context | None,
     confirm: bool,
 ) -> dict[str, Any]:
-    if subaction not in _PLUGIN_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for plugin. Must be one of: {sorted(_PLUGIN_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _PLUGIN_SUBACTIONS, "plugin")
 
     await gate_destructive_action(
         ctx,

--- a/unraid_mcp/tools/_rclone.py
+++ b/unraid_mcp/tools/_rclone.py
@@ -11,7 +11,8 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
-from ..core.validation import DANGEROUS_KEY_PATTERN, MAX_VALUE_LENGTH
+from ..core.utils import safe_get, validate_subaction
+from ..core.validation import DANGEROUS_KEY_PATTERN, validate_scalar_mapping
 
 
 # ===========================================================================
@@ -31,28 +32,15 @@ _RCLONE_MUTATIONS: dict[str, str] = {
 _RCLONE_SUBACTIONS: set[str] = set(_RCLONE_QUERIES) | set(_RCLONE_MUTATIONS)
 _RCLONE_DESTRUCTIVE: set[str] = {"delete_remote"}
 _MAX_CONFIG_KEYS = 50
+_MAX_NAME_LENGTH = 128
 
 
-def _validate_rclone_config(config_data: dict[str, Any]) -> dict[str, str]:
-    if len(config_data) > _MAX_CONFIG_KEYS:
-        raise ToolError(f"config_data has {len(config_data)} keys (max {_MAX_CONFIG_KEYS})")
-    validated: dict[str, str] = {}
-    for key, value in config_data.items():
-        if not isinstance(key, str) or not key.strip():
-            raise ToolError(
-                f"config_data keys must be non-empty strings, got: {type(key).__name__}"
-            )
-        if DANGEROUS_KEY_PATTERN.search(key):
-            raise ToolError(f"config_data key '{key}' contains disallowed characters")
-        if not isinstance(value, (str, int, float, bool)):
-            raise ToolError(f"config_data['{key}'] must be a string, number, or boolean")
-        str_value = str(value)
-        if len(str_value) > MAX_VALUE_LENGTH:
-            raise ToolError(
-                f"config_data['{key}'] value exceeds max length ({len(str_value)} > {MAX_VALUE_LENGTH})"
-            )
-        validated[key] = str_value
-    return validated
+def _validate_rclone_name(value: str, label: str) -> None:
+    """Validate a top-level rclone field (name or provider_type)."""
+    if len(value) > _MAX_NAME_LENGTH:
+        raise ToolError(f"{label} exceeds max length ({len(value)} > {_MAX_NAME_LENGTH})")
+    if DANGEROUS_KEY_PATTERN.search(value):
+        raise ToolError(f"{label} contains disallowed characters")
 
 
 async def _handle_rclone(
@@ -63,10 +51,7 @@ async def _handle_rclone(
     ctx: Context | None,
     confirm: bool,
 ) -> dict[str, Any]:
-    if subaction not in _RCLONE_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for rclone. Must be one of: {sorted(_RCLONE_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _RCLONE_SUBACTIONS, "rclone")
 
     await gate_destructive_action(
         ctx,
@@ -81,7 +66,7 @@ async def _handle_rclone(
 
         if subaction == "list_remotes":
             data = await _client.make_graphql_request(_RCLONE_QUERIES["list_remotes"])
-            remotes = data.get("rclone", {}).get("remotes", [])
+            remotes = safe_get(data, "rclone", "remotes", default=[])
             return {"remotes": list(remotes) if isinstance(remotes, list) else []}
 
         if subaction == "config_form":
@@ -91,7 +76,7 @@ async def _handle_rclone(
             data = await _client.make_graphql_request(
                 _RCLONE_QUERIES["config_form"], variables or None
             )
-            form = (data.get("rclone") or {}).get("configForm", {})
+            form = safe_get(data, "rclone", "configForm", default={})
             if not form:
                 raise ToolError("No RClone config form data received")
             return dict(form)
@@ -99,12 +84,16 @@ async def _handle_rclone(
         if subaction == "create_remote":
             if name is None or provider_type is None or config_data is None:
                 raise ToolError("create_remote requires name, provider_type, and config_data")
-            validated = _validate_rclone_config(config_data)
+            _validate_rclone_name(name, "name")
+            _validate_rclone_name(provider_type, "provider_type")
+            validated = validate_scalar_mapping(
+                config_data, "config_data", max_keys=_MAX_CONFIG_KEYS, stringify=True
+            )
             data = await _client.make_graphql_request(
                 _RCLONE_MUTATIONS["create_remote"],
                 {"input": {"name": name, "type": provider_type, "parameters": validated}},
             )
-            remote = (data.get("rclone") or {}).get("createRCloneRemote")
+            remote = safe_get(data, "rclone", "createRCloneRemote")
             if not remote:
                 raise ToolError(f"Failed to create remote '{name}': no confirmation from server")
             return {
@@ -119,7 +108,7 @@ async def _handle_rclone(
             data = await _client.make_graphql_request(
                 _RCLONE_MUTATIONS["delete_remote"], {"input": {"name": name}}
             )
-            if not (data.get("rclone") or {}).get("deleteRCloneRemote", False):
+            if not safe_get(data, "rclone", "deleteRCloneRemote", default=False):
                 raise ToolError(f"Failed to delete remote '{name}'")
             return {"success": True, "message": f"Remote '{name}' deleted successfully"}
 

--- a/unraid_mcp/tools/_setting.py
+++ b/unraid_mcp/tools/_setting.py
@@ -10,8 +10,9 @@ from fastmcp import Context
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import validate_subaction
 from ..core.guards import gate_destructive_action
-from ..core.validation import DANGEROUS_KEY_PATTERN, MAX_VALUE_LENGTH
+from ..core.validation import DANGEROUS_KEY_PATTERN, validate_scalar_mapping
 
 
 # ===========================================================================
@@ -19,45 +20,6 @@ from ..core.validation import DANGEROUS_KEY_PATTERN, MAX_VALUE_LENGTH
 # ===========================================================================
 
 _MAX_SETTINGS_KEYS = 100
-
-
-def _validate_settings_mapping(settings_input: dict[str, Any]) -> dict[str, Any]:
-    """Validate flat scalar settings data before forwarding to the Unraid API.
-
-    Enforces a key count cap and rejects dangerous key names and oversized values
-    to prevent unvalidated bulk input from reaching the API. Modeled on
-    _validate_rclone_config in _rclone.py.
-
-    Only scalar values (str, int, float, bool) are accepted — dict/list values
-    cannot be accurately size-checked without JSON serialisation and may carry
-    nested injection payloads. Callers needing complex values should use the
-    raw GraphQL API instead.
-    """
-    if len(settings_input) > _MAX_SETTINGS_KEYS:
-        raise ToolError(f"settings_input has {len(settings_input)} keys (max {_MAX_SETTINGS_KEYS})")
-    validated: dict[str, Any] = {}
-    for key, value in settings_input.items():
-        if not isinstance(key, str) or not key.strip():
-            raise ToolError(
-                f"settings_input keys must be non-empty strings, got: {type(key).__name__}"
-            )
-        if DANGEROUS_KEY_PATTERN.search(key):
-            raise ToolError(f"settings_input key '{key}' contains disallowed characters")
-        if not isinstance(value, (str, int, float, bool)):
-            raise ToolError(
-                f"settings_input['{key}'] must be a string, number, or boolean, got: {type(value).__name__}"
-            )
-        str_value = str(value)
-        if len(str_value) > MAX_VALUE_LENGTH:
-            raise ToolError(
-                f"settings_input['{key}'] value exceeds max length ({len(str_value)} > {MAX_VALUE_LENGTH})"
-            )
-        # Store the original typed value, not str_value — callers (GraphQL mutations)
-        # expect int/float/bool to arrive as their native types, not stringified.
-        # _rclone.py differs: it always stringifies because rclone config values are
-        # strings on the wire; settings mutations accept JSON scalars directly.
-        validated[key] = value
-    return validated
 
 
 def _validate_json_settings_input(settings_input: dict[str, Any]) -> dict[str, Any]:
@@ -92,10 +54,7 @@ async def _handle_setting(
     ctx: Context | None,
     confirm: bool,
 ) -> dict[str, Any]:
-    if subaction not in _SETTING_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for setting. Must be one of: {sorted(_SETTING_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _SETTING_SUBACTIONS, "setting")
 
     await gate_destructive_action(
         ctx,
@@ -123,7 +82,9 @@ async def _handle_setting(
             # Validate ups_config with the same rules as settings_input — key count
             # cap, scalar-only values, MAX_VALUE_LENGTH — to prevent unvalidated bulk
             # input from reaching the GraphQL mutation.
-            validated_ups = _validate_settings_mapping(ups_config)
+            validated_ups = validate_scalar_mapping(
+                ups_config, "ups_config", max_keys=_MAX_SETTINGS_KEYS
+            )
             data = await _client.make_graphql_request(
                 _SETTING_MUTATIONS["configure_ups"], {"config": validated_ups}
             )

--- a/unraid_mcp/tools/_system.py
+++ b/unraid_mcp/tools/_system.py
@@ -2,7 +2,7 @@
 
 Covers: overview, array, network, registration, variables, metrics, services,
 display, config, online, owner, settings, server, servers, flash, ups_devices,
-ups_device, ups_config (18 subactions).
+ups_device, ups_config, server_time, timezones (20 subactions).
 """
 
 from typing import Any
@@ -10,7 +10,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
-from ..core.utils import format_kb
+from ..core.utils import format_kb, safe_get, validate_subaction
 
 
 # ===========================================================================
@@ -87,6 +87,8 @@ _SYSTEM_QUERIES: dict[str, str] = {
     "ups_devices": "query GetUpsDevices { upsDevices { id name model status battery { chargeLevel estimatedRuntime health } power { loadPercentage inputVoltage outputVoltage } } }",
     "ups_device": "query GetUpsDevice($id: String!) { upsDeviceById(id: $id) { id name model status battery { chargeLevel estimatedRuntime health } power { loadPercentage inputVoltage outputVoltage } } }",
     "ups_config": "query GetUpsConfig { upsConfiguration { service upsCable upsType device batteryLevel minutes timeout killUps upsName } }",
+    "server_time": "query GetSystemTime { systemTime { currentTime timeZone useNtp ntpServers } }",
+    "timezones": "query GetTimeZones { timeZoneOptions { value label } }",
 }
 
 _SYSTEM_SUBACTIONS: set[str] = set(_SYSTEM_QUERIES)
@@ -120,10 +122,7 @@ def _analyze_disk_health(disks: list[dict[str, Any]]) -> dict[str, int]:
 
 
 async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any]:
-    if subaction not in _SYSTEM_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for system. Must be one of: {sorted(_SYSTEM_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _SYSTEM_SUBACTIONS, "system")
 
     if subaction == "ups_device" and not device_id:
         raise ToolError("device_id is required for system/ups_device")
@@ -197,7 +196,7 @@ async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any
             return {"summary": summary, "details": raw}
 
         if subaction == "display":
-            return dict((data.get("info") or {}).get("display") or {})
+            return dict(safe_get(data, "info", "display", default={}))
         if subaction == "online":
             return {"online": data.get("online")}
         if subaction == "settings":
@@ -243,6 +242,7 @@ async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any
             "owner": "owner",
             "flash": "flash",
             "ups_config": "upsConfiguration",
+            "server_time": "systemTime",
         }
         if subaction in simple_dict:
             result = data.get(simple_dict[subaction])
@@ -259,6 +259,7 @@ async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any
             "services": ("services", "services"),
             "servers": ("servers", "servers"),
             "ups_devices": ("upsDevices", "ups_devices"),
+            "timezones": ("timeZoneOptions", "timezones"),
         }
         if subaction in list_actions:
             response_key, output_key = list_actions[subaction]

--- a/unraid_mcp/tools/_user.py
+++ b/unraid_mcp/tools/_user.py
@@ -8,6 +8,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.utils import validate_subaction
 
 
 # ===========================================================================
@@ -22,10 +23,7 @@ _USER_SUBACTIONS: set[str] = set(_USER_QUERIES)
 
 
 async def _handle_user(subaction: str) -> dict[str, Any]:
-    if subaction not in _USER_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for user. Must be one of: {sorted(_USER_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _USER_SUBACTIONS, "user")
 
     with tool_error_handler("user", subaction, logger):
         logger.info("Executing unraid action=user subaction=me")

--- a/unraid_mcp/tools/_vm.py
+++ b/unraid_mcp/tools/_vm.py
@@ -11,15 +11,19 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.utils import validate_subaction
 
 
 # ===========================================================================
 # VM
 # ===========================================================================
 
+# VmDomain only exposes id/name/state/uuid — no richer detail query exists in the
+# Unraid GraphQL schema, so "details" reuses the same query and filters client-side.
+_VM_LIST_QUERY = "query ListVMs { vms { id domains { id name state uuid } } }"
+
 _VM_QUERIES: dict[str, str] = {
-    "list": "query ListVMs { vms { id domains { id name state uuid } } }",
-    "details": "query ListVMs { vms { id domains { id name state uuid } } }",
+    "list": _VM_LIST_QUERY,
 }
 
 _VM_MUTATIONS: dict[str, str] = {
@@ -32,7 +36,7 @@ _VM_MUTATIONS: dict[str, str] = {
     "reset": "mutation ResetVM($id: PrefixedID!) { vm { reset(id: $id) } }",
 }
 
-_VM_SUBACTIONS: set[str] = set(_VM_QUERIES) | set(_VM_MUTATIONS)
+_VM_SUBACTIONS: set[str] = set(_VM_QUERIES) | set(_VM_MUTATIONS) | {"details"}
 _VM_DESTRUCTIVE: set[str] = {"force_stop", "reset"}
 _VM_MUTATION_FIELDS: dict[str, str] = {"force_stop": "forceStop"}
 
@@ -40,10 +44,7 @@ _VM_MUTATION_FIELDS: dict[str, str] = {"force_stop": "forceStop"}
 async def _handle_vm(
     subaction: str, vm_id: str | None, ctx: Context | None, confirm: bool
 ) -> dict[str, Any]:
-    if subaction not in _VM_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for vm. Must be one of: {sorted(_VM_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _VM_SUBACTIONS, "vm")
     if subaction != "list" and not vm_id:
         raise ToolError(f"vm_id is required for vm/{subaction}")
 
@@ -71,7 +72,8 @@ async def _handle_vm(
             return {"vms": []}
 
         if subaction == "details":
-            data = await _client.make_graphql_request(_VM_QUERIES["details"])
+            # VmDomain has no richer fields than list — reuse the same query, filter client-side.
+            data = await _client.make_graphql_request(_VM_LIST_QUERY)
             if not data.get("vms"):
                 raise ToolError("No VM data returned from server")
             vms = data["vms"].get("domains") or data["vms"].get("domain") or []

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -4,14 +4,14 @@ Provides the `unraid` tool with 15 actions, each routing to domain-specific
 subactions via the action + subaction pattern.
 
 Actions:
-  system       - Server info, metrics, network, UPS (19 subactions)
+  system       - Server info, metrics, network, UPS (20 subactions)
   health       - Health checks, connection test, diagnostics, setup (4 subactions)
   array        - Parity checks, array state, disk operations (13 subactions)
   disk         - Shares, physical disks, log files (6 subactions)
   docker       - Container lifecycle and network inspection (7 subactions)
   vm           - Virtual machine lifecycle (9 subactions)
-  notification - System notifications CRUD (12 subactions)
-  key          - API key management (7 subactions)
+  notification - System notifications CRUD (13 subactions)
+  key          - API key management (8 subactions)
   plugin       - Plugin management (3 subactions)
   rclone       - Cloud storage remote management (4 subactions)
   setting      - System settings and UPS config (2 subactions)
@@ -31,6 +31,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.setup import elicit_and_configure, elicit_reset_confirmation
+from ..core.utils import validate_subaction
 
 # Re-exports: domain modules' constants and helpers needed by tests
 # Re-export array queries for schema tests
@@ -91,10 +92,7 @@ from ._vm import _VM_DESTRUCTIVE, _VM_MUTATIONS, _VM_QUERIES, _handle_vm  # noqa
 
 
 async def _handle_health(subaction: str, ctx: Context | None) -> dict[str, Any] | str:
-    if subaction not in _HEALTH_SUBACTIONS:
-        raise ToolError(
-            f"Invalid subaction '{subaction}' for health. Must be one of: {sorted(_HEALTH_SUBACTIONS)}"
-        )
+    validate_subaction(subaction, _HEALTH_SUBACTIONS, "health")
 
     from ..config.settings import (
         CREDENTIALS_ENV_PATH,
@@ -224,7 +222,7 @@ Single entry point for all operations. Use `action` + `subaction` to select an o
 |-----------|------|-------------|
 | `action` | str | One of the actions above |
 | `subaction` | str | Operation within the action |
-| `confirm` | bool | Required for destructive operations (default: False) |
+| `confirm` | bool | Set `True` for destructive subactions (marked `*`). Interactive clients are prompted via elicitation; agents and one-shot API callers **must** pass `confirm=True` to bypass elicitation. (default: False) |
 | `container_id` | str | Docker container ID or name |
 | `vm_id` | str | VM identifier |
 | `disk_id` | str | Disk identifier |
@@ -395,7 +393,9 @@ def register_unraid_tool(mcp: FastMCP) -> None:
         │                 │ log_tail (requires path=), notification_feed                         │
         └─────────────────┴──────────────────────────────────────────────────────────────────────┘
 
-        * Destructive — requires confirm=True
+        * Destructive — interactive clients are prompted for confirmation via
+          elicitation. Agents and non-interactive callers must pass confirm=True
+          to execute these subactions.
         """
         if action == "system":
             return await _handle_system(subaction, device_id)

--- a/uv.lock
+++ b/uv.lock
@@ -1572,7 +1572,7 @@ wheels = [
 
 [[package]]
 name = "unraid-mcp"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

- Generate 42 documentation files across 6 subdirectories based on plugin-lab templates
- All content is real, derived from the actual codebase — zero template placeholders
- Covers the full MCP surface: 4 tools, 15 action domains, 107 subactions, 10 live subscription resources
- Preserves all existing docs/ content (plans/, reports/, sessions/, API references, schema files)

### Documentation structure

| Directory | Files | Coverage |
|-----------|-------|----------|
| `docs/` (root) | 6 | README, Setup, Config, Checklist, Guardrails, Inventory |
| `docs/mcp/` | 20 | Tools, Resources, Schema, ENV, Auth, Transport, Deploy, Logs, Tests, Mcporter, CI/CD, Pre-commit, Publish, Connect, Dev, Elicitation, Patterns, WebMCP, MCPUI, index |
| `docs/plugin/` | 11 | Plugins, Skills, Hooks, Commands, Agents, Channels, Config, Marketplaces, Output-styles, Schedules, index |
| `docs/repo/` | 6 | Repo structure, Recipes, Scripts, Rules, Memory, index |
| `docs/stack/` | 4 | Architecture, Tech choices, Prerequisites, index |
| `docs/upstream/` | 1 | Unraid GraphQL API integration |

## Test plan

- [x] Verify no template placeholders (`my-plugin`, `my_plugin`, `MY_PLUGIN`, `MyPlugin`, `my-service`) in any new file
- [x] Verify all cross-references between docs resolve to existing files
- [x] Verify existing docs/ content is preserved (not overwritten or deleted)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a complete documentation set for `unraid-mcp` and syncs versions to 1.2.4. This includes 42 files across 6 directories plus a test coverage guide, providing end-to-end guidance while retaining existing docs.

- **New Documentation**
  - 42 files across `docs/`, `docs/mcp/`, `docs/plugin/`, `docs/repo/`, `docs/stack/`, `docs/upstream/`.
  - Full MCP surface: 4 tools, 15 action domains, 107 subactions, 10 live resources.
  - Topics: setup, config, auth, transport, deploy (Docker/local), logs, tests, CI/CD, guardrails, schema, upstream GraphQL.
  - Added `tests/TEST_COVERAGE.md` and updated `CHANGELOG.md`; versions aligned to 1.2.4 in `pyproject.toml`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and `gemini-extension.json`.
  - All content derived from the codebase; cross-references validated; existing `docs/` content retained.

- **Migration**
  - Removed deprecated env flags from `.env.example` and README: `UNRAID_MCP_ALLOW_DESTRUCTIVE`, `UNRAID_MCP_ALLOW_YOLO`.

<sup>Written for commit 391463b942a2406a890d26009d48a497cc0cd4b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live metrics subscriptions: Docker container stats and system temperature monitoring.
  * New notification action to prevent duplicate alerts.
  * System info expanded with server time and timezone options.

* **Changes**
  * Removed deprecated safety flag environment variables.
  * Live subscription data now includes timestamps for cache verification.
  * Version updated to 1.2.4.

* **Documentation**
  * Comprehensive guides added: setup, configuration, authentication, deployment, and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->