### PR TITLE
docs: document Claude Desktop mcp-remote proxy config (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,13 @@ uv run python -m unraid_mcp
 docker compose up -d
 ```
 
+### Claude Desktop
+
+Newer Claude Desktop builds may reject the raw `streamable-http` URL config when the
+server runs in Docker. Connect through the `mcp-remote` proxy instead — see
+[docs/mcp/CONNECT.md](docs/mcp/CONNECT.md#claude-desktop-via-mcp-remote-proxy) for the
+macOS/Linux and Windows config snippets.
+
 ## Configuration
 
 Create `.env` from `.env.example`:

--- a/docs/mcp/CONNECT.md
+++ b/docs/mcp/CONNECT.md
@@ -37,6 +37,39 @@ If running the server separately (Docker, remote host):
 }
 ```
 
+## Claude Desktop (via mcp-remote proxy)
+
+Newer Claude Desktop builds may reject the raw `streamable-http` URL config
+(`{ "url": "...", "transport": "streamable-http" }`), especially when the server runs
+in Docker. The reliable workaround is to proxy the connection locally with the
+[`mcp-remote`](https://www.npmjs.com/package/mcp-remote) npm package, which speaks stdio
+to Claude Desktop and forwards to the HTTP endpoint.
+
+Add one of the following to your `claude_desktop_config.json` under `mcpServers`.
+Replace `<SERVER>` with your Unraid (or MCP server) host.
+
+**macOS / Linux:**
+
+```json
+"unraid": {
+  "command": "npx",
+  "args": ["-y", "mcp-remote", "http://<SERVER>:6970/mcp", "--allow-http"]
+}
+```
+
+**Windows:**
+
+```json
+"unraid": {
+  "command": "wsl",
+  "args": ["npx", "-y", "mcp-remote", "http://<SERVER>:6970/mcp", "--allow-http"]
+}
+```
+
+`--allow-http` permits a plain `http://` endpoint; omit it if the server is reachable
+over `https://`. If the server requires a Bearer token, append
+`--header "Authorization: Bearer <token>"`.
+
 ## Codex CLI
 
 The `.codex-plugin/plugin.json` provides Codex integration:


### PR DESCRIPTION
## Summary

Documents the `mcp-remote` proxy workaround for connecting Claude Desktop to the server, addressing #2.

Newer Claude Desktop builds reject the raw `{ "url": "...", "transport": "streamable-http" }` config when the server runs in Docker. Proxying locally via the `mcp-remote` npm package is a reliable workaround.

## Changes

- **docs/mcp/CONNECT.md** — adds a "Claude Desktop (via mcp-remote proxy)" section with both macOS/Linux (`npx`) and Windows (`wsl`) config snippets, a note on what `--allow-http` does, and how to add a Bearer token header. Placed alongside the existing per-client connection sections.
- **README.md** — adds a short "Claude Desktop" subsection under Installation pointing to the new CONNECT.md section.

Docs-only; no code touched.

Closes #2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to connect Claude Desktop to the server via the `mcp-remote` proxy to avoid `streamable-http` rejections, especially when the server runs in Docker. Adds a docs section with macOS/Linux (`npx`) and Windows (`wsl`) examples, notes on `--allow-http` and Bearer auth, and a README link to the new section.

<sup>Written for commit 03d24f7025ac8ab5f945978fd8740a714f6a0fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

