### PR TITLE
feat(plugin): wire userConfig into MCP server env; remove HTTP fields

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "unraid-mcp",
   "displayName": "Unraid MCP",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools. Supports system info, Docker, VMs, array/parity, notifications, plugins, rclone, and live telemetry.",
   "author": {
     "name": "Jacob Magar",
@@ -33,19 +33,6 @@
     ]
   },
   "userConfig": {
-    "unraid_mcp_url": {
-      "type": "string",
-      "title": "Unraid MCP Server URL",
-      "description": "URL of the MCP server. Default works if running locally via uv or docker compose.",
-      "default": "https://unraid.tootie.tv/mcp",
-      "sensitive": false
-    },
-    "unraid_mcp_token": {
-      "type": "string",
-      "title": "MCP Server Bearer Token",
-      "description": "Bearer token for authenticating with the MCP server. Must match UNRAID_MCP_BEARER_TOKEN in the server's .env. Generate with: openssl rand -hex 32",
-      "sensitive": true
-    },
     "unraid_api_url": {
       "type": "string",
       "title": "Unraid GraphQL API URL",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "unraid-mcp",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Unraid server management via MCP.",
   "homepage": "https://github.com/jmagar/unraid-mcp",
   "repository": "https://github.com/jmagar/unraid-mcp",

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,8 +11,8 @@
       "env": {
         "UV_PROJECT_ENVIRONMENT": "${CLAUDE_PLUGIN_DATA}/.venv",
         "UNRAID_MCP_TRANSPORT": "stdio",
-        "UNRAID_API_URL": "",
-        "UNRAID_API_KEY": "",
+        "UNRAID_API_URL": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}",
+        "UNRAID_API_KEY": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}",
         "UNRAID_VERIFY_SSL": "true",
         "UNRAID_MCP_LOG_LEVEL": "INFO",
         "UNRAID_MCP_LOG_FILE": "unraid-mcp.log",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-06-19
+
+### Added
+
+- **Claude Code plugin `userConfig` is now actually wired to the server.** `.mcp.json` maps the `unraid_api_url` / `unraid_api_key` plugin options into the stdio server's environment via `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}` / `${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}` (previously these env vars were hardcoded to empty strings, so the configured values never reached the server). The reliable `$CLAUDE_PLUGIN_OPTION_*` env-var form is used rather than the `${user_config.*}` placeholder, which silently breaks MCP server spawn (claude-code #51573).
+
+### Removed
+
+- **HTTP-transport `userConfig` fields** (`unraid_mcp_url`, `unraid_mcp_token`) from `.claude-plugin/plugin.json`. The bundled plugin runs the server over stdio, so the remote MCP URL and bearer-token options were vestigial and never consumed.
+
 ## [1.4.1] - 2026-06-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **HTTP-transport `userConfig` fields** (`unraid_mcp_url`, `unraid_mcp_token`) from `.claude-plugin/plugin.json`. The bundled plugin runs the server over stdio, so the remote MCP URL and bearer-token options were vestigial and never consumed.
 
+### Fixed
+
+- **Test suite collection error.** `tests/test_generate_unraid_api_reference.py` imported the generator from the old `scripts.` package; it now loads `bin/generate_unraid_api_reference.py` by file path. This import error was aborting the entire `Test` CI job at collection.
+- **Removed stale regression tests** in `tests/test_review_regressions.py` that exercised `hooks/scripts/sync-env.sh` and `hooks/scripts/ensure-gitignore.sh` — scripts deleted in the earlier `hooks/scripts/` → `bin/`/lefthook migration. They could only fail (script not found) and were masked by the collection error above.
+
 ## [1.4.1] - 2026-06-19
 
 ### Fixed

--- a/docs/mcp/AUTH.md
+++ b/docs/mcp/AUTH.md
@@ -40,7 +40,7 @@ UNRAID_MCP_BEARER_TOKEN=<your-token>
 ### Client configuration
 
 #### Claude Code plugin
-The `userConfig` in `.claude-plugin/plugin.json` includes `unraid_mcp_token` (sensitive: true). Claude Code prompts the user for this value during plugin installation.
+The bundled plugin runs the server over **stdio**, so no inbound bearer token is needed — the `userConfig` collects only `unraid_api_url` / `unraid_api_key` (the outbound Unraid GraphQL credentials), which `.mcp.json` wires into the server's environment. A bearer token applies only to direct HTTP deployments below.
 
 #### Direct HTTP
 ```bash

--- a/docs/plugin/CONFIG.md
+++ b/docs/plugin/CONFIG.md
@@ -2,24 +2,35 @@
 
 ## userConfig (Claude Code)
 
-The `.claude-plugin/plugin.json` defines four user-configurable settings:
+The `.claude-plugin/plugin.json` defines two user-configurable settings:
 
 | Key | Type | Sensitive | Default | Description |
 |-----|------|-----------|---------|-------------|
-| `unraid_mcp_url` | string | no | `https://unraid.tootie.tv/mcp` | URL of the MCP server |
-| `unraid_mcp_token` | string | yes | -- | Bearer token for MCP auth |
 | `unraid_api_url` | string | yes | -- | Unraid GraphQL API URL |
 | `unraid_api_key` | string | yes | -- | Unraid API key |
 
 ### How settings are used
 
-- **Non-sensitive**: Available as literal values in skill templates (`${user_config.unraid_mcp_url}`)
-- **Sensitive**: Available ONLY as `$CLAUDE_PLUGIN_OPTION_*` environment variables in Bash subprocesses
-  - `$CLAUDE_PLUGIN_OPTION_UNRAID_MCP_TOKEN`
-  - `$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL`
-  - `$CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY`
+Both values are sensitive and are exposed to plugin-spawned processes as
+`$CLAUDE_PLUGIN_OPTION_*` environment variables:
 
-Attempting `${user_config.unraid_api_key}` in a template will not work for sensitive values.
+- `$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL`
+- `$CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY`
+
+`.mcp.json` wires these into the stdio MCP server's environment so the server
+picks them up directly:
+
+```json
+"env": {
+  "UNRAID_API_URL": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}",
+  "UNRAID_API_KEY": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}"
+}
+```
+
+> The `${user_config.*}` placeholder form is **not** used here: referencing it
+> directly in a `.mcp.json` `env` block causes the MCP server to silently fail
+> to spawn (claude-code issue #51573). The `$CLAUDE_PLUGIN_OPTION_*` env-var
+> form is the reliable path.
 
 ## Settings (Gemini CLI)
 

--- a/docs/plugin/PLUGINS.md
+++ b/docs/plugin/PLUGINS.md
@@ -17,8 +17,6 @@
     }
   },
   "userConfig": {
-    "unraid_mcp_url": { "type": "string", "sensitive": false },
-    "unraid_mcp_token": { "type": "string", "sensitive": true },
     "unraid_api_url": { "type": "string", "sensitive": true },
     "unraid_api_key": { "type": "string", "sensitive": true }
   }
@@ -28,7 +26,7 @@
 ### Key fields
 
 - **mcpServers.unraid**: stdio transport via `uv run`. The `${CLAUDE_PLUGIN_ROOT}` variable resolves to the plugin installation directory.
-- **userConfig**: Four settings collected at install time. Sensitive values are stored encrypted and exposed as `$CLAUDE_PLUGIN_OPTION_*` environment variables in Bash subprocesses.
+- **userConfig**: Two settings collected at install time (`unraid_api_url`, `unraid_api_key`). Both are sensitive, stored encrypted, and exposed as `$CLAUDE_PLUGIN_OPTION_*` environment variables. `.mcp.json` wires them into the stdio server's `UNRAID_API_URL` / `UNRAID_API_KEY` env vars.
 
 ## Codex CLI (`.codex-plugin/plugin.json`)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "unraid-mcp",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Query, monitor, and manage Unraid servers via GraphQL API through MCP tools. Supports system info, Docker, VMs, array/parity, notifications, plugins, and live telemetry.",
   "mcpServers": {
     "unraid-mcp": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "hatchling.build"
 # ============================================================================
 [project]
 name = "unraid-mcp"
-version = "1.4.1"
+version = "1.5.0"
 description = "MCP Server for Unraid API - provides tools to interact with an Unraid server's GraphQL API"
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/skills/unraid/SKILL.md
+++ b/skills/unraid/SKILL.md
@@ -12,9 +12,8 @@ description: "This skill should be used when the user mentions Unraid, asks to c
 **HTTP fallback**: Use when MCP tools are unavailable. Credentials are in Bash subprocesses
 as `$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL` and `$CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY`.
 Do NOT attempt `${user_config.unraid_api_key}` in curl — sensitive values only work
-as `$CLAUDE_PLUGIN_OPTION_*` in Bash subprocesses.
-
-**MCP URL**: `${user_config.unraid_mcp_url}`
+as `$CLAUDE_PLUGIN_OPTION_*` in Bash subprocesses. The fallback queries the Unraid
+GraphQL API directly with these credentials.
 
 ---
 

--- a/tests/test_generate_unraid_api_reference.py
+++ b/tests/test_generate_unraid_api_reference.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
-from scripts.generate_unraid_api_reference import _build_changes_markdown
+import importlib.util
+from pathlib import Path
+
+
+# The generator script lives in bin/ (renamed from scripts/) and bin/ is not an
+# importable package, so load the module directly by file path.
+_GEN_PATH = Path(__file__).resolve().parents[1] / "bin" / "generate_unraid_api_reference.py"
+_spec = importlib.util.spec_from_file_location("generate_unraid_api_reference", _GEN_PATH)
+assert _spec is not None and _spec.loader is not None
+_gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_gen)
+_build_changes_markdown = _gen._build_changes_markdown
 
 
 def _type_ref(

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -13,7 +13,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 def test_plugin_manifest_restores_stdio_server_definition() -> None:
     plugin = json.loads((PROJECT_ROOT / ".claude-plugin" / "plugin.json").read_text())
-    assert plugin["userConfig"]["unraid_mcp_token"]["sensitive"] is True
+    assert plugin["userConfig"]["unraid_api_key"]["sensitive"] is True
     assert "mcpServers" in plugin
     assert plugin["mcpServers"] == "./.mcp.json"
 

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -1,10 +1,8 @@
-"""Regression coverage for packaging, manifests, and hook scripts."""
+"""Regression coverage for packaging and manifests."""
 
 from __future__ import annotations
 
 import json
-import os
-import subprocess
 from pathlib import Path
 
 
@@ -41,60 +39,3 @@ def test_test_live_script_uses_safe_counters_and_resource_failures() -> None:
     assert "(( PASS++ ))" in script
     assert "(( FAIL++ ))" in script
     assert "(( SKIP++ ))" in script
-
-
-def test_sync_env_rejects_multiline_values(tmp_path: Path) -> None:
-    env = os.environ.copy()
-    env["CLAUDE_PLUGIN_ROOT"] = str(tmp_path)
-    env["CLAUDE_PLUGIN_OPTION_UNRAID_API_URL"] = "https://tower.local\nINJECT=1"
-
-    result = subprocess.run(  # noqa: S603
-        ["/usr/bin/bash", str(PROJECT_ROOT / "hooks" / "scripts" / "sync-env.sh")],
-        cwd=PROJECT_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode != 0
-    assert "control characters" in result.stderr
-
-
-def test_sync_env_rejects_empty_bearer_token(tmp_path: Path) -> None:
-    """sync-env must fail when no bearer token is provided — auto-generation was removed."""
-    env_file = tmp_path / ".env"
-    env_file.write_text("UNRAID_MCP_BEARER_TOKEN=\n")
-
-    env = os.environ.copy()
-    env["CLAUDE_PLUGIN_ROOT"] = str(tmp_path)
-
-    result = subprocess.run(  # noqa: S603
-        ["/usr/bin/bash", str(PROJECT_ROOT / "hooks" / "scripts" / "sync-env.sh")],
-        cwd=PROJECT_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode != 0
-    assert "UNRAID_MCP_BEARER_TOKEN is not set" in result.stderr
-
-
-def test_ensure_gitignore_preserves_ignore_before_negation(tmp_path: Path) -> None:
-    gitignore = tmp_path / ".gitignore"
-    gitignore.write_text("!backups/.gitkeep\n")
-
-    env = os.environ.copy()
-    env["CLAUDE_PLUGIN_ROOT"] = str(tmp_path)
-
-    result = subprocess.run(  # noqa: S603
-        ["/usr/bin/bash", str(PROJECT_ROOT / "hooks" / "scripts" / "ensure-gitignore.sh")],
-        cwd=PROJECT_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0
-    lines = gitignore.read_text().splitlines()
-    assert lines.index("backups/*") < lines.index("!backups/.gitkeep")

--- a/uv.lock
+++ b/uv.lock
@@ -1572,7 +1572,7 @@ wheels = [
 
 [[package]]
 name = "unraid-mcp"
-version = "1.4.1"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

Answers the question "are we using `userConfig` for the Claude Code plugin?" — it was **declared but not wired**. The plugin's `userConfig` collected `unraid_api_url` / `unraid_api_key`, but `.mcp.json` hardcoded `UNRAID_API_URL=""` / `UNRAID_API_KEY=""`, so the configured values never reached the spawned stdio server.

### Changes
- **Wire userConfig → server env.** `.mcp.json` now maps the values via `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}` / `${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}`.
  - Uses the reliable `$CLAUDE_PLUGIN_OPTION_*` env-var form rather than the `${user_config.*}` placeholder, which silently breaks MCP server spawn ([claude-code #51573](https://github.com/anthropics/claude-code/issues/51573)).
- **Remove the HTTP-transport `userConfig` fields** (`unraid_mcp_url`, `unraid_mcp_token`) from `.claude-plugin/plugin.json`. The bundled plugin runs over **stdio**, so the remote MCP URL and inbound bearer token were vestigial and never consumed.
- Updated docs (`CONFIG.md`, `PLUGINS.md`, `AUTH.md`, `SKILL.md`) and the manifest regression test.
- Version bump `1.4.1 → 1.5.0` across all version-bearing files + CHANGELOG.

### Verification
- `bin/check-version-sync.sh` → all files at v1.5.0
- `tests/test_review_regressions.py::test_plugin_manifest_restores_stdio_server_definition` passes
- All edited JSON manifests parse cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nps965FS6yZQFYZrgpvZN5)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired the Claude Code plugin `userConfig` into the MCP stdio server so Unraid API credentials reach the server. Removed unused HTTP config fields and fixed tests to restore the Test CI job.

- **Bug Fixes**
  - Map `unraid_api_url` and `unraid_api_key` from plugin options to server env in `.mcp.json` via `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}` and `${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}` (replaces empty strings).
  - Remove vestigial HTTP `userConfig` fields from `.claude-plugin/plugin.json`; update docs to note stdio needs no bearer token; bump versions to `1.5.0` across manifests and `pyproject`/`uv.lock`.
  - Repair tests: load the API reference generator from `bin/generate_unraid_api_reference.py` by file path; drop stale hook-script regressions; update the manifest test to assert `unraid_api_key` is sensitive.

<sup>Written for commit d39d8c127d3de5e9b0543308985dca550a76678a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

