### PR TITLE
fix: tolerate null Share.id for auto-created shares (#29)

### DIFF
--- a/tests/contract/test_response_contracts.py
+++ b/tests/contract/test_response_contracts.py
@@ -721,6 +721,32 @@ class TestStorageSharesContract:
         StorageSharesResult(**result)
         assert result["shares"] == []
 
+    async def test_shares_synthesizes_id_from_name(self, _storage_mock: AsyncMock) -> None:
+        """The shares query no longer selects `id`; the handler must synthesize
+        a stable `id` from `name` (issue #29)."""
+        _storage_mock.return_value = {
+            "shares": [
+                {"name": "media", "free": 500000, "used": 100000, "size": 600000},
+                {"name": "appdata", "free": 200000, "used": 50000, "size": 250000},
+            ]
+        }
+        result = await _storage_tool()(action="disk", subaction="shares")
+        validated = StorageSharesResult(**result)
+        for share in validated.shares:
+            # ShareEntry requires a non-null `id` — synthesis must satisfy it.
+            entry = ShareEntry(**share)
+            assert entry.id == entry.name
+
+    async def test_shares_tolerates_null_id_auto_share(self, _storage_mock: AsyncMock) -> None:
+        """Auto-created shares may carry an explicit null `id`; the handler must
+        backfill it from `name` rather than propagate the null (issue #29)."""
+        _storage_mock.return_value = {
+            "shares": [{"id": None, "name": "autoshare", "free": 1, "used": 2, "size": 3}]
+        }
+        result = await _storage_tool()(action="disk", subaction="shares")
+        assert result["shares"][0]["id"] == "autoshare"
+        ShareEntry(**result["shares"][0])
+
     async def test_shares_missing_name_fails_contract(self, _storage_mock: AsyncMock) -> None:
         """A share without required 'name' must fail contract validation."""
         _storage_mock.return_value = {"shares": [{"id": "share:1", "free": 100}]}

--- a/tests/schema/test_query_validation.py
+++ b/tests/schema/test_query_validation.py
@@ -347,6 +347,19 @@ class TestStorageQueries:
         errors = _validate_operation(schema, QUERIES["shares"])
         assert not errors, f"shares query validation failed: {errors}"
 
+    def test_shares_query_does_not_select_id(self) -> None:
+        """Auto-created user shares resolve Share.id to null, and the
+        non-nullable Share.id field rejects the whole response (issue #29).
+        The shares query must not select `id` — `name` is the stable id."""
+        from unraid_mcp.tools._disk import _DISK_QUERIES as QUERIES
+
+        query = QUERIES["shares"]
+        # `id` must not appear as a selected field inside the shares block.
+        assert " id " not in query and "{ id" not in query, (
+            f"shares query must not select `id` (issue #29): {query}"
+        )
+        assert "name" in query
+
     def test_disks_query(self, schema: GraphQLSchema) -> None:
         from unraid_mcp.tools._disk import _DISK_QUERIES as QUERIES
 

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -21,7 +21,12 @@ from ..core.utils import format_bytes, validate_subaction
 # ===========================================================================
 
 _DISK_QUERIES: dict[str, str] = {
-    "shares": "query GetSharesInfo { shares { id name free used size include exclude cache nameOrig comment allocator splitLevel floor cow color luksStatus } }",
+    # NOTE: `id` is intentionally omitted. Auto-created user shares (top-level
+    # folders with no /boot/config/shares/<name>.cfg) resolve Share.id to null,
+    # and the non-nullable Share.id field rejects the entire response — so no
+    # shares could be listed while any auto-share existed (issue #29). `name` is
+    # the stable identifier; the handler synthesizes `id` from `name`.
+    "shares": "query GetSharesInfo { shares { name free used size include exclude cache nameOrig comment allocator splitLevel floor cow color luksStatus } }",
     "disks": "query ListPhysicalDisks { disks { id device name } }",
     "disk_details": "query GetDiskDetails($id: PrefixedID!) { disk(id: $id) { id device name serialNum size temperature } }",
     "log_files": "query ListLogFiles { logFiles { name path size modifiedAt } }",

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -162,7 +162,14 @@ async def _handle_disk(
         )
 
         if subaction == "shares":
-            return {"shares": data.get("shares", [])}
+            shares = data.get("shares", []) or []
+            # `id` is no longer selected (see _DISK_QUERIES["shares"]); synthesize
+            # a stable id from `name` so downstream consumers expecting an `id`
+            # key still get one. `name` is the stable share identifier.
+            for share in shares:
+                if isinstance(share, dict) and not share.get("id"):
+                    share["id"] = share.get("name")
+            return {"shares": shares}
         if subaction == "disks":
             return {"disks": data.get("disks", [])}
         if subaction == "disk_details":


### PR DESCRIPTION
## Problem

\`unraid action=disk subaction=shares\` failed with:

\`\`\`
GraphQL API error: Cannot return null for non-nullable field Share.id
\`\`\`

whenever the array had auto-created user shares (top-level folders with no
\`/boot/config/shares/<name>.cfg\`). These auto-shares return a \`null\` \`id\`, and the
non-nullable \`Share.id\` selection rejects the **whole** response — so NO shares
could be listed while any auto-share existed. Reported on Unraid 7.2.4, API 4.34.0.

## Fix

1. Remove \`id\` from the \`shares\` GraphQL selection set so the API is never forced
   to resolve the null non-nullable field. \`name\` is the stable share identifier.
2. In the \`shares\` response handler, synthesize a stable \`id\` from each share's
   \`name\` (\`share["id"] = share.get("id") or share["name"]\`) so downstream
   consumers expecting an \`id\` key still get one.
3. Tests: schema test asserting the query no longer selects \`id\`; contract/unit
   tests asserting the handler synthesizes \`id\` from \`name\` and tolerates a
   null-id share.

Closes #29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent shares listing from failing when auto-created user shares return a null Share.id. We remove `id` from the `shares` GraphQL query and synthesize `id` from `name` in the handler (tolerates explicit nulls), with tests ensuring the query omits `id` and ids are backfilled.

<sup>Written for commit 893a62ed0880399cb2b0c1329ca2dac6265a8d3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

