### PR TITLE
fix: correct unraid tool docstring subaction counts

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unraid-mcp",
   "displayName": "Unraid MCP",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools. Supports system info, Docker, VMs, array/parity, notifications, plugins, rclone, and live telemetry.",
   "author": {
     "name": "Jacob Magar",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unraid-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Unraid server management via MCP.",
   "homepage": "https://github.com/jmagar/unraid-mcp",
   "repository": "https://github.com/jmagar/unraid-mcp",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-19
+
+### Fixed
+
+- **`unraid` tool docstring subaction counts** now match the documented (user-facing) convention used across `CLAUDE.md`, `README.md`, and `docs/`: `docker` 7 → 8 (the `ports` subaction added in 1.4.0 was missed in the module docstring), `system` 20 → 18, `notification` 13 → 12, `key` 8 → 7. The higher numbers counted deprecated/internal subactions (`logs`, `server_time`, `timezones`, `notify_if_unique`, `possible_roles`) that the rest of the docs intentionally exclude, the same way `docker` already omits the deprecated `logs` subaction.
+
 ## [1.4.0] - 2026-04-28
 
 ### Added

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "unraid-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools. Supports system info, Docker, VMs, array/parity, notifications, plugins, and live telemetry.",
   "mcpServers": {
     "unraid-mcp": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # ============================================================================
 [project]
 name = "unraid-mcp"
-version = "1.4.0"
+version = "1.4.1"
 description = "MCP Server for Unraid API - provides tools to interact with an Unraid server's GraphQL API"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -4,14 +4,14 @@ Provides the `unraid` tool with 15 actions, each routing to domain-specific
 subactions via the action + subaction pattern.
 
 Actions:
-  system       - Server info, metrics, network, UPS (20 subactions)
+  system       - Server info, metrics, network, UPS (18 subactions)
   health       - Health checks, connection test, diagnostics, setup (4 subactions)
   array        - Parity checks, array state, disk operations (13 subactions)
   disk         - Shares, physical disks, log files (6 subactions)
-  docker       - Container lifecycle and network inspection (7 subactions)
+  docker       - Container lifecycle and network inspection (8 subactions)
   vm           - Virtual machine lifecycle (9 subactions)
-  notification - System notifications CRUD (13 subactions)
-  key          - API key management (8 subactions)
+  notification - System notifications CRUD (12 subactions)
+  key          - API key management (7 subactions)
   plugin       - Plugin management (3 subactions)
   rclone       - Cloud storage remote management (4 subactions)
   setting      - System settings and UPS config (2 subactions)

--- a/uv.lock
+++ b/uv.lock
@@ -1572,7 +1572,7 @@ wheels = [
 
 [[package]]
 name = "unraid-mcp"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
Follow-up cleanup after #27. Aligns the `unraid` tool module docstring (`unraid_mcp/tools/unraid.py`) subaction counts with the documented (user-facing) convention used everywhere else in the repo (`CLAUDE.md`, `README.md`, `docs/`).

## What
| domain | before | after | reason |
|--------|--------|-------|--------|
| `docker` | 7 | **8** | `ports` was added in #27 but the module docstring line was missed |
| `system` | 20 | **18** | docstring counted internal/undocumented subactions |
| `notification` | 13 | **12** | same |
| `key` | 8 | **7** | same |

The pre-#27 docstring numbers (20/13/8) counted deprecated/internal subactions that the rest of the docs intentionally exclude — `logs` (docker), `server_time` + `timezones` (system), `notify_if_unique` (notification), `possible_roles` (key). This makes the count consistent with how `docker` already omits the deprecated `logs` subaction, so the docstring now matches the CLAUDE.md table and all other docs.

> Note: those five subactions remain callable but undocumented. Documenting them across the doc tables (which would raise the counts instead) is a separate, larger decision and intentionally out of scope here.

## Tests
- `ruff check` clean
- `tests/test_docker.py`: 33 passed

Version bumped 1.4.0 → 1.4.1 (patch) across all manifests + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLsxxxMvg2hzGDRjbJCuSf)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the `unraid` tool docstring subaction counts to match the user-facing docs, and bumped the package to `1.4.1`.

- **Bug Fixes**
  - `docker`: 7 → 8 (added `ports` in 1.4.0 but docstring missed it).
  - `system` 20 → 18, `notification` 13 → 12, `key` 8 → 7 (exclude deprecated/internal subactions: `logs`, `server_time`, `timezones`, `notify_if_unique`, `possible_roles`).

<sup>Written for commit a83ef237545d1b82e0378b8e9330e96bf1792949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

