### PR TITLE
fix: handle HEAD /health in HealthMiddleware for Docker healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`HealthMiddleware`**: now handles `HEAD /health` in addition to `GET /health`
+  without bearer auth. Docker's image healthcheck uses `wget --spider`, which
+  sends a `HEAD` request that previously fell through to bearer auth and returned
+  `401 Unauthorized`, marking the container `unhealthy` whenever
+  `UNRAID_MCP_BEARER_TOKEN` was configured. HEAD returns the same status/headers
+  as GET with an empty body per RFC 9110. (#31)
+
 ### Changed
 - **`bin/generate_unraid_api_reference.py`**: replaced the hand-rolled Markdown
   and schema-diff builders with official GraphQL tooling, invoked via `npx` on

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -23,6 +23,7 @@ from unraid_mcp.core.auth import (
     _RATE_MAX_FAILURES,
     _RATE_WINDOW_SECS,
     BearerAuthMiddleware,
+    HealthMiddleware,
     WellKnownMiddleware,
 )
 
@@ -448,6 +449,72 @@ class TestStartupGuard:
             s.UNRAID_MCP_TRANSPORT = orig_transport
             s.UNRAID_MCP_BEARER_TOKEN = orig_token
             s.UNRAID_MCP_DISABLE_HTTP_AUTH = orig_disabled
+
+
+# ---------------------------------------------------------------------------
+# HealthMiddleware — unauthenticated GET/HEAD /health (regression for #31)
+#
+# Docker's image healthcheck uses `wget --spider`, which sends HEAD /health.
+# The middleware previously only handled GET, so HEAD fell through to bearer
+# auth and returned 401, marking the container unhealthy.
+# ---------------------------------------------------------------------------
+
+
+async def _run_health(method: str, path: str = "/health"):
+    """Run HealthMiddleware over BearerAuth and return (status, headers, body, app_called)."""
+    inner, called = _app_called_flag()
+    authed = BearerAuthMiddleware(inner, token="secret", disabled=False)
+    mw = HealthMiddleware(authed)
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "headers": [],  # no Authorization header
+        "client": ("127.0.0.1", 9999),
+    }
+    received: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(msg: dict):
+        received.append(msg)
+
+    await mw(scope, receive, send)
+    start = next(m for m in received if m["type"] == "http.response.start")
+    body_msg = next(m for m in received if m["type"] == "http.response.body")
+    headers = {k.decode(): v.decode() for k, v in start["headers"]}
+    return start["status"], headers, body_msg["body"], called["value"]
+
+
+class TestHealthMiddleware:
+    def _run(self, method, path="/health"):
+        return asyncio.get_event_loop().run_until_complete(_run_health(method, path))
+
+    def test_get_health_returns_200_without_auth(self):
+        status, _, body, called = self._run("GET")
+        assert status == 200
+        assert body == b'{"status":"ok"}'
+        assert not called  # never reached the auth layer
+
+    def test_head_health_returns_200_without_auth(self):
+        """Regression for #31: `wget --spider` sends HEAD and must not 401."""
+        status, headers, body, called = self._run("HEAD")
+        assert status == 200
+        # HEAD carries no body but keeps GET's content-length header.
+        assert body == b""
+        assert headers["content-length"] == str(len(b'{"status":"ok"}'))
+        assert not called
+
+    def test_normalized_path_still_matches(self):
+        status, _, _, _ = self._run("HEAD", path="/health/")
+        assert status == 200
+
+    def test_post_health_falls_through_to_auth(self):
+        """Other methods are not health probes — they hit the auth layer (401)."""
+        status, _, _, called = self._run("POST")
+        assert status == 401
+        assert not called
 
 
 # ---------------------------------------------------------------------------

--- a/unraid_mcp/core/auth.py
+++ b/unraid_mcp/core/auth.py
@@ -234,11 +234,13 @@ class BearerAuthMiddleware:
 
 
 class HealthMiddleware:
-    """ASGI middleware that responds 200 to GET /health without authentication.
+    """ASGI middleware that responds 200 to GET/HEAD /health without authentication.
 
     Place this OUTSIDE BearerAuthMiddleware (first in the middleware list) so it
-    intercepts GET /health before auth — no bypass needed in BearerAuthMiddleware.
-    Only GET is handled; other methods fall through to the auth layer.
+    intercepts /health before auth — no bypass needed in BearerAuthMiddleware.
+    Both GET and HEAD are handled (HEAD is what ``wget --spider`` sends, and many
+    health probes use it); other methods fall through to the auth layer. Per HTTP
+    semantics, HEAD returns the same status/headers as GET but with no body.
     """
 
     _BODY: bytes = b'{"status":"ok"}'
@@ -258,10 +260,13 @@ class HealthMiddleware:
         if (
             scope["type"] == "http"
             and posixpath.normpath(scope["path"]) == "/health"
-            and scope["method"] == "GET"
+            and scope["method"] in ("GET", "HEAD")
         ):
+            # HEAD shares GET's status and headers (incl. content-length) but
+            # carries no body, per RFC 9110.
+            body = b"" if scope["method"] == "HEAD" else self._BODY
             await send({"type": "http.response.start", "status": 200, "headers": self._HEADERS})
-            await send({"type": "http.response.body", "body": self._BODY, "more_body": False})
+            await send({"type": "http.response.body", "body": body, "more_body": False})
             return
         await self.app(scope, receive, send)
 


### PR DESCRIPTION
## Summary

Fixes #31 — the Docker image reported `unhealthy` even though the MCP server was running fine.

The image healthcheck uses `wget --spider`, which sends a **`HEAD /health`** request. `HealthMiddleware` only intercepted **`GET /health`**, so `HEAD` fell through to `BearerAuthMiddleware` and returned `401 Unauthorized` whenever `UNRAID_MCP_BEARER_TOKEN` was configured — marking the container unhealthy.

## Fix

Implemented option 1 from the issue (the more robust path, since health probes commonly use `HEAD`):

- `HealthMiddleware` now responds `200` to **both `GET` and `HEAD` `/health`** without auth.
- Per RFC 9110, `HEAD` returns the same status and headers as `GET` (including `content-length`) but with an **empty body**.
- Other methods (e.g. `POST`) still fall through to the auth layer.

## Tests

Added `TestHealthMiddleware` regression tests in `tests/test_auth.py` (previously there was no direct coverage of this middleware):

- `GET /health` → 200, body `{"status":"ok"}`, never reaches auth
- `HEAD /health` → 200, empty body, `content-length` matches GET, never reaches auth
- normalized path (`/health/`) still matches
- `POST /health` falls through to auth (401)

All `tests/test_auth.py` and `tests/test_health.py` pass; ruff clean.

## Version

Patch bump `1.3.8` → `1.3.9` across `pyproject.toml`, `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`, plus a `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyfVTCzSQZC5qM3f83qLna

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyfVTCzSQZC5qM3f83qLna)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handles HEAD /health in `HealthMiddleware` so Docker’s `wget --spider` healthcheck passes when bearer auth is enabled. Fixes #31.

- **Bug Fixes**
  - Return 200 for GET/HEAD `/health` without auth; HEAD mirrors GET headers (incl. content-length) with an empty body; other methods still hit auth.
  - Added regression tests (GET/HEAD, `/health/` normalization, POST falls through); updated changelog.

<sup>Written for commit 6f4d7a59b67163ddb00e4fb9706645815b65c875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

