### PR TITLE
feat: severity + context filtering for live log subactions (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,18 @@ The server registers **3 MCP tools**:
 
 `*` = destructive, requires `confirm=True`
 
+### Log Filtering (`disk/logs`, `live/log_tail`)
+Both log-reading subactions accept optional `level` and `context` params to filter noisy
+streams down to relevant severity:
+- `level` — one of `debug|info|notice|warning|error|critical`. Keeps lines at-or-above the
+  requested severity when a structured level is detectable, else falls back to a
+  case-insensitive keyword match. Omit for unchanged output (backward compatible).
+- `context` — lines of surrounding context kept before/after each match (default `2`).
+  Non-contiguous matches are separated by a `---` marker.
+
+Filtered responses add `matchedLines` (count) and a `filter` echo. The pure helper is
+`filter_log_lines(lines, level=None, context=2)` in `unraid_mcp/core/utils.py`.
+
 ### Destructive Actions (require `confirm=True`)
 - **array**: stop_array, remove_disk, clear_disk_stats
 - **vm**: force_stop, reset

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -150,3 +150,43 @@ def test_collect_actions_all_handled():
         f"COLLECT_ACTIONS keys without handlers in _handle_live: {unhandled}. "
         "Add an if-branch in unraid_mcp/tools/_live.py."
     )
+
+
+@pytest.mark.asyncio
+async def test_log_tail_level_filters_events(_mock_subscribe_collect):
+    _mock_subscribe_collect.return_value = [
+        {
+            "logFile": {
+                "path": "/var/log/syslog",
+                "content": "a info\nb [ERROR] boom\nc info\nd info",
+                "totalLines": 4,
+            }
+        }
+    ]
+    result = await _make_tool()(
+        action="live",
+        subaction="log_tail",
+        path="/var/log/syslog",
+        collect_for=1.0,
+        level="error",
+        context=1,
+    )
+    assert result["filter"] == {"level": "error", "context": 1}
+    log_file = result["events"][0]["logFile"]
+    # match at idx1, context 1 → idx 0..2
+    assert log_file["content"] == "a info\nb [ERROR] boom\nc info"
+    assert log_file["matchedLines"] == 3
+    # original fields preserved
+    assert log_file["path"] == "/var/log/syslog"
+
+
+@pytest.mark.asyncio
+async def test_log_tail_no_level_unchanged(_mock_subscribe_collect):
+    _mock_subscribe_collect.return_value = [
+        {"logFile": {"path": "/var/log/syslog", "content": "a info\nb [ERROR] boom"}}
+    ]
+    result = await _make_tool()(
+        action="live", subaction="log_tail", path="/var/log/syslog", collect_for=1.0
+    )
+    assert result["filter"] is None
+    assert result["events"][0]["logFile"]["content"] == "a info\nb [ERROR] boom"

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -1,0 +1,142 @@
+# tests/test_log_filter.py
+"""Unit tests for the filter_log_lines helper (issue #26)."""
+
+from __future__ import annotations
+
+import pytest
+
+from unraid_mcp.core.utils import filter_log_lines
+
+
+def test_no_level_returns_unchanged():
+    lines = ["a", "b", "c"]
+    assert filter_log_lines(lines) == lines
+    assert filter_log_lines(lines, level=None) == lines
+
+
+def test_no_match_returns_empty():
+    lines = ["info: all good", "debug: tracing"]
+    assert filter_log_lines(lines, level="error") == []
+
+
+def test_structured_level_match_with_context():
+    lines = [
+        "line0 info",
+        "line1 info",
+        "line2 [ERROR] boom",
+        "line3 info",
+        "line4 info",
+        "line5 info",
+    ]
+    result = filter_log_lines(lines, level="error", context=2)
+    # match at idx 2, context 2 → idx 0..4
+    assert result == lines[0:5]
+
+
+def test_context_clamped_at_boundaries():
+    lines = ["[error] first", "next", "last [error]"]
+    result = filter_log_lines(lines, level="error", context=5)
+    # both matches expand to cover the whole list, merged into one group
+    assert result == lines
+
+
+def test_contiguous_groups_merge_no_separator():
+    lines = [
+        "ctx",
+        "[warning] one",
+        "between",
+        "[warning] two",
+        "ctx",
+    ]
+    result = filter_log_lines(lines, level="warning", context=1)
+    # windows [0..2] and [2..4] overlap → single group, no "---"
+    assert "---" not in result
+    assert result == lines
+
+
+def test_non_contiguous_groups_get_separator():
+    lines = [
+        "[error] a",  # 0
+        "b",  # 1
+        "c",  # 2
+        "d",  # 3
+        "e",  # 4
+        "f",  # 5
+        "[error] g",  # 6
+    ]
+    result = filter_log_lines(lines, level="error", context=1)
+    # groups: [0..1] and [5..6], separated by "---"
+    assert result == ["[error] a", "b", "---", "f", "[error] g"]
+
+
+def test_level_threshold_at_or_above():
+    lines = [
+        "debug: d",
+        "info: i",
+        "notice: n",
+        "warning: w",
+        "error: e",
+        "critical: c",
+    ]
+    result = filter_log_lines(lines, level="warning", context=0)
+    # warning and above only
+    assert result == ["warning: w", "error: e", "critical: c"]
+
+
+def test_below_threshold_excluded():
+    lines = ["debug: d", "info: i", "notice: n"]
+    assert filter_log_lines(lines, level="warning", context=0) == []
+
+
+def test_alias_levels_recognized():
+    lines = ["kernel: warn something", "kernel: err other", "kernel: crit bad"]
+    result = filter_log_lines(lines, level="warning", context=0)
+    assert result == lines  # warn, err, crit all >= warning
+
+
+def test_keyword_fallback_when_no_structured_level():
+    # No bracketed/structured token detectable as a severity rank in a way the
+    # threshold path keys on — falls back to substring keyword match.
+    lines = [
+        "the operation completed",
+        "something went wrong",
+        "an Error occurred while syncing",
+    ]
+    result = filter_log_lines(lines, level="error", context=0)
+    assert result == ["an Error occurred while syncing"]
+
+
+def test_keyword_fallback_uses_alias():
+    lines = ["disk is degraded", "WARN: cache filling up"]
+    # "warning" should also keyword-match the alias "warn"
+    result = filter_log_lines(lines, level="warning", context=0)
+    assert "WARN: cache filling up" in result
+
+
+def test_negative_context_treated_as_zero():
+    lines = ["a", "[error] b", "c"]
+    assert filter_log_lines(lines, level="error", context=-3) == ["[error] b"]
+
+
+def test_dedup_overlapping_windows():
+    lines = ["[error] " + str(i) if i % 2 == 0 else str(i) for i in range(5)]
+    result = filter_log_lines(lines, level="error", context=2)
+    # every other line matches with context 2 → whole list, each line once
+    assert result == lines
+    assert len(result) == len(set(map(id, result))) or len(result) == 5
+
+
+@pytest.mark.parametrize(
+    "fmt",
+    [
+        "[ERROR] boom",
+        "level=error boom",
+        "app: error: boom",
+        "2024-01-01 ERROR boom",
+        "<error> boom",
+    ],
+)
+def test_tolerant_level_shapes(fmt):
+    lines = ["ok info", fmt]
+    result = filter_log_lines(lines, level="error", context=0)
+    assert result == [fmt]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -354,3 +354,46 @@ class TestStorageFlashBackup:
             backup_options={"dryRun": True},
         )
         assert _mock_graphql.call_args[0][1]["input"]["options"] == {"dryRun": True}
+
+
+class TestLogsFiltering:
+    """Severity/context filtering on disk/logs (issue #26)."""
+
+    _CONTENT = "line0 info\nline1 info\nline2 [ERROR] boom\nline3 info\nline4 info"
+
+    async def test_logs_no_level_returns_full_content(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "logFile": {"path": "/var/log/syslog", "content": self._CONTENT}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="disk", subaction="logs", log_path="/var/log/syslog")
+        assert result["content"] == self._CONTENT
+        assert "matchedLines" not in result
+
+    async def test_logs_level_filters_content(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "logFile": {"path": "/var/log/syslog", "content": self._CONTENT}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(
+            action="disk",
+            subaction="logs",
+            log_path="/var/log/syslog",
+            level="error",
+            context=1,
+        )
+        # match at line2, context 1 → lines 1..3
+        assert result["content"] == "line1 info\nline2 [ERROR] boom\nline3 info"
+        assert result["matchedLines"] == 3
+        assert result["filter"] == {"level": "error", "context": 1}
+
+    async def test_logs_level_no_match(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "logFile": {"path": "/var/log/syslog", "content": "info: a\ninfo: b"}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(
+            action="disk", subaction="logs", log_path="/var/log/syslog", level="error"
+        )
+        assert result["content"] == ""
+        assert result["matchedLines"] == 0

--- a/unraid_mcp/core/utils.py
+++ b/unraid_mcp/core/utils.py
@@ -39,9 +39,10 @@ _SEVERITY_ALIASES: dict[str, str] = {
 # Matches a structured level token inside a log line. Tolerant of several common
 # shapes: bracketed ([ERROR]), key=value (level=warn), and bare priority words
 # surrounded by separators (... err: ...). Case-insensitive.
-_LEVEL_TOKEN = "|".join(
-    sorted(set(_SEVERITY_ORDER) | set(_SEVERITY_ALIASES), key=len, reverse=True)
+_LEVEL_TOKENS: list[str] = sorted(
+    set(_SEVERITY_ORDER) | set(_SEVERITY_ALIASES), key=lambda t: len(t), reverse=True
 )
+_LEVEL_TOKEN = "|".join(_LEVEL_TOKENS)
 _LEVEL_RE = re.compile(
     r"(?:^|[\[\(<\s:=|/])(" + _LEVEL_TOKEN + r")(?:[\]\)>\s:=|/.,]|$)",
     re.IGNORECASE,

--- a/unraid_mcp/core/utils.py
+++ b/unraid_mcp/core/utils.py
@@ -1,10 +1,138 @@
 """Shared utility functions for Unraid MCP tools."""
 
+import re
 from typing import Any
 from urllib.parse import urlparse
 
 
 _MISSING: object = object()
+
+# Syslog/Unraid severity levels, ordered low → high. A request for ``warning``
+# matches ``warning`` and everything more severe (error, critical, …).
+_SEVERITY_ORDER: tuple[str, ...] = (
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+)
+_SEVERITY_RANK: dict[str, int] = {name: i for i, name in enumerate(_SEVERITY_ORDER)}
+
+# Common aliases seen in syslog / Unraid / kernel log output, mapped to the
+# canonical level name above.
+_SEVERITY_ALIASES: dict[str, str] = {
+    "dbg": "debug",
+    "informational": "info",
+    "warn": "warning",
+    "err": "error",
+    "error": "error",
+    "crit": "critical",
+    "critical": "critical",
+    "alert": "critical",
+    "emerg": "critical",
+    "emergency": "critical",
+    "fatal": "critical",
+    "panic": "critical",
+}
+
+# Matches a structured level token inside a log line. Tolerant of several common
+# shapes: bracketed ([ERROR]), key=value (level=warn), and bare priority words
+# surrounded by separators (... err: ...). Case-insensitive.
+_LEVEL_TOKEN = "|".join(
+    sorted(set(_SEVERITY_ORDER) | set(_SEVERITY_ALIASES), key=len, reverse=True)
+)
+_LEVEL_RE = re.compile(
+    r"(?:^|[\[\(<\s:=|/])(" + _LEVEL_TOKEN + r")(?:[\]\)>\s:=|/.,]|$)",
+    re.IGNORECASE,
+)
+
+
+def _line_severity_rank(line: str) -> int | None:
+    """Return the highest severity rank detected in a log line, or None.
+
+    Scans for a structured level token (bracketed, key=value, or a bare
+    priority word delimited by separators). If several appear, the most severe
+    wins. Returns None when no recognizable level token is present.
+    """
+    best: int | None = None
+    for match in _LEVEL_RE.finditer(line):
+        token = match.group(1).lower()
+        canonical = _SEVERITY_ALIASES.get(token, token)
+        rank = _SEVERITY_RANK.get(canonical)
+        if rank is not None and (best is None or rank > best):
+            best = rank
+    return best
+
+
+def filter_log_lines(
+    lines: list[str],
+    level: str | None = None,
+    context: int = 2,
+) -> list[str]:
+    """Filter log lines by severity, keeping N lines of surrounding context.
+
+    Args:
+        lines: The raw log lines (without trailing newlines).
+        level: Minimum severity to keep, one of
+            ``debug|info|notice|warning|error|critical``. A line matches when
+            its detected level is at-or-above ``level``. When a line has no
+            detectable structured level, the requested level name (and its
+            aliases, e.g. ``warn`` for ``warning``) is matched case-insensitively
+            as a substring keyword fallback. If ``level`` is None, every line
+            matches (no filtering).
+        context: Number of lines of context to include before and after each
+            matching line. Non-contiguous groups are separated by a ``"---"``
+            marker. Defaults to 2.
+
+    Returns:
+        The matching lines plus context, de-duplicated and in original order,
+        with ``"---"`` separators between non-contiguous groups. Returns an
+        empty list when nothing matches.
+
+    Backward compatible: ``filter_log_lines(lines)`` (no level) returns ``lines``
+    unchanged.
+    """
+    if level is None:
+        return list(lines)
+    if context < 0:
+        context = 0
+
+    canonical = _SEVERITY_ALIASES.get(level.lower(), level.lower())
+    threshold = _SEVERITY_RANK.get(canonical)
+
+    # Keyword fallback set: the requested level plus any aliases pointing at the
+    # same canonical level (so level="warning" also keyword-matches "warn").
+    keywords = {level.lower(), canonical}
+    keywords.update(a for a, c in _SEVERITY_ALIASES.items() if c == canonical)
+
+    def _matches(line: str) -> bool:
+        rank = _line_severity_rank(line)
+        if rank is not None and threshold is not None:
+            return rank >= threshold
+        lowered = line.lower()
+        return any(kw in lowered for kw in keywords)
+
+    match_indices = [i for i, line in enumerate(lines) if _matches(line)]
+    if not match_indices:
+        return []
+
+    # Expand each match to its context window, then merge into ordered ranges.
+    keep: set[int] = set()
+    for i in match_indices:
+        start = max(0, i - context)
+        end = min(len(lines) - 1, i + context)
+        keep.update(range(start, end + 1))
+
+    ordered = sorted(keep)
+    result: list[str] = []
+    prev: int | None = None
+    for idx in ordered:
+        if prev is not None and idx != prev + 1:
+            result.append("---")
+        result.append(lines[idx])
+        prev = idx
+    return result
 
 
 def safe_get(data: dict[str, Any], *keys: str, default: Any = None) -> Any:

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -13,7 +13,7 @@ from ..core import client as _client
 from ..core.client import DISK_TIMEOUT
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
-from ..core.utils import format_bytes, validate_subaction
+from ..core.utils import filter_log_lines, format_bytes, validate_subaction
 
 
 # ===========================================================================
@@ -74,6 +74,8 @@ async def _handle_disk(
     backup_options: dict[str, Any] | None,
     ctx: Context | None,
     confirm: bool,
+    level: str | None = None,
+    context: int = 2,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _DISK_SUBACTIONS, "disk")
 
@@ -183,6 +185,13 @@ async def _handle_disk(
             result = data.get("logFile")
             if not result:
                 raise ToolError(f"Log file not found or inaccessible: {log_path}")
-            return dict(result)
+            out = dict(result)
+            if level is not None and isinstance(out.get("content"), str):
+                lines = out["content"].split("\n")
+                filtered = filter_log_lines(lines, level=level, context=context)
+                out["content"] = "\n".join(filtered)
+                out["matchedLines"] = len(filtered)
+                out["filter"] = {"level": level, "context": context}
+            return out
 
         raise ToolError(f"Unhandled disk subaction '{subaction}' — this is a bug")

--- a/unraid_mcp/tools/_live.py
+++ b/unraid_mcp/tools/_live.py
@@ -17,11 +17,36 @@ from ._disk import _ALLOWED_LOG_PREFIXES, _validate_path
 # ===========================================================================
 
 
+def _filter_log_event(event: dict[str, Any], level: str, context: int) -> dict[str, Any]:
+    """Apply severity/context filtering to a single log_tail event's content.
+
+    Each event is shaped ``{"logFile": {"content": "...", ...}}``. The ``content``
+    field is a newline-joined block of log lines. Returns a shallow-copied event
+    with the filtered content and a ``matchedLines`` count. Events lacking a
+    string ``content`` are returned unchanged.
+    """
+    from ..core.utils import filter_log_lines
+
+    log_file = event.get("logFile")
+    if not isinstance(log_file, dict):
+        return event
+    content = log_file.get("content")
+    if not isinstance(content, str):
+        return event
+
+    lines = content.split("\n")
+    filtered = filter_log_lines(lines, level=level, context=context)
+    new_log_file = {**log_file, "content": "\n".join(filtered), "matchedLines": len(filtered)}
+    return {**event, "logFile": new_log_file}
+
+
 async def _handle_live(
     subaction: str,
     path: str | None,
     collect_for: float,
     timeout: float,  # noqa: ASYNC109
+    level: str | None = None,
+    context: int = 2,
 ) -> dict[str, Any]:
     # IMPORTANT: Every key in COLLECT_ACTIONS must have an explicit handler in _handle_live below.
     # Adding to COLLECT_ACTIONS without updating this function causes a ToolError at runtime.
@@ -64,11 +89,14 @@ async def _handle_live(
                 collect_for=collect_for,
                 timeout=timeout,
             )
+            if level is not None:
+                events = [_filter_log_event(e, level, context) for e in events]
             return {
                 "success": True,
                 "subaction": subaction,
                 "path": path,
                 "collect_for": collect_for,
+                "filter": {"level": level, "context": context} if level is not None else None,
                 "event_count": len(events),
                 "events": events,
             }

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -232,6 +232,8 @@ Single entry point for all operations. Use `action` + `subaction` to select an o
 | `name` | str | Name for create/update operations |
 | `path` | str | Log file path (for live/log_tail) |
 | `collect_for` | float | WebSocket collection duration in seconds (default: 5.0) |
+| `level` | str | Filter logs to this severity and above: one of debug, info, notice, warning, error, critical (for `disk/logs` and `live/log_tail`). Omit for no filtering. |
+| `context` | int | Lines of context kept before/after each matching log line (default: 2). Non-contiguous matches are separated by `---`. |
 | `limit` | int | Max items to return (default: 20) |
 | `offset` | int | Pagination offset (default: 0) |
 
@@ -249,6 +251,8 @@ unraid(action="notification", subaction="list", limit=10, list_type="UNREAD")
 unraid(action="disk", subaction="disks")
 unraid(action="live", subaction="cpu", collect_for=3.0)
 unraid(action="live", subaction="log_tail", path="/var/log/syslog", collect_for=5.0)
+unraid(action="live", subaction="log_tail", path="/var/log/syslog", level="warning", context=3)
+unraid(action="disk", subaction="logs", log_path="/var/log/syslog", level="error", context=2)
 unraid(action="array", subaction="stop_array", confirm=True)
 ```
 
@@ -343,6 +347,9 @@ def register_unraid_tool(mcp: FastMCP) -> None:
         path: str | None = None,
         collect_for: float = 5.0,
         timeout: float = 10.0,  # noqa: ASYNC109
+        # log filtering (disk/logs + live/log_tail)
+        level: str | None = None,
+        context: int = 2,
     ) -> dict[str, Any] | str:
         """Interact with an Unraid server's GraphQL API.
 
@@ -397,6 +404,12 @@ def register_unraid_tool(mcp: FastMCP) -> None:
         * Destructive — interactive clients are prompted for confirmation via
           elicitation. Agents and non-interactive callers must pass confirm=True
           to execute these subactions.
+
+        Log filtering (disk/logs, live/log_tail): pass level= to keep only lines
+        at-or-above a severity (debug|info|notice|warning|error|critical) and
+        context= (default 2) for lines of surrounding context around each match.
+        Non-contiguous matches are separated by a '---' marker. Omit level for
+        unchanged output.
         """
         if action == "system":
             return await _handle_system(subaction, device_id)
@@ -419,6 +432,8 @@ def register_unraid_tool(mcp: FastMCP) -> None:
                 backup_options,
                 ctx,
                 confirm,
+                level,
+                context,
             )
 
         if action == "docker":
@@ -466,7 +481,7 @@ def register_unraid_tool(mcp: FastMCP) -> None:
             return await _handle_user(subaction)
 
         if action == "live":
-            return await _handle_live(subaction, path, collect_for, timeout)
+            return await _handle_live(subaction, path, collect_for, timeout, level, context)
 
         raise ToolError(
             f"Invalid action '{action}'. Must be one of: {sorted(get_args(UNRAID_ACTIONS))}"


### PR DESCRIPTION
## Summary
Implements GitHub feature request #26: filter Unraid log streams by severity and include a few lines of surrounding context, so an AI can analyze errors without spending tokens on the full noisy stream.

## What's included
- New pure helper `filter_log_lines(lines, level=None, context=2)` in `unraid_mcp/core/utils.py`:
  - Severity threshold (`debug|info|notice|warning|error|critical`) — matches at-or-above the requested level when a structured level is detectable.
  - Tolerant level parsing for common syslog/Unraid/kernel shapes (`[ERROR]`, `level=warn`, bare `err:`, aliases like `crit`/`emerg`/`fatal`).
  - Case-insensitive keyword fallback when no structured level is present.
  - N lines of context before/after each match, de-duplicated, in order, with `---` separators between non-contiguous groups.
  - Fully backward compatible — no `level` ⇒ lines returned unchanged.
- Wired `level` / `context` params into the `live/log_tail` subaction and `disk/logs` read.
- Thorough unit tests for the helper + handler-level tests.
- Docstring/table updates for the new params.

Closes #26

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds severity and context filtering to Unraid log outputs (both `live/log_tail` and `disk/logs`) so you can pull only warnings/errors with surrounding lines. Cuts noise while keeping useful context.

- **New Features**
  - Added `filter_log_lines(lines, level=None, context=2)` in `unraid_mcp/core/utils.py`.
  - Supports severity thresholds (`debug`→`critical`) with common aliases and tolerant formats; falls back to keyword matching when needed.
  - Keeps N lines of context, merges overlaps, and inserts `---` between gaps.
  - Wired `level`/`context` into `live/log_tail` and `disk/logs`; filtered outputs include `matchedLines` and a `filter` echo, and return unchanged when `level` is omitted. Docs/help updated; tests added.

<sup>Written for commit 9f6ca5b9395c5a8ba90c175ca8dd58d88f777110. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/46?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

