### PR TITLE
fix: treat empty credential env vars as unset so ~/.unraid-mcp/.env loads (#28)

### DIFF
--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,90 @@
+"""Tests for env-file loading in unraid_mcp.config.settings.
+
+Regression coverage for GitHub issue #28: empty-string credential env vars
+(e.g. an unset `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}` from the bundled
+.mcp.json) must NOT shadow values from the canonical ~/.unraid-mcp/.env file.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from unraid_mcp.config import settings as settings_module
+
+
+def _write_env(tmp_path: Path, **values: str) -> Path:
+    """Write a .env file under tmp_path and return its path."""
+    env_path = tmp_path / ".env"
+    env_path.write_text("\n".join(f"{k}={v}" for k, v in values.items()) + "\n")
+    return env_path
+
+
+def _point_search_path_at(monkeypatch: pytest.MonkeyPatch, env_path: Path) -> None:
+    """Make _load_env_files() pick up env_path as the first existing dotenv."""
+    monkeypatch.setattr(settings_module, "CREDENTIALS_ENV_PATH", env_path)
+
+
+def test_empty_string_credentials_do_not_shadow_env_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Empty-string UNRAID_API_URL/KEY in os.environ must not block the .env file."""
+    env_path = _write_env(
+        tmp_path,
+        UNRAID_API_URL="http://from-dotenv:6970/graphql",
+        UNRAID_API_KEY="dotenv-key",
+    )
+    _point_search_path_at(monkeypatch, env_path)
+
+    # Simulate the unset-plugin-option case: present but empty.
+    monkeypatch.setenv("UNRAID_API_URL", "")
+    monkeypatch.setenv("UNRAID_API_KEY", "")
+
+    settings_module._load_env_files()
+
+    import os
+
+    assert os.environ["UNRAID_API_URL"] == "http://from-dotenv:6970/graphql"
+    assert os.environ["UNRAID_API_KEY"] == "dotenv-key"
+
+
+def test_whitespace_only_credentials_treated_as_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Whitespace-only credential env vars must also be treated as unset."""
+    env_path = _write_env(
+        tmp_path,
+        UNRAID_API_URL="http://from-dotenv:6970/graphql",
+        UNRAID_API_KEY="dotenv-key",
+    )
+    _point_search_path_at(monkeypatch, env_path)
+
+    monkeypatch.setenv("UNRAID_API_URL", "   ")
+    monkeypatch.setenv("UNRAID_API_KEY", "\t")
+
+    settings_module._load_env_files()
+
+    import os
+
+    assert os.environ["UNRAID_API_URL"] == "http://from-dotenv:6970/graphql"
+    assert os.environ["UNRAID_API_KEY"] == "dotenv-key"
+
+
+def test_nonempty_env_var_is_respected(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A genuinely-set (non-empty) env var must NOT be clobbered by the .env file."""
+    env_path = _write_env(
+        tmp_path,
+        UNRAID_API_URL="http://from-dotenv:6970/graphql",
+        UNRAID_API_KEY="dotenv-key",
+    )
+    _point_search_path_at(monkeypatch, env_path)
+
+    monkeypatch.setenv("UNRAID_API_URL", "http://from-shell:9999/graphql")
+    monkeypatch.setenv("UNRAID_API_KEY", "shell-key")
+
+    settings_module._load_env_files()
+
+    import os
+
+    # load_dotenv(override=False) must leave the real shell exports intact.
+    assert os.environ["UNRAID_API_URL"] == "http://from-shell:9999/graphql"
+    assert os.environ["UNRAID_API_KEY"] == "shell-key"

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -24,21 +24,45 @@ PROJECT_ROOT = UNRAID_MCP_DIR.parent  # /home/user/code/unraid-mcp/
 CREDENTIALS_DIR = Path(os.getenv("UNRAID_CREDENTIALS_DIR", str(Path.home() / ".unraid-mcp")))
 CREDENTIALS_ENV_PATH = CREDENTIALS_DIR / ".env"
 
-# Load environment variables from .env file
-# Priority: canonical ~/.unraid-mcp/.env first, then dev/container fallbacks.
-dotenv_paths = [
-    CREDENTIALS_ENV_PATH,  # primary — ~/.unraid-mcp/.env (all runtimes)
-    CREDENTIALS_DIR / ".env.local",  # only used if ~/.unraid-mcp/.env absent
-    Path("/app/.env.local"),  # Docker compat mount
-    PROJECT_ROOT / ".env.local",  # dev overrides
-    PROJECT_ROOT / ".env",  # dev fallback
-    UNRAID_MCP_DIR / ".env",  # last resort
-]
+# Credential env vars that an empty string must NOT shadow. The bundled
+# `.mcp.json` passes `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}` (and key), which
+# resolves to "" when the plugin option is unset. With load_dotenv's default
+# override=False, those empty values would otherwise take precedence over every
+# .env on the search path — including the canonical ~/.unraid-mcp/.env — so the
+# credentials silently never load. See GitHub issue #28.
+_EMPTY_AS_UNSET_KEYS = ("UNRAID_API_URL", "UNRAID_API_KEY")
 
-for dotenv_path in dotenv_paths:
-    if dotenv_path.exists():
-        load_dotenv(dotenv_path=dotenv_path)
-        break
+
+def _load_env_files() -> None:
+    """Load environment variables from the first existing .env on the search path.
+
+    Priority: canonical ~/.unraid-mcp/.env first, then dev/container fallbacks.
+
+    Before loading, empty-string entries for the credential keys are removed from
+    os.environ so that ``load_dotenv(override=False)`` can populate them from the
+    .env file. A genuinely-set (non-empty) shell export is still respected.
+    """
+    # Treat empty-string credential env vars as unset (issue #28).
+    for key in _EMPTY_AS_UNSET_KEYS:
+        if os.environ.get(key, "").strip() == "":
+            os.environ.pop(key, None)
+
+    dotenv_paths = [
+        CREDENTIALS_ENV_PATH,  # primary — ~/.unraid-mcp/.env (all runtimes)
+        CREDENTIALS_DIR / ".env.local",  # only used if ~/.unraid-mcp/.env absent
+        Path("/app/.env.local"),  # Docker compat mount
+        PROJECT_ROOT / ".env.local",  # dev overrides
+        PROJECT_ROOT / ".env",  # dev fallback
+        UNRAID_MCP_DIR / ".env",  # last resort
+    ]
+
+    for dotenv_path in dotenv_paths:
+        if dotenv_path.exists():
+            load_dotenv(dotenv_path=dotenv_path)
+            break
+
+
+_load_env_files()
 
 # Core API Configuration
 # IMPORTANT: UNRAID_API_URL and UNRAID_API_KEY are mutated at runtime by apply_runtime_config().


### PR DESCRIPTION
## Problem

Empty-string env vars shadow the canonical credentials file. `unraid_mcp/config/settings.py` called `load_dotenv(dotenv_path=...)` with the default `override=False`. When `UNRAID_API_URL`/`UNRAID_API_KEY` are present in the process environment as empty strings `""` (e.g. the bundled `.mcp.json` passes `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}`, which resolves to empty when the plugin option is unset), those empty values take precedence over EVERY `.env` on the search path — including the canonical `~/.unraid-mcp/.env`. Result: credentials silently never load and the server reports `CredentialsNotConfiguredError`.

## Fix

Before the `load_dotenv` loop, remove empty-string entries for the credential keys (`UNRAID_API_URL`, `UNRAID_API_KEY`) from `os.environ`. This lets `load_dotenv(override=False)` populate them from the `.env` file. A genuinely-set (non-empty) shell export is still respected — we deliberately do **not** flip to `override=True` globally, which would let a project `.env` clobber a real exported value.

The dotenv-loading block was refactored into a small `_load_env_files()` function (called at import) so it can be tested deterministically with a patched environment. Public behavior at import time is identical.

## Tests

Added `tests/test_settings.py`:
- Empty-string `UNRAID_API_URL`/`UNRAID_API_KEY` in `os.environ` do NOT shadow values from a `.env` file.
- A genuinely-set (non-empty) env var is still respected.
- Whitespace-only credential env vars are treated as unset.

Closes #28

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats empty credential env vars as unset so the canonical ~/.unraid-mcp/.env loads, fixing silent credential failures (issue #28). Extracts dotenv loading into a small helper and adds regression tests to lock this behavior.

- **Bug Fixes**
  - Remove empty or whitespace-only UNRAID_API_URL and UNRAID_API_KEY from the environment before dotenv loads, allowing values from ~/.unraid-mcp/.env to apply.
  - Keep override=False so non-empty shell exports are respected.
  - Add regression tests to ensure empty/whitespace vars don’t shadow .env and non-empty exports win.

- **Refactors**
  - Move dotenv loading into a `_load_env_files()` helper, called at import; external behavior is unchanged.

<sup>Written for commit af7114a108de9658315045b7a9ad1a9468bae3ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

