### PR TITLE
feat: replace credential elicitation with plugin userConfig + .env setup hook

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -27,6 +27,21 @@
           {
             "type": "command",
             "command": "diff -q \"${CLAUDE_PLUGIN_ROOT}/uv.lock\" \"${CLAUDE_PLUGIN_DATA}/uv.lock\" >/dev/null 2>&1 || (cp \"${CLAUDE_PLUGIN_ROOT}/uv.lock\" \"${CLAUDE_PLUGIN_DATA}/uv.lock\" && UV_PROJECT_ENVIRONMENT=\"${CLAUDE_PLUGIN_DATA}/.venv\" uv sync --project \"${CLAUDE_PLUGIN_ROOT}\") || rm -f \"${CLAUDE_PLUGIN_DATA}/uv.lock\""
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/plugin-setup.sh"
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "matcher": "user_settings",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/plugin-setup.sh"
           }
         ]
       }

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Connection and system health diagnostics.
 | `check` | Comprehensive health: API latency, array state, alerts, Docker container summary | — |
 | `test_connection` | Ping the Unraid API and return latency in ms | — |
 | `diagnose` | Subscription system status, error counts, reconnect state | — |
-| `setup` | Interactive credential setup (supports MCP elicitation) | — |
+| `setup` | Report credential status and print plugin/`.env` setup instructions | — |
 
 #### `array` — 13 subactions
 

--- a/bin/plugin-setup.sh
+++ b/bin/plugin-setup.sh
@@ -4,10 +4,10 @@
 # Idempotent: writing identical credentials is a no-op-equivalent rewrite.
 set -euo pipefail
 
-# Make a hook failure greppable: `set -e` exits non-zero on a failed `uv run`
-# (missing uv, broken venv), but the raw error gives no hint that *credential
-# setup* is what failed. Note: run_plugin_hook itself exits 0 even when the .env
-# write fails (advisory, by design), so this trap only catches uv/env failures.
+# Make a hook failure greppable: under `set -euo pipefail` any errexit failure
+# (a failed `uv run` from missing uv / broken venv, or an unexpected setup error)
+# prints this marker. Note: run_plugin_hook itself exits 0 even when the .env
+# write fails (advisory, by design), so this trap is mainly the uv/env safety net.
 trap 'echo "plugin-setup.sh: credential setup hook failed (exit $?)" >&2' ERR
 
 REPO_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"

--- a/bin/plugin-setup.sh
+++ b/bin/plugin-setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Persist the plugin's userConfig credentials to ~/.unraid-mcp/.env.
+# Runs `unraid-mcp setup plugin-hook` inside the plugin's uv-managed venv.
+# Idempotent: writing identical credentials is a no-op-equivalent rewrite.
+set -euo pipefail
+
+REPO_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+DATA_ROOT="${CLAUDE_PLUGIN_DATA:-${REPO_ROOT}}"
+VENV_DIR="${DATA_ROOT}/.venv"
+
+UV_PROJECT_ENVIRONMENT="${VENV_DIR}" uv run --project "${REPO_ROOT}" \
+  unraid-mcp setup plugin-hook

--- a/bin/plugin-setup.sh
+++ b/bin/plugin-setup.sh
@@ -4,6 +4,12 @@
 # Idempotent: writing identical credentials is a no-op-equivalent rewrite.
 set -euo pipefail
 
+# Make a hook failure greppable: `set -e` exits non-zero on a failed `uv run`
+# (missing uv, broken venv), but the raw error gives no hint that *credential
+# setup* is what failed. Note: run_plugin_hook itself exits 0 even when the .env
+# write fails (advisory, by design), so this trap only catches uv/env failures.
+trap 'echo "plugin-setup.sh: credential setup hook failed (exit $?)" >&2' ERR
+
 REPO_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 DATA_ROOT="${CLAUDE_PLUGIN_DATA:-${REPO_ROOT}}"
 VENV_DIR="${DATA_ROOT}/.venv"

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -26,11 +26,9 @@ Add it to `~/.unraid-mcp/.env` (preferred) or the project `.env`:
 UNRAID_MCP_BEARER_TOKEN=a3f8c2d1e4b7...
 ```
 
-Or run the interactive setup tool:
-
-```
-unraid(action="health", subaction="setup")
-```
+(The server also auto-generates this token on first HTTP startup if it is absent —
+see [SETUP.md](SETUP.md). `unraid(action="health", subaction="setup")` reports
+credential status but does not set the bearer token.)
 
 ### 3. Configure your MCP client
 

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -7,7 +7,7 @@ Safety and security patterns enforced across the unraid-mcp server.
 ### Storage
 
 - Credentials live in `~/.unraid-mcp/.env` (mode 600, directory mode 700)
-- The elicitation setup wizard writes credentials atomically (tmp file + `os.replace`)
+- The plugin setup hook writes credentials atomically (tmp file + `os.replace`)
 - Credentials are never written to `os.environ` after startup -- all internal consumers read from module globals via `from ..config import settings`
 - Bearer tokens are removed from `os.environ` immediately after being applied to prevent subprocess inheritance
 

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -194,9 +194,11 @@ After installation, users can:
    ```
 
 2. **Check credential status on first run**
-   ```
+
+   ```text
    unraid(action="health", subaction="setup")
    ```
+
    Reports whether credentials are configured and prints setup instructions. Set the
    plugin's *Unraid GraphQL API URL* / *Unraid API Key* fields in the config form — the
    setup hook persists them to `~/.unraid-mcp/.env` on the next session.

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -193,11 +193,13 @@ After installation, users can:
    unraid(action="health", subaction="check")
    ```
 
-2. **Use the credential setup tool on first run**
+2. **Check credential status on first run**
    ```
    unraid(action="health", subaction="setup")
    ```
-   This triggers elicitation to collect and persist credentials to `~/.unraid-mcp/.env`.
+   Reports whether credentials are configured and prints setup instructions. Set the
+   plugin's *Unraid GraphQL API URL* / *Unraid API Key* fields in the config form — the
+   setup hook persists them to `~/.unraid-mcp/.env` on the next session.
 
 3. **Monitor live data via subscriptions**
    ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ The server supports streamable-http (default), SSE (deprecated), and stdio trans
 - `unraid_mcp/server.py`: FastMCP server with 4-layer middleware chain and ASGI bearer auth
 - `unraid_mcp/tools/`: 16 domain modules (array, customization, disk, docker, health, key, live, notification, oidc, plugin, rclone, setting, system, user, vm) plus the consolidated `unraid.py` router
 - `unraid_mcp/subscriptions/`: WebSocket subscription manager, resource registration, diagnostics, and snapshot queries
-- `unraid_mcp/core/`: GraphQL client, elicitation-based setup, destructive action guards, auth middleware
+- `unraid_mcp/core/`: GraphQL client, plugin-option credential setup, destructive action guards, auth middleware
 - `unraid_mcp/config/`: Settings management and structured logging
 - `skills/unraid/SKILL.md`: Client-facing skill documentation
 - `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `gemini-extension.json`: Client manifests
@@ -130,7 +130,9 @@ cp .env.example ~/.unraid-mcp/.env
 chmod 600 ~/.unraid-mcp/.env
 ```
 
-Or use the interactive setup wizard:
+Or, as a Claude Code plugin, set the *Unraid GraphQL API URL* / *Unraid API Key*
+fields in the plugin config form — the setup hook persists them to `~/.unraid-mcp/.env`.
+Check status any time with:
 
 ```python
 unraid(action="health", subaction="setup")

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -9,9 +9,9 @@ Step-by-step instructions to get unraid-mcp running locally, in Docker, or as a 
 - An Unraid server with the API enabled (Settings > Management Access > API Keys)
 - Docker and Docker Compose (for container deployment)
 
-## Option 1: Interactive setup (recommended)
+## Option 1: Claude Code plugin (recommended)
 
-The server includes an elicitation-based setup wizard that collects credentials interactively.
+Configuration is collected by the plugin's config form — no interactive wizard.
 
 1. Install as a Claude Code plugin:
    ```bash
@@ -19,16 +19,18 @@ The server includes an elicitation-based setup wizard that collects credentials 
    /plugin install unraid-mcp @jmagar-claude-homelab
    ```
 
-2. Run the setup wizard:
+2. In the plugin's configuration form, set:
+   - **Unraid GraphQL API URL**: Your Unraid GraphQL endpoint (e.g. `https://10-1-0-2.xxx.myunraid.net:31337`)
+   - **Unraid API Key**: Found in Unraid > Settings > Management Access > API Keys
+
+3. On the next session start (and whenever you change these fields), a setup hook
+   persists them to `~/.unraid-mcp/.env` with mode 600 — so the server, CLI, and
+   Docker all share one source of truth. No manual file editing required.
+
+4. Check status / get help any time:
    ```python
    unraid(action="health", subaction="setup")
    ```
-
-3. The wizard prompts for:
-   - **API URL**: Your Unraid GraphQL endpoint (e.g. `https://10-1-0-2.xxx.myunraid.net:31337`)
-   - **API Key**: Found in Unraid > Settings > Management Access > API Keys
-
-4. Credentials are written to `~/.unraid-mcp/.env` with mode 600.
 
 5. Verify the connection:
    ```python
@@ -114,8 +116,10 @@ unraid(action="system", subaction="overview")
 ## Troubleshooting
 
 **"Credentials not configured"**
-- Run `unraid(action="health", subaction="setup")` to configure interactively
+- Set the plugin's *Unraid GraphQL API URL* / *Unraid API Key* fields (the setup
+  hook persists them to `~/.unraid-mcp/.env`), then restart the server
 - Or create `~/.unraid-mcp/.env` manually from `.env.example`
+- Run `unraid(action="health", subaction="setup")` to see current status + the exact path
 
 **"Connection refused"**
 - Verify `UNRAID_API_URL` is correct and accessible from the server host

--- a/docs/mcp/AUTH.md
+++ b/docs/mcp/AUTH.md
@@ -99,9 +99,9 @@ x-api-key: <UNRAID_API_KEY>
 
 ### Credential sources
 
-1. **Elicitation**: The `health/setup` subaction collects credentials interactively and writes them to `~/.unraid-mcp/.env`
+1. **Plugin userConfig**: The plugin config form supplies `CLAUDE_PLUGIN_OPTION_*` env vars; the `setup plugin-hook` (run on SessionStart / ConfigChange) persists them to `~/.unraid-mcp/.env`
 2. **Environment file**: Loaded from the `.env` priority chain at startup
-3. **Runtime update**: `apply_runtime_config()` updates module globals without touching `os.environ`
+3. **Hand-edited `.env`**: Create `~/.unraid-mcp/.env` directly (mode 600); the server reads it at startup
 
 ### SSL/TLS
 
@@ -126,5 +126,6 @@ These endpoints are handled before `BearerAuthMiddleware` in the ASGI middleware
 
 - [ENV.md](ENV.md) -- Environment variables for auth configuration
 - [TRANSPORT.md](TRANSPORT.md) -- Transport-specific auth requirements
-- [ELICITATION.md](ELICITATION.md) -- Interactive credential setup flow
+- [../SETUP.md](../SETUP.md) -- Credential setup (plugin userConfig + `.env`)
+- [ELICITATION.md](ELICITATION.md) -- Destructive action confirmation flow
 - [../GUARDRAILS.md](../GUARDRAILS.md) -- Security patterns

--- a/docs/mcp/CLAUDE.md
+++ b/docs/mcp/CLAUDE.md
@@ -21,7 +21,7 @@ Documentation for the unraid-mcp MCP server.
 | [PUBLISH.md](PUBLISH.md) | Versioning, PyPI, Docker, and MCP registry publishing |
 | [CONNECT.md](CONNECT.md) | Client connection guides for Claude Code, Codex, Gemini, and direct HTTP |
 | [DEV.md](DEV.md) | Day-to-day development workflow with uv and Justfile recipes |
-| [ELICITATION.md](ELICITATION.md) | Interactive credential setup and destructive action confirmation |
+| [ELICITATION.md](ELICITATION.md) | Destructive action confirmation (credential setup is in SETUP.md) |
 | [PATTERNS.md](PATTERNS.md) | Common code patterns: action routing, GraphQL queries, error handling |
 | [WEBMCP.md](WEBMCP.md) | Health endpoint, well-known discovery, and CORS configuration |
 | [MCPUI.md](MCPUI.md) | Protocol-level UI hints for tool rendering |
@@ -34,7 +34,7 @@ Documentation for the unraid-mcp MCP server.
 3. TRANSPORT.md -- choose a transport and connect
 4. TOOLS.md -- learn available operations (15 domains, 108 subactions)
 5. RESOURCES.md -- discover live subscription data endpoints
-6. ELICITATION.md -- understand the setup wizard and destructive action gates
+6. ELICITATION.md -- understand the destructive action gates
 
 **Experienced developers:**
 - TOOLS.md and RESOURCES.md for the API surface

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -15,7 +15,7 @@ uv run unraid-mcp-server
 just dev
 ```
 
-The server reads credentials from `~/.unraid-mcp/.env`. Create this file from `.env.example` or use the setup wizard.
+The server reads credentials from `~/.unraid-mcp/.env`. Create this file from `.env.example`, or (as a Claude Code plugin) set the credential fields in the plugin config form so the setup hook writes them for you.
 
 ## Docker Compose (recommended for production)
 

--- a/docs/mcp/ELICITATION.md
+++ b/docs/mcp/ELICITATION.md
@@ -65,7 +65,8 @@ _ARRAY_DESTRUCTIVE = {"stop_array", "remove_disk", "clear_disk_stats"}
 
 When the client does not support elicitation (`NotImplementedError`), destructive
 actions return a `ToolError`:
-```
+
+```text
 Action 'stop_array' was not confirmed. Re-run with confirm=True to bypass elicitation.
 ```
 

--- a/docs/mcp/ELICITATION.md
+++ b/docs/mcp/ELICITATION.md
@@ -1,50 +1,20 @@
-# MCP Elicitation
+# MCP Elicitation (Destructive Action Confirmation)
 
-Interactive credential and configuration entry via the MCP elicitation protocol.
+Interactive confirmation of destructive operations via the MCP elicitation protocol.
+
+> **Credential setup is not elicitation-based.** Credentials come from the plugin's
+> `userConfig` form (persisted to `~/.unraid-mcp/.env` by the `setup plugin-hook`)
+> or a hand-edited `.env`. See [../SETUP.md](../SETUP.md) and [ENV.md](ENV.md).
 
 ## What is elicitation
 
-Elicitation is an MCP protocol capability that allows servers to request information from users interactively through the client. Instead of requiring pre-configured environment variables, the server can prompt the user for missing values at runtime.
+Elicitation is an MCP protocol capability that lets the server request explicit
+confirmation from the user through the client before executing a destructive action.
 
 ## When elicitation is used
 
-- **First-run setup**: Server detects missing `UNRAID_API_URL` or `UNRAID_API_KEY` and prompts the user via `health/setup`.
-- **Credential rotation**: User triggers `health/setup` to reconfigure credentials, even when existing credentials are working.
-- **Destructive operation confirmation**: All 12 destructive subactions gate execution behind explicit user acknowledgment.
-
-## Credential setup flow
-
-### Implementation (`core/setup.py`)
-
-The `elicit_and_configure()` function handles first-run and reconfiguration:
-
-1. Client calls `unraid(action="health", subaction="setup")`
-2. If credentials exist:
-   - Server tests the connection (GraphQL query for `online` status)
-   - Reports whether connection is working, failing, or uncertain
-   - Asks via `elicit_reset_confirmation()` whether to overwrite (uses `bool` response type)
-   - If user declines, returns current status without changes
-3. Server sends elicitation request with `_UnraidCredentials` schema:
-   ```
-   Fields:
-     api_url: str  -- Unraid GraphQL endpoint (e.g. https://10-1-0-2.xxx.myunraid.net:31337)
-     api_key: str  -- API key from Unraid Settings > Management Access > API Keys
-   ```
-4. Client renders an interactive form
-5. User fills in values and submits
-6. Server writes to `~/.unraid-mcp/.env` (atomic: tmp file + `os.replace`)
-7. Sets directory to mode 700, file to mode 600
-8. Applies credentials to running process via `apply_runtime_config()`
-9. Returns success message
-
-### Connection probe behavior
-
-The setup wizard always prompts for confirmation before overwriting, even if the current connection is failing. This prevents a transient outage from silently triggering a credential reset.
-
-Status messages:
-- "Credentials already configured (and working)" -- connection test passed
-- "Credentials already configured (but the connection test failed -- may be a transient outage)" -- connection test failed
-- "Credentials not configured" -- no `.env` file found
+- **Destructive operation confirmation only**: the 12 destructive subactions gate
+  execution behind explicit user acknowledgment.
 
 ## Destructive operation confirmation
 
@@ -89,29 +59,19 @@ _ARRAY_DESTRUCTIVE = {"stop_array", "remove_disk", "clear_disk_stats"}
 | Codex CLI | Partial | Text-based prompts |
 | Gemini CLI | Partial | Text-based prompts |
 | MCP Inspector | Full | Form rendering in web UI |
-| Non-interactive | None | Falls back to `ToolError` with instructions |
+| Non-interactive | None | Falls back to `ToolError` instructing `confirm=True` |
 
 ## Fallback for unsupported clients
 
-When the client does not support elicitation (`NotImplementedError`):
-
-**Credential setup**: Returns a `ToolError` with manual instructions:
-```
-Missing required configuration. Create ~/.unraid-mcp/.env with:
-  UNRAID_API_URL=https://your-unraid-server:port
-  UNRAID_API_KEY=your-api-key
-```
-
-**Destructive actions**: Returns a `ToolError` instructing:
+When the client does not support elicitation (`NotImplementedError`), destructive
+actions return a `ToolError`:
 ```
 Action 'stop_array' was not confirmed. Re-run with confirm=True to bypass elicitation.
 ```
 
-**Reset confirmation**: Silently declines the reset (returns False). Overwriting working credentials on a non-interactive client could be destructive.
-
 ## See Also
 
+- [../SETUP.md](../SETUP.md) -- credential setup (plugin userConfig + .env)
 - [AUTH.md](AUTH.md) -- How credentials are used after setup
-- [ENV.md](ENV.md) -- Environment variables set by elicitation
 - [TOOLS.md](TOOLS.md) -- Destructive action list
 - [../GUARDRAILS.md](../GUARDRAILS.md) -- Security patterns

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -72,4 +72,5 @@ The server loads the first `.env` file found:
 
 - [AUTH.md](AUTH.md) -- Authentication details
 - [../CONFIG.md](../CONFIG.md) -- Full configuration reference with timeouts and middleware
-- [ELICITATION.md](ELICITATION.md) -- Interactive credential setup
+- [../SETUP.md](../SETUP.md) -- Credential setup (plugin userConfig + `.env`)
+- [ELICITATION.md](ELICITATION.md) -- Destructive action confirmation

--- a/docs/mcp/LOGS.md
+++ b/docs/mcp/LOGS.md
@@ -43,7 +43,7 @@ The `LoggingMiddleware` (outermost MCP middleware) logs:
 Exception
   +-- ToolError (FastMCP)
   |     +-- ToolError (unraid_mcp) -- user-facing MCP errors
-  +-- CredentialsNotConfiguredError -- triggers elicitation flow
+  +-- CredentialsNotConfiguredError -- surfaces setup instructions
 ```
 
 ### Error handling chain

--- a/docs/mcp/MCPUI.md
+++ b/docs/mcp/MCPUI.md
@@ -30,11 +30,8 @@ Clients that support markdown rendering display this as formatted documentation.
 
 ## Elicitation forms
 
-### Credential setup form
-
-The `_UnraidCredentials` dataclass generates a two-field form:
-- `api_url` (string): "Your Unraid GraphQL endpoint"
-- `api_key` (string): "Found in Unraid > Settings > Management Access > API Keys"
+Elicitation is used only for destructive action confirmation. Credential setup is
+handled by the plugin's `userConfig` form — see [../SETUP.md](../SETUP.md).
 
 ### Destructive confirmation form
 
@@ -45,10 +42,6 @@ The confirmation message includes:
 - Bold action name
 - Human-readable description of the impact
 - "Are you sure you want to proceed?"
-
-### Reset confirmation
-
-Uses a simple `bool` response type, rendering as a yes/no prompt.
 
 ## Response formatting
 
@@ -69,5 +62,5 @@ Tool responses are formatted for LLM consumption:
 ## See Also
 
 - [TOOLS.md](TOOLS.md) -- Tool interface details
-- [ELICITATION.md](ELICITATION.md) -- Interactive form patterns
+- [ELICITATION.md](ELICITATION.md) -- Destructive confirmation form patterns
 - [RESOURCES.md](RESOURCES.md) -- Resource data formats

--- a/docs/mcp/PATTERNS.md
+++ b/docs/mcp/PATTERNS.md
@@ -112,22 +112,19 @@ The factory function handles:
 - Falling back to `subscribe_once` when auto-start is disabled
 - Surfacing terminal errors
 
-## Elicitation pattern
+## Elicitation pattern (destructive confirmation only)
+
+Elicitation is used solely to confirm destructive operations (`core/guards.py`).
+Credential setup is **not** elicitation-based — see [../SETUP.md](../SETUP.md).
 
 ```python
-# Credential collection
+# Boolean confirmation for a destructive action
 result = await ctx.elicit(
-    message="Prompt text with **markdown** formatting",
-    response_type=_UnraidCredentials,  # dataclass with typed fields
+    message="Are you sure?",
+    response_type=_ConfirmAction,  # dataclass with a `confirmed: bool` field
 )
 if result.action != "accept":
     return  # User cancelled
-
-# Boolean confirmation
-result = await ctx.elicit(
-    message="Are you sure?",
-    response_type=bool,
-)
 ```
 
 ## See Also

--- a/docs/mcp/SCHEMA.md
+++ b/docs/mcp/SCHEMA.md
@@ -84,16 +84,8 @@ async def unraid(
 
 ## Elicitation Models
 
-### Credential setup
-
-```python
-@dataclass
-class _UnraidCredentials:
-    api_url: str
-    api_key: str
-```
-
-Used by `elicit_and_configure()` to collect Unraid server credentials interactively.
+Elicitation is used only for destructive action confirmation. Credential setup is
+handled by the plugin's `userConfig` form + `setup plugin-hook` (no elicitation model).
 
 ### Destructive action confirmation
 
@@ -103,10 +95,6 @@ class _ConfirmAction(BaseModel):
 ```
 
 Used by `elicit_destructive_confirmation()` to gate destructive operations.
-
-### Reset confirmation
-
-The reset flow uses a simple `bool` response type to ask whether to overwrite existing credentials.
 
 ## GraphQL Query Organization
 

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -42,7 +42,8 @@ tests/
 +-- test_resources.py              # MCP resource tests
 +-- test_review_regressions.py     # Regression tests
 +-- test_settings.py               # Settings domain tests
-+-- test_setup.py                  # Elicitation setup flow tests
++-- test_setup.py                  # Credential .env write + sentinel error tests
++-- test_plugin_setup.py           # Plugin-option mapping + setup plugin-hook tests
 +-- test_snapshot.py               # WebSocket snapshot tests
 +-- test_storage.py                # Storage/disk domain tests
 +-- test_subscription_manager.py   # Subscription manager tests

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -81,7 +81,7 @@ Health checks, connection testing, diagnostics, and credential setup.
 | `check` | Comprehensive health check (connectivity, array, disks, containers, VMs, resources) | -- |
 | `test_connection` | Test API connectivity and authentication, returns latency | -- |
 | `diagnose` | Detailed diagnostic report with subscription status and middleware error stats | -- |
-| `setup` | Configure credentials interactively via elicitation (stores to `~/.unraid-mcp/.env`) | -- |
+| `setup` | Report credential status and print plugin/`.env` setup instructions (creds persist to `~/.unraid-mcp/.env`) | -- |
 
 #### `array` (13 subactions)
 
@@ -286,7 +286,7 @@ All destructive operations require `confirm=True`. Without it, interactive clien
 Errors use FastMCP's `ToolError` for user-facing messages:
 
 - **ToolError** -- invalid action, subaction, or missing required parameter
-- **CredentialsNotConfiguredError** -- triggers elicitation or setup instructions
+- **CredentialsNotConfiguredError** -- surfaces setup instructions (plugin userConfig + `.env`)
 - **TimeoutError** -- upstream Unraid API did not respond in time
 - **GraphQL errors** -- converted to ToolError with descriptive messages
 
@@ -323,4 +323,4 @@ unraid(action="notification", subaction="list", limit=10, list_type="UNREAD")
 - [SCHEMA.md](SCHEMA.md) -- Schema definitions behind these tools
 - [AUTH.md](AUTH.md) -- Authentication required before tool calls
 - [ENV.md](ENV.md) -- Environment variable configuration
-- [ELICITATION.md](ELICITATION.md) -- Interactive credential and confirmation flows
+- [ELICITATION.md](ELICITATION.md) -- Destructive action confirmation flows

--- a/docs/plugin/SKILLS.md
+++ b/docs/plugin/SKILLS.md
@@ -47,4 +47,4 @@ Credentials are available as `$CLAUDE_PLUGIN_OPTION_*` environment variables (fr
 
 - [PLUGINS.md](PLUGINS.md) -- Plugin manifests that register the skill
 - [../mcp/TOOLS.md](../mcp/TOOLS.md) -- Tool definitions the skill documents
-- [../mcp/ELICITATION.md](../mcp/ELICITATION.md) -- Setup wizard referenced by the skill
+- [../mcp/ELICITATION.md](../mcp/ELICITATION.md) -- Destructive action confirmation referenced by the skill

--- a/docs/repo/MEMORY.md
+++ b/docs/repo/MEMORY.md
@@ -12,7 +12,7 @@ This project uses `bd` (beads) for persistent knowledge instead of MEMORY.md fil
 - 4-layer MCP middleware chain: logging, error handling, rate limiting, response limiting
 - 3-layer ASGI middleware: health bypass, well-known discovery, bearer auth
 - WebSocket subscription manager for 10 live data streams
-- Elicitation-based credential setup and destructive action gating
+- Plugin-option credential setup (setup plugin-hook -> .env) and elicitation-based destructive action gating
 
 ### Critical gotchas
 

--- a/docs/repo/REPO.md
+++ b/docs/repo/REPO.md
@@ -44,7 +44,7 @@ unraid-mcp/
 |   |   +-- exceptions.py              # ToolError, CredentialsNotConfiguredError
 |   |   +-- guards.py                  # Destructive action gating via elicitation
 |   |   +-- middleware_refs.py         # Circular import breaker for error middleware
-|   |   +-- setup.py                   # Elicitation-based credential setup
+|   |   +-- setup.py                   # Plugin-option credential persistence (setup plugin-hook)
 |   |   +-- types.py                   # Shared type definitions
 |   |   +-- utils.py                   # safe_get, safe_display_url, path validation
 |   |   +-- validation.py             # Input validation helpers

--- a/docs/sessions/2026-06-19-remove-elicitation-config.md
+++ b/docs/sessions/2026-06-19-remove-elicitation-config.md
@@ -1,0 +1,140 @@
+---
+date: 2026-06-19 04:06:39 EST
+repo: https://github.com/jmagar/unraid-mcp
+branch: claude/clever-mcnulty-415b5e
+head: 6d947ac
+plan: docs/superpowers/plans/2026-06-19-remove-elicitation-config.md (gitignored local artifact)
+working directory: /home/jmagar/workspace/unraid-mcp/.claude/worktrees/clever-mcnulty-415b5e
+worktree: /home/jmagar/workspace/unraid-mcp/.claude/worktrees/clever-mcnulty-415b5e
+pr: 47 — feat: replace credential elicitation with plugin userConfig + .env setup hook — https://github.com/jmagar/unraid-mcp/pull/47
+beads: No bead activity observed
+---
+
+# Remove elicitation-based server configuration
+
+## User Request
+
+"Use writing plans skill to create a plan to remove the use of elicitation to configure the server," then — after reviewing the Rust `rmcp-template`/`axon`/`lab` config patterns — "leverage" that pattern, and finally "work-it" to execute the plan to a green PR with full review.
+
+## Session Overview
+
+Replaced the MCP-elicitation credential setup flow with the canonical `rmcp-template` pattern: the plugin's `userConfig` form is the configuration UI, and a non-interactive `unraid-mcp setup plugin-hook` command maps `CLAUDE_PLUGIN_OPTION_*` env vars to `~/.unraid-mcp/.env` (atomic, mode 600), wired into `SessionStart`/`ConfigChange` hooks. Destructive-action elicitation in `core/guards.py` was intentionally retained. Work was executed via the `work-it` skill: a written plan, an implementation agent, eight review-wave agents, and CodeRabbit, producing PR #47 with 1056 passing tests and all review threads resolved.
+
+## Sequence of Events
+
+1. **Plan authored** (`writing-plans` skill) after exploring the elicitation surface; saved to the gitignored `docs/superpowers/plans/`.
+2. **Rust pattern review**: three `Explore` agents read `rmcp-template`, `axon`, `lab` configs; discovered unraid-mcp already declares `userConfig` and interpolates `${CLAUDE_PLUGIN_OPTION_*}` in `.mcp.json` — only the persisting `setup plugin-hook` was missing.
+3. **Approach chosen** via AskUserQuestion: "Full rmcp-template port" (setup hook writes `.env`) over the minimal axon-style option.
+4. **Plan rewritten** to the full port (keep + repurpose `_write_env`); `work-it` invoked.
+5. **Rebased** the worktree onto `origin/main` (4 commits incl. `e19c981` empty-cred handling) so the change built on current code.
+6. **Implementation agent** executed the 8-task plan to green (8 commits).
+7. **Review wave** (8 agents in parallel: lavra Python, code-reviewer, silent-failure-hunter, pr-test-analyzer, 3× code-simplifier, comment-analyzer) → triaged and fixed real findings.
+8. **PR #47 created**, then **CodeRabbit** review fixes applied; all 4 inline threads resolved.
+9. **Verification**: full suite 1056 passed; CI green; session note saved.
+
+## Key Findings
+
+- `.mcp.json` already maps `UNRAID_API_URL/KEY` to `${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL/KEY}`, and `.claude-plugin/plugin.json` already declares the `userConfig` schema — so elicitation was redundant for the plugin path.
+- The only runtime consumers of the elicitation functions were in `unraid_mcp/tools/unraid.py` `_handle_health` (setup subaction); `apply_runtime_config` was only called by `elicit_and_configure`, making it dead after removal.
+- Credentials load once at startup (`settings.py:72-73`); after dropping `apply_runtime_config`, a `health/setup` status based purely on `is_configured()` would mislabel a freshly-written-but-unloaded `.env` — fixed by re-checking `CREDENTIALS_ENV_PATH.exists()`.
+
+## Technical Decisions
+
+- **Repurpose, not delete, `setup.py`**: kept the atomic 0600 `_write_env` as the persistence primitive for the new hook.
+- **`run_plugin_hook` always exits 0** (advisory) so a credential issue never blocks a session; write failures and present-but-rejected values are surfaced in `advisory_failures` instead of escaping.
+- **Keep destructive-action elicitation** (`core/guards.py`) — out of scope; it confirms operations, not configuration.
+- **No manual version bumps** — release-please owns versioning.
+- **Declined** strict URL-scheme validation and a `TypedDict` report shape as over-engineering; the connection test already surfaces a bad URL.
+
+## Files Changed
+
+| status | path | purpose | evidence |
+|---|---|---|---|
+| modified | unraid_mcp/core/setup.py | remove elicitation; add `apply_plugin_options`/`run_plugin_hook`; keep `_write_env` | 1056 tests pass |
+| modified | unraid_mcp/main.py | `setup [plugin-hook]` dispatch; reject unknown subcommands | test_plugin_setup |
+| modified | unraid_mcp/tools/unraid.py | non-interactive `health/setup` reporter; file-aware status | test_health |
+| modified | unraid_mcp/tools/_health.py | corrected module docstring (circular-import reason) | comment-analyzer |
+| modified | unraid_mcp/config/settings.py | drop `apply_runtime_config`; update comment | grep clean |
+| modified | unraid_mcp/core/client.py | comment no longer references apply_runtime_config | grep clean |
+| modified | unraid_mcp/core/exceptions.py | reword `CredentialsNotConfiguredError` docstring | — |
+| modified | unraid_mcp/server.py | startup warning describes env/userConfig, not elicitation | test_setup |
+| created | bin/plugin-setup.sh | hook wrapper running `unraid-mcp setup plugin-hook` | shellcheck ok |
+| modified | .claude-plugin/plugin.json | SessionStart + ConfigChange setup hooks | json valid |
+| modified | hooks/hooks.json | mirror setup-hook wiring | json valid |
+| modified | hooks/CLAUDE.md | accurate authoritative-hooks note | docs review |
+| created | tests/test_plugin_setup.py | cover options mapping, hook write/advisory, dispatch | 21 pass |
+| modified | tests/test_setup.py | drop elicitation tests; keep `_write_env` tests | 18 pass |
+| modified | tests/test_health.py | non-interactive setup tests incl. file-exists branch | 27 pass |
+| modified | docs/SETUP.md, README.md, docs/mcp/ELICITATION.md, docs/mcp/CLAUDE.md, docs/AUTHENTICATION.md, docs/MARKETPLACE.md, +others | describe userConfig + .env flow; scope ELICITATION.md to destructive actions | doc sweep |
+
+## Beads Activity
+
+No bead activity observed. `bd` was not used this session; the injected context reported no recent beads.
+
+## Repository Maintenance
+
+- **Plans**: the plan lives under gitignored `docs/superpowers/plans/` (not tracked) — no move needed; it is the completed source for this PR.
+- **Beads**: none relevant; no tracker state changed.
+- **Worktrees/branches**: inspected `git worktree list`; left all other worktrees (`nifty-haibt-da9825`, agent worktrees) untouched — not owned by this session. The rebase fast-forwarded this branch onto `origin/main` cleanly.
+- **Stale docs**: updated as part of the PR (incl. `docs/AUTHENTICATION.md` which the doc-review agent flagged as still implying interactive setup). No further stale docs identified.
+
+## Tools and Skills Used
+
+- **Skills**: `superpowers:writing-plans`, `superpowers:executing-plans` (via impl agent), `vibin:work-it`, `vibin:save-to-md`.
+- **Agents**: 3× `Explore` (Rust config review), 1× `general-purpose` (implementation), 8× review agents (lavra kieran-python-reviewer, pr-review-toolkit code-reviewer/silent-failure-hunter/pr-test-analyzer/comment-analyzer, 3× code-simplifier). No agent dispatch failures.
+- **Shell/CLI**: `git`, `uv` (pytest/ruff/ty), `gh` (PR + GraphQL thread resolution), `shellcheck`. CodeRabbit external reviewer; Codex hit usage limits (no review). No other issues.
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `git rebase origin/main` | fast-forwarded onto b97284c |
+| `uv run pytest` | 1056 passed |
+| `uv run ruff check / format --check` | clean (84 files) |
+| `uv run ty check unraid_mcp/` | All checks passed |
+| `shellcheck bin/plugin-setup.sh` | ok |
+| `gh pr create` | PR #47 |
+| `gh api graphql resolveReviewThread` | 4 threads resolved |
+
+## Errors Encountered
+
+- **NUL-byte test failed**: `patch.dict(os.environ, {"...": "x\0y"})` raised `ValueError: embedded null byte` — the OS rejects NUL in env. Resolved by testing `\0` directly against `_safe_env_value` and parametrizing the env-based test to `\n`/`\r` only.
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Credential setup | `health/setup` prompted via `ctx.elicit` (hung on non-interactive clients) | plugin `userConfig` form → `setup plugin-hook` writes `~/.unraid-mcp/.env`; `health/setup` reports status only |
+| Missing creds at startup | warned "will prompt via elicitation" | warns to set userConfig / `.env` and restart |
+| `health/setup` with unloaded `.env` | n/a | distinctly reports "file exists but not loaded — restart" |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `uv run pytest` | all pass | 1056 passed | pass |
+| `uv run ruff check` | clean | All checks passed | pass |
+| `uv run ty check unraid_mcp/` | clean | All checks passed | pass |
+| grep elicit_/apply_runtime_config in unraid_mcp/tests | none | none | pass |
+| grep `ctx.elicit` | guards.py only | guards.py:45 only | pass |
+| `gh pr checks 47` | green | all pass (MCP Integration pending at note time) | pass |
+
+## Risks and Rollback
+
+- Low risk. The hooks merge behavior (plugin.json inline vs `hooks/hooks.json`) is based on documented plugin-structure guidance; `bin/plugin-setup.sh` is idempotent so a double-run is harmless. Rollback: revert PR #47 — credentials still load from `.env`/env, unaffected.
+
+## Decisions Not Taken
+
+- Strict `http(s)://` URL validation in `apply_plugin_options` — rejected (connection test already surfaces a bad URL; avoids false rejections).
+- `TypedDict` for the hook report — rejected as over-engineering.
+- Removing the pre-existing dead `get_api_credentials()` — out of scope.
+
+## References
+
+- PR: https://github.com/jmagar/unraid-mcp/pull/47
+- Pattern source: `~/workspace/rmcp-template` (`setup plugin-hook`, `env_registry`), `~/workspace/axon`, `~/workspace/lab`.
+
+## Next Steps
+
+- Merge PR #47 once `MCP Integration Tests` finishes green (all other CI checks pass).
+- Optional follow-up: remove dead `get_api_credentials()` in `settings.py` (pre-existing, unrelated).

--- a/docs/stack/ARCH.md
+++ b/docs/stack/ARCH.md
@@ -98,15 +98,17 @@ MCP Client (Claude Code / Codex / Gemini / HTTP)
 6. If failed (terminal state): return error message
 7. If auto-start disabled: fall back to `subscribe_once` one-shot query
 
-### Credential setup (elicitation)
+### Credential setup (plugin userConfig + setup hook)
 
-1. Client calls `unraid(action="health", subaction="setup")`
-2. If credentials exist: probe connection, ask to reset via elicitation
-3. If resetting or first run: send `_UnraidCredentials` elicitation form
-4. User fills in API URL and key
-5. Write to `~/.unraid-mcp/.env` (atomic: tmp + `os.replace`)
-6. Apply to running process via `apply_runtime_config()`
-7. Return success message
+1. User sets *Unraid GraphQL API URL* / *Unraid API Key* in the plugin's config form
+2. Claude Code injects them as `CLAUDE_PLUGIN_OPTION_*` env vars and fires the
+   SessionStart / ConfigChange hooks, which run `unraid-mcp setup plugin-hook`
+3. `run_plugin_hook()` maps the plugin options to canonical names (`apply_plugin_options()`),
+   rejecting empty/newline-injected values
+4. If both URL and key are present: write to `~/.unraid-mcp/.env` (atomic: tmp + `os.replace`, mode 600)
+5. The server, CLI, and Docker read those credentials from `.env`/env at startup
+6. `unraid(action="health", subaction="setup")` reports status and prints instructions —
+   it never prompts interactively
 
 ## Key design decisions
 

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,5 +1,10 @@
 # `hooks/`
 
+> **Authoritative hooks live in `.claude-plugin/plugin.json`.** Claude Code loads both
+> the inline `plugin.json` hooks and `hooks/hooks.json` and merges them, so this file
+> mirrors the same wiring. All hook wrappers are idempotent (`bin/sync-uv.sh`,
+> `bin/plugin-setup.sh`), so a double-run from both sources is harmless. Keep the two in sync.
+
 Use this subtree only for hook entrypoints that are called from `hooks/hooks.json`.
 
 - Put hook-specific wrappers here when Claude Code needs to run them automatically

--- a/hooks/CLAUDE.md
+++ b/hooks/CLAUDE.md
@@ -1,9 +1,12 @@
 # `hooks/`
 
-> **Authoritative hooks live in `.claude-plugin/plugin.json`.** Claude Code loads both
-> the inline `plugin.json` hooks and `hooks/hooks.json` and merges them, so this file
-> mirrors the same wiring. All hook wrappers are idempotent (`bin/sync-uv.sh`,
-> `bin/plugin-setup.sh`), so a double-run from both sources is harmless. Keep the two in sync.
+> **Authoritative hooks live in `.claude-plugin/plugin.json`** (declared inline). This
+> `hooks/hooks.json` is kept as a mirror for environments/tooling that read the default
+> `hooks/` location. The two are not byte-identical — `plugin.json` inlines the uv-sync
+> command while this file calls `bin/sync-uv.sh` — but both end SessionStart by running
+> `bin/plugin-setup.sh` and define the same `ConfigChange` hook. Every wrapper is
+> idempotent, so if both sources are loaded a double-run is harmless. When changing the
+> setup/ConfigChange wiring, update both files.
 
 Use this subtree only for hook entrypoints that are called from `hooks/hooks.json`.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,6 +6,21 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/bin/sync-uv.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/plugin-setup.sh"
+          }
+        ]
+      }
+    ],
+    "ConfigChange": [
+      {
+        "matcher": "user_settings",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/bin/plugin-setup.sh"
           }
         ]
       }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,7 +196,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401", "D104"]
-"tests/**/*.py" = ["D", "S101", "S105", "S106", "S107", "PLR2004", "N815"]  # Allow test-only patterns; N815 permits camelCase Pydantic fields that mirror GraphQL response keys
+"tests/**/*.py" = ["D", "S101", "S105", "S106", "S107", "S603", "S607", "PLR2004", "N815"]  # Allow test-only patterns; S603/S607 permit subprocess-driven shell tests; N815 permits camelCase Pydantic fields that mirror GraphQL response keys
 "tests/test_docker.py" = ["D", "S101", "S104", "S105", "S106", "S107", "PLR2004", "N815"]  # docker port mock fixtures use literal "0.0.0.0"
 
 [tool.ruff.lint.pydocstyle]

--- a/skills/unraid/README.md
+++ b/skills/unraid/README.md
@@ -15,7 +15,7 @@ The skill drives the single `unraid` MCP tool, which uses `action` (domain) +
 skills/unraid/
 ├── SKILL.md                       # Main skill documentation (domains, subactions, examples)
 ├── README.md                      # This file
-├── load-env.sh                    # Sources ~/.unraid-mcp/.env for the HTTP fallback (sourced, not run)
+├── load-env.sh                    # Parses ~/.unraid-mcp/.env for the HTTP fallback (this library is sourced, not run)
 ├── scripts/
 │   ├── unraid-query.sh            # GraphQL query helper (sources load-env.sh)
 │   └── dashboard.sh               # System dashboard (single server, or a multi-server fleet)
@@ -45,8 +45,9 @@ This skill ships with the Unraid MCP plugin. Install via the Claude Code marketp
 Configuration comes from the plugin's **userConfig** form (*Unraid GraphQL API URL* /
 *Unraid API Key*). Claude Code injects those values as `CLAUDE_PLUGIN_OPTION_*` only into
 plugin subprocesses (hooks/MCP), **not** the Bash tool — so the plugin's setup hook reads
-them and writes `~/.unraid-mcp/.env`, and the skill's scripts source that file via
-`load-env.sh`. For manual/Docker installs, create `~/.unraid-mcp/.env` directly:
+them and writes `~/.unraid-mcp/.env`, and the skill's scripts read that file via
+`load-env.sh` (which parses it, not sources it). For manual/Docker installs, create
+`~/.unraid-mcp/.env` directly:
 
 ```bash
 UNRAID_API_URL=https://your-unraid-server/graphql

--- a/skills/unraid/README.md
+++ b/skills/unraid/README.md
@@ -1,160 +1,100 @@
-# Unraid API Skill
+# Unraid Skill
 
-Query and monitor Unraid servers via the GraphQL API.
+Query, monitor, and manage Unraid servers through the consolidated `unraid` MCP tool,
+with a `curl`-based HTTP fallback for when MCP tools are unavailable.
 
 ## What's Included
 
-This skill provides complete access to all 27 read-only Unraid GraphQL API endpoints.
+The skill drives the single `unraid` MCP tool, which uses `action` (domain) +
+`subaction` (operation) routing across 15 domains and ~108 subactions — e.g.
+`unraid(action="docker", subaction="list")`. See `SKILL.md` for the full domain tables.
 
 ### Files
 
 ```text
 skills/unraid/
-├── SKILL.md                           # Main skill documentation
-├── README.md                          # This file
+├── SKILL.md                       # Main skill documentation (domains, subactions, examples)
+├── README.md                      # This file
+├── load-env.sh                    # Sources ~/.unraid-mcp/.env for the HTTP fallback (sourced, not run)
 ├── scripts/
-│   └── unraid-query.sh               # GraphQL query helper script
+│   ├── unraid-query.sh            # GraphQL query helper (sources load-env.sh)
+│   └── dashboard.sh               # System dashboard (single server, or a multi-server fleet)
 ├── examples/
-│   ├── monitoring-dashboard.sh       # Complete system dashboard
-│   ├── disk-health.sh                # Disk temperature & health check
-│   └── read-logs.sh                  # Log file reader
+│   ├── disk-health.sh             # Disk temperature & health check
+│   └── read-logs.sh               # Log file reader
 └── references/
-    ├── api-reference.md              # Complete API documentation
-    └── quick-reference.md            # Common queries cheat sheet
+    ├── quick-reference.md         # Common operations cheat sheet
+    ├── troubleshooting.md         # Error → fix guide
+    ├── api-reference.md           # GraphQL API reference
+    ├── endpoints.md               # Endpoint catalog
+    ├── introspection-schema.md    # Introspection notes
+    └── schema.graphql             # Raw GraphQL schema
 ```
 
 ## Installation
 
-This skill is part of the Unraid MCP plugin. Install via the Claude Code marketplace:
+This skill ships with the Unraid MCP plugin. Install via the Claude Code marketplace:
 
 ```bash
 /plugin marketplace add jmagar/unraid-mcp
-/plugin install unraid @unraid-mcp
+/plugin install unraid-mcp @unraid-mcp
 ```
 
-The plugin includes both the MCP server and this skill at `skills/unraid/`.
+## Credentials
+
+Configuration comes from the plugin's **userConfig** form (*Unraid GraphQL API URL* /
+*Unraid API Key*). Claude Code injects those values as `CLAUDE_PLUGIN_OPTION_*` only into
+plugin subprocesses (hooks/MCP), **not** the Bash tool — so the plugin's setup hook reads
+them and writes `~/.unraid-mcp/.env`, and the skill's scripts source that file via
+`load-env.sh`. For manual/Docker installs, create `~/.unraid-mcp/.env` directly:
+
+```bash
+UNRAID_API_URL=https://your-unraid-server/graphql
+UNRAID_API_KEY=your-api-key
+```
+
+Credentials are read once at server startup — restart the server after changing them.
+Check status any time (read-only) with `unraid(action="health", subaction="setup")`.
 
 ## Quick Start
 
-1. **Set your credentials:**
-   ```bash
-   export UNRAID_URL="https://your-unraid-server/graphql"
-   export UNRAID_API_KEY="your-api-key"
-   ```
+Preferred — use the MCP tool:
 
-2. **Run a query:**
-   ```bash
-   cd skills/unraid
-   ./scripts/unraid-query.sh -q "{ online }"
-   ```
+```python
+unraid(action="system", subaction="overview")
+unraid(action="health", subaction="check")
+unraid(action="docker", subaction="list")
+```
 
-3. **Run examples:**
-   ```bash
-   ./examples/monitoring-dashboard.sh
-   ./examples/disk-health.sh
-   ```
+HTTP fallback (when MCP tools are unavailable) — the helper sources `load-env.sh` for you:
+
+```bash
+"$CLAUDE_PLUGIN_ROOT/skills/unraid/scripts/unraid-query.sh" -q "{ online }"
+"$CLAUDE_PLUGIN_ROOT/skills/unraid/examples/disk-health.sh"
+```
 
 ## Triggers
 
-This skill activates when you mention:
-- "check Unraid"
-- "monitor Unraid"
-- "Unraid API"
-- "Unraid disk temperatures"
-- "Unraid array status"
-- "read Unraid logs"
-- And more Unraid-related monitoring tasks
-
-## Features
-
-- **27 working endpoints** - All read-only queries documented
-- **Helper script** - Easy CLI interface for GraphQL queries
-- **Example scripts** - Ready-to-use monitoring scripts
-- **Complete reference** - Detailed documentation with examples
-- **Quick reference** - Common queries cheat sheet
-
-## Endpoints Covered
-
-### System & Monitoring
-- System info (CPU, OS, hardware)
-- Real-time metrics (CPU %, memory %)
-- Configuration & settings
-- Log files (list & read)
-
-### Storage
-- Array status & disks
-- All physical disks (including cache/USB)
-- Network shares
-- Parity check status
-
-### Virtualization
-- Docker containers
-- Virtual machines
-
-### Power & Alerts
-- UPS devices
-- System notifications
-
-### Administration
-- API key management
-- User & authentication
-- Server registration
-- UI customization
+Activates on Unraid-related requests: check server health, array/parity status, disk
+temperatures, Docker container list/restart, VM start/stop, system logs, notifications,
+UPS/power status, live CPU/memory, API keys, and rclone remotes.
 
 ## Requirements
 
-- **Unraid 7.2+** (GraphQL API)
-- **API Key** with Viewer role
-- **jq** for JSON parsing (usually pre-installed)
-- **curl** for HTTP requests
-
-## Getting an API Key
-
-1. Log in to Unraid WebGUI
-2. Settings → Management Access → API Keys
-3. Click "Create API Key"
-4. Name: "monitoring" (or whatever you like)
-5. Role: Select "Viewer" (read-only)
-6. Copy the generated key
+- Unraid server with the GraphQL API enabled, and an API key (Settings → Management
+  Access → API Keys)
+- `curl` and `jq` for the HTTP fallback scripts (usually pre-installed)
 
 ## Documentation
 
-- **SKILL.md** - Start here for task-oriented guidance
-- **references/api-reference.md** - Complete endpoint reference
-- **references/quick-reference.md** - Quick query examples
-
-## Examples
-
-### System Status
-```bash
-./scripts/unraid-query.sh -q "{ online metrics { cpu { percentTotal } } }"
-```
-
-### Disk Health
-```bash
-./examples/disk-health.sh
-```
-
-### Complete Dashboard
-```bash
-./examples/monitoring-dashboard.sh
-```
-
-### Read Logs
-```bash
-./examples/read-logs.sh syslog 20
-```
+- `SKILL.md` — task-oriented guidance and the full domain/subaction tables
+- `references/quick-reference.md` — common operations cheat sheet
+- `references/troubleshooting.md` — error → fix guide
+- `references/api-reference.md` / `schema.graphql` — GraphQL API reference
 
 ## Notes
 
-- Disk/array sizes are in **kilobytes**; memory values (from `info.memory` and `metrics.memory`) are in **bytes**
-- Temperatures are in **Celsius**
-- Docker container logs are **not accessible** via API (use SSH)
-- Poll no faster than every **5 seconds** to avoid server load
-
-## Version
-
-- **Skill Version:** 0.2.0
-- **API Version:** Unraid 7.2 GraphQL
-- **Tested:** 2026-01-21
-- **Endpoints:** 27 working read-only queries
+- Array/disk sizes are in **kilobytes**; memory values are in **bytes**; temperatures in **Celsius**.
+- Docker container logs are **not** available via the API — use SSH + `docker logs`.
+- Destructive subactions require `confirm=True` (see the Destructive Actions table in `SKILL.md`).
+- Rate limit: 100 requests / 10 seconds.

--- a/skills/unraid/SKILL.md
+++ b/skills/unraid/SKILL.md
@@ -9,11 +9,11 @@ description: "This skill should be used when the user mentions Unraid, asks to c
 
 **MCP mode** (preferred): Use when `mcp__unraid-mcp__unraid` tool is available.
 
-**HTTP fallback**: Use when MCP tools are unavailable. Credentials are in Bash subprocesses
-as `$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL` and `$CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY`.
-Do NOT attempt `${user_config.unraid_api_key}` in curl — sensitive values only work
-as `$CLAUDE_PLUGIN_OPTION_*` in Bash subprocesses. The fallback queries the Unraid
-GraphQL API directly with these credentials.
+**HTTP fallback**: Use when MCP tools are unavailable. Credentials live in the file
+`~/.unraid-mcp/.env`; source it before running `curl` (see "HTTP Fallback Mode" below).
+Do NOT use `$CLAUDE_PLUGIN_OPTION_*` in the Bash tool — Claude Code injects those vars
+only into plugin subprocesses (hooks/MCP/LSP), not the Bash tool. The plugin's setup
+hook reads them and materializes `~/.unraid-mcp/.env`; the skill sources that file.
 
 ---
 
@@ -21,13 +21,19 @@ Use the single `unraid` MCP tool with `action` (domain) + `subaction` (operation
 
 ## Setup
 
-First time? Run setup to configure credentials:
+Credentials come from the plugin's configuration form (*Unraid GraphQL API URL* /
+*Unraid API Key*) or a hand-edited `~/.unraid-mcp/.env`. They are read once at server
+startup, so after changing them you must restart the server / MCP client.
+
+To check whether credentials are configured and the connection works:
 
 ```
-unraid(action="health", subaction="setup")
+unraid(action="health", subaction="setup")            # read-only status + instructions
+unraid(action="health", subaction="test_connection")  # verify connectivity
 ```
 
-Credentials are stored at `~/.unraid-mcp/.env`. Re-run `setup` any time to update or verify.
+`setup` does not prompt for or write credentials — it only reports the current status
+and explains how to set them.
 
 ## Calling Convention
 
@@ -79,14 +85,14 @@ unraid(action="live",    subaction="cpu")
 | `check` | Comprehensive health check — connectivity, array, disks, containers, VMs, resources |
 | `test_connection` | Test API connectivity and authentication |
 | `diagnose` | Detailed diagnostic report with troubleshooting recommendations |
-| `setup` | Configure credentials interactively (stores to `~/.unraid-mcp/.env`) |
+| `setup` | Report credential status + setup instructions (read-only; does not write or prompt) |
 
 ### `array` — Array & Parity
 | Subaction | Description |
 |-----------|-------------|
 | `parity_status` | Current parity check progress and status |
 | `parity_history` | Historical parity check results |
-| `parity_start` | Start a parity check |
+| `parity_start` | Start a parity check (requires `correct` — `True` writes corrections, `False` checks only) |
 | `parity_pause` | Pause a running parity check |
 | `parity_resume` | Resume a paused parity check |
 | `parity_cancel` | Cancel a running parity check |
@@ -138,7 +144,7 @@ unraid(action="live",    subaction="cpu")
 | Subaction | Description |
 |-----------|-------------|
 | `overview` | Notification counts (unread, archived by type) |
-| `list` | List notifications (optional `filter`, `limit`, `offset`) |
+| `list` | List notifications (requires `list_type`: `UNREAD`/`ARCHIVE`; optional `importance`, `limit`, `offset`) |
 | `mark_unread` | Mark a notification as unread (requires `notification_id`) |
 | `create` | Create a notification (requires `title`, `subject`, `description`, `importance`) |
 | `archive` | Archive a notification (requires `notification_id`) |
@@ -226,7 +232,7 @@ These use persistent WebSocket connections. Returns a "connecting" placeholder o
 
 ## Destructive Actions
 
-All require `confirm=True` as an explicit parameter. Without it, the action is blocked and elicitation is triggered.
+All require `confirm=True` as an explicit parameter. Without it, the action is blocked: interactive MCP clients are asked to confirm (elicitation), and non-interactive callers get a `ToolError` — re-run with `confirm=True`.
 
 | Domain | Subaction | Risk |
 |--------|-----------|------|
@@ -247,10 +253,10 @@ All require `confirm=True` as an explicit parameter. Without it, the action is b
 
 ## Common Workflows
 
-### First-time setup
+### Verify credentials
 ```
-unraid(action="health", subaction="setup")
-unraid(action="health", subaction="check")
+unraid(action="health", subaction="setup")            # status + instructions (read-only)
+unraid(action="health", subaction="test_connection")  # confirm connectivity
 ```
 
 ### System health overview
@@ -307,25 +313,37 @@ unraid(action="vm", subaction="force_stop", vm_id="<id>", confirm=True)
 
 ## HTTP Fallback Mode
 
-When MCP tools are unavailable, use direct GraphQL queries via curl. Credentials are
-available as `$CLAUDE_PLUGIN_OPTION_*` environment variables in Bash subprocesses.
+When MCP tools are unavailable, query the GraphQL API directly with `curl`. Source the
+credentials file first — `$CLAUDE_PLUGIN_OPTION_*` is **not** set in the Bash tool, so
+read `~/.unraid-mcp/.env` (which the plugin's setup hook materializes) instead. The
+bundled `load-env.sh` does this for you:
 
 ```bash
+# Load UNRAID_API_URL / UNRAID_API_KEY from ~/.unraid-mcp/.env
+source "$CLAUDE_PLUGIN_ROOT/skills/unraid/load-env.sh"
+load_unraid_credentials || exit 1
+
 # System overview
-curl -s "$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL" \
-  -H "x-api-key: $CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY" \
+curl -s "$UNRAID_API_URL" \
+  -H "x-api-key: $UNRAID_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"query":"{ info { os { hostname uptime } } }"}'
 
 # List Docker containers
-curl -s "$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL" \
-  -H "x-api-key: $CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY" \
+curl -s "$UNRAID_API_URL" \
+  -H "x-api-key: $UNRAID_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"query":"{ docker { containers { names state status } } }"}'
 
 # Array status
-curl -s "$CLAUDE_PLUGIN_OPTION_UNRAID_API_URL" \
-  -H "x-api-key: $CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY" \
+curl -s "$UNRAID_API_URL" \
+  -H "x-api-key: $UNRAID_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"query":"{ array { state capacity { kilobytes { free used total } } disks { name status temp } } }"}'
+```
+
+Or use the helper script, which sources `load-env.sh` automatically:
+
+```bash
+"$CLAUDE_PLUGIN_ROOT/skills/unraid/scripts/unraid-query.sh" -q "{ online }"
 ```

--- a/skills/unraid/SKILL.md
+++ b/skills/unraid/SKILL.md
@@ -27,7 +27,7 @@ startup, so after changing them you must restart the server / MCP client.
 
 To check whether credentials are configured and the connection works:
 
-```
+```text
 unraid(action="health", subaction="setup")            # read-only status + instructions
 unraid(action="health", subaction="test_connection")  # verify connectivity
 ```
@@ -37,12 +37,12 @@ and explains how to set them.
 
 ## Calling Convention
 
-```
+```text
 unraid(action="<domain>", subaction="<operation>", [additional params])
 ```
 
 **Examples:**
-```
+```text
 unraid(action="system",  subaction="overview")
 unraid(action="docker",  subaction="list")
 unraid(action="health",  subaction="check")
@@ -58,6 +58,7 @@ unraid(action="live",    subaction="cpu")
 ## All Domains and Subactions
 
 ### `system` — Server Information
+
 | Subaction | Description |
 |-----------|-------------|
 | `overview` | Complete system summary (recommended starting point) |
@@ -80,6 +81,7 @@ unraid(action="live",    subaction="cpu")
 | `ups_config` | UPS configuration |
 
 ### `health` — Diagnostics
+
 | Subaction | Description |
 |-----------|-------------|
 | `check` | Comprehensive health check — connectivity, array, disks, containers, VMs, resources |
@@ -88,6 +90,7 @@ unraid(action="live",    subaction="cpu")
 | `setup` | Report credential status + setup instructions (read-only; does not write or prompt) |
 
 ### `array` — Array & Parity
+
 | Subaction | Description |
 |-----------|-------------|
 | `parity_status` | Current parity check progress and status |
@@ -105,6 +108,7 @@ unraid(action="live",    subaction="cpu")
 | `clear_disk_stats` | ⚠️ Clear disk statistics (requires `confirm=True`) |
 
 ### `disk` — Storage & Logs
+
 | Subaction | Description |
 |-----------|-------------|
 | `shares` | List network shares |
@@ -115,6 +119,7 @@ unraid(action="live",    subaction="cpu")
 | `flash_backup` | ⚠️ Trigger a flash backup (requires `confirm=True`) |
 
 ### `docker` — Containers
+
 | Subaction | Description |
 |-----------|-------------|
 | `list` | All containers with status, image, state |
@@ -128,6 +133,7 @@ unraid(action="live",    subaction="cpu")
 **Container Identification:** Name, ID, or partial name (fuzzy match supported).
 
 ### `vm` — Virtual Machines
+
 | Subaction | Description |
 |-----------|-------------|
 | `list` | All VMs with state |
@@ -141,6 +147,7 @@ unraid(action="live",    subaction="cpu")
 | `reset` | ⚠️ Hard reset a VM (requires `vm_id`, `confirm=True`) |
 
 ### `notification` — Notifications
+
 | Subaction | Description |
 |-----------|-------------|
 | `overview` | Notification counts (unread, archived by type) |
@@ -157,6 +164,7 @@ unraid(action="live",    subaction="cpu")
 | `recalculate` | Recalculate notification counts |
 
 ### `key` — API Keys
+
 | Subaction | Description |
 |-----------|-------------|
 | `list` | All API keys |
@@ -168,6 +176,7 @@ unraid(action="live",    subaction="cpu")
 | `remove_role` | Remove a role from a key (requires `key_id`, `roles`) |
 
 ### `plugin` — Plugins
+
 | Subaction | Description |
 |-----------|-------------|
 | `list` | All installed plugins |
@@ -175,6 +184,7 @@ unraid(action="live",    subaction="cpu")
 | `remove` | ⚠️ Uninstall plugins (requires `names` — list of plugin names, `confirm=True`) |
 
 ### `rclone` — Cloud Storage
+
 | Subaction | Description |
 |-----------|-------------|
 | `list_remotes` | List configured rclone remotes |
@@ -183,12 +193,14 @@ unraid(action="live",    subaction="cpu")
 | `delete_remote` | ⚠️ Delete a remote (requires `name`, `confirm=True`) |
 
 ### `setting` — System Settings
+
 | Subaction | Description |
 |-----------|-------------|
 | `update` | Update system settings (requires `settings_input` object) |
 | `configure_ups` | ⚠️ Configure UPS settings (requires `confirm=True`) |
 
 ### `customization` — Theme & Appearance
+
 | Subaction | Description |
 |-----------|-------------|
 | `theme` | Current theme settings |
@@ -198,6 +210,7 @@ unraid(action="live",    subaction="cpu")
 | `set_theme` | Update theme (requires theme parameters) |
 
 ### `oidc` — SSO / OpenID Connect
+
 | Subaction | Description |
 |-----------|-------------|
 | `providers` | List configured OIDC providers |
@@ -207,6 +220,7 @@ unraid(action="live",    subaction="cpu")
 | `validate_session` | Validate current SSO session (requires `token`) |
 
 ### `user` — Current User
+
 | Subaction | Description |
 |-----------|-------------|
 | `me` | Current authenticated user info |
@@ -254,46 +268,46 @@ All require `confirm=True` as an explicit parameter. Without it, the action is b
 ## Common Workflows
 
 ### Verify credentials
-```
+```text
 unraid(action="health", subaction="setup")            # status + instructions (read-only)
 unraid(action="health", subaction="test_connection")  # confirm connectivity
 ```
 
 ### System health overview
-```
+```text
 unraid(action="system", subaction="overview")
 unraid(action="health", subaction="check")
 ```
 
 ### Container management
-```
+```text
 unraid(action="docker", subaction="list")
 unraid(action="docker", subaction="details", container_id="plex")
 unraid(action="docker", subaction="restart", container_id="sonarr")
 ```
 
 ### Array and disk status
-```
+```text
 unraid(action="array",  subaction="parity_status")
 unraid(action="disk",   subaction="disks")
 unraid(action="system", subaction="array")
 ```
 
 ### Read logs
-```
+```text
 unraid(action="disk", subaction="log_files")
 unraid(action="disk", subaction="logs", log_path="/var/log/syslog", tail_lines=50)
 ```
 
 ### Live monitoring
-```
+```text
 unraid(action="live", subaction="cpu")
 unraid(action="live", subaction="memory")
 unraid(action="live", subaction="array_state")
 ```
 
 ### VM operations
-```
+```text
 unraid(action="vm", subaction="list")
 unraid(action="vm", subaction="start",      vm_id="<id>")
 unraid(action="vm", subaction="force_stop", vm_id="<id>", confirm=True)

--- a/skills/unraid/SKILL.md
+++ b/skills/unraid/SKILL.md
@@ -10,10 +10,11 @@ description: "This skill should be used when the user mentions Unraid, asks to c
 **MCP mode** (preferred): Use when `mcp__unraid-mcp__unraid` tool is available.
 
 **HTTP fallback**: Use when MCP tools are unavailable. Credentials live in the file
-`~/.unraid-mcp/.env`; source it before running `curl` (see "HTTP Fallback Mode" below).
+`~/.unraid-mcp/.env`; load it before running `curl` (see "HTTP Fallback Mode" below).
 Do NOT use `$CLAUDE_PLUGIN_OPTION_*` in the Bash tool — Claude Code injects those vars
 only into plugin subprocesses (hooks/MCP/LSP), not the Bash tool. The plugin's setup
-hook reads them and materializes `~/.unraid-mcp/.env`; the skill sources that file.
+hook reads them and materializes `~/.unraid-mcp/.env`; the skill loads that file via
+`load-env.sh` (which parses it, never executes it).
 
 ---
 
@@ -327,10 +328,10 @@ unraid(action="vm", subaction="force_stop", vm_id="<id>", confirm=True)
 
 ## HTTP Fallback Mode
 
-When MCP tools are unavailable, query the GraphQL API directly with `curl`. Source the
-credentials file first — `$CLAUDE_PLUGIN_OPTION_*` is **not** set in the Bash tool, so
-read `~/.unraid-mcp/.env` (which the plugin's setup hook materializes) instead. The
-bundled `load-env.sh` does this for you:
+When MCP tools are unavailable, query the GraphQL API directly with `curl`. Load the
+credentials first — `$CLAUDE_PLUGIN_OPTION_*` is **not** set in the Bash tool, so read
+`~/.unraid-mcp/.env` (which the plugin's setup hook materializes) instead. Source the
+bundled `load-env.sh` library and call its loader (it parses the `.env`, never executes it):
 
 ```bash
 # Load UNRAID_API_URL / UNRAID_API_KEY from ~/.unraid-mcp/.env

--- a/skills/unraid/load-env.sh
+++ b/skills/unraid/load-env.sh
@@ -25,6 +25,13 @@ load_env_file() {
     local default_file="$creds_dir/.env"
     local env_file="${1:-${UNRAID_ENV_FILE:-$default_file}}"
 
+    # Refuse a symlinked credentials file — it holds secrets and a planted symlink
+    # could redirect the read to attacker-controlled content (CWE-22). Mirrors the
+    # rmcp-template / axon convention.
+    if [[ -L "$env_file" ]]; then
+        echo "ERROR: refusing to read symlinked credentials file $env_file" >&2
+        return 1
+    fi
     if [[ ! -f "$env_file" ]]; then
         echo "ERROR: $env_file not found" >&2
         echo "Set the plugin's Unraid GraphQL API URL / API Key in the config form" >&2

--- a/skills/unraid/load-env.sh
+++ b/skills/unraid/load-env.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Environment Loading Library for the Unraid skill.
+#
+# Sources the credentials file that the plugin's setup hook materializes from the
+# userConfig form. Claude Code injects CLAUDE_PLUGIN_OPTION_* only into plugin
+# subprocesses (hooks/MCP/LSP), NOT into the Bash tool that runs skill scripts —
+# so the hook reads those vars and writes ~/.unraid-mcp/.env, and the skill
+# sources that file.
+#
+# In skill scripts, source as:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/../load-env.sh"
+
+# Prevent direct execution
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    echo "Error: This library must be sourced, not executed directly" >&2
+    exit 1
+fi
+
+# Load ~/.unraid-mcp/.env (honoring UNRAID_CREDENTIALS_DIR), with a legacy
+# ~/.lab/.env fallback. Usage: load_env_file [/optional/override/path]
+load_env_file() {
+    local creds_dir="${UNRAID_CREDENTIALS_DIR:-$HOME/.unraid-mcp}"
+    local default_file="$creds_dir/.env"
+    local env_file="${1:-${UNRAID_ENV_FILE:-$default_file}}"
+
+    if [[ ! -f "$env_file" && "$env_file" == "$default_file" && -f "$HOME/.lab/.env" ]]; then
+        env_file="$HOME/.lab/.env"
+    fi
+    if [[ ! -f "$env_file" ]]; then
+        echo "ERROR: $env_file not found" >&2
+        echo "Set the plugin's Unraid GraphQL API URL / API Key in the config form" >&2
+        echo "(the setup hook writes ~/.unraid-mcp/.env), or create the file manually." >&2
+        return 1
+    fi
+
+    set -a
+    # shellcheck source=/dev/null
+    source "$env_file"
+    set +a
+}
+
+# Validate that required environment variables are set and non-empty.
+# Usage: validate_env_vars "VAR1" "VAR2" ...
+validate_env_vars() {
+    local missing=()
+    for var in "$@"; do
+        [[ -z "${!var:-}" ]] && missing+=("$var")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "ERROR: Missing required variables: ${missing[*]}" >&2
+        return 1
+    fi
+}
+
+# Load and validate the default-server Unraid credentials in one call.
+# Populates UNRAID_API_URL and UNRAID_API_KEY. Usage: load_unraid_credentials
+load_unraid_credentials() {
+    if [[ -z "${UNRAID_API_URL:-}" || -z "${UNRAID_API_KEY:-}" ]]; then
+        load_env_file || return 1
+    fi
+    validate_env_vars UNRAID_API_URL UNRAID_API_KEY
+}

--- a/skills/unraid/load-env.sh
+++ b/skills/unraid/load-env.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Environment Loading Library for the Unraid skill.
 #
-# Sources the credentials file that the plugin's setup hook materializes from the
-# userConfig form. Claude Code injects CLAUDE_PLUGIN_OPTION_* only into plugin
-# subprocesses (hooks/MCP/LSP), NOT into the Bash tool that runs skill scripts —
-# so the hook reads those vars and writes ~/.unraid-mcp/.env, and this library
-# parses that file (without executing it) into the environment.
+# Loads (parses, does not execute) the credentials file that the plugin's setup
+# hook materializes from the userConfig form. Claude Code injects
+# CLAUDE_PLUGIN_OPTION_* only into plugin subprocesses (hooks/MCP/LSP), NOT into
+# the Bash tool that runs skill scripts — so the hook reads those vars and writes
+# ~/.unraid-mcp/.env, and this library parses that file into the environment.
 #
-# In skill scripts, source as:
+# In skill scripts, source THIS LIBRARY (it defines functions; it is sourced, the
+# credentials file is not):
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "$SCRIPT_DIR/../load-env.sh"
 
@@ -17,16 +18,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     exit 1
 fi
 
-# Load ~/.unraid-mcp/.env (honoring UNRAID_CREDENTIALS_DIR), with a legacy
-# ~/.lab/.env fallback. Usage: load_env_file [/optional/override/path]
+# Parse ~/.unraid-mcp/.env (honoring UNRAID_CREDENTIALS_DIR, or UNRAID_ENV_FILE to
+# override the path). Usage: load_env_file [/optional/override/path]
 load_env_file() {
     local creds_dir="${UNRAID_CREDENTIALS_DIR:-$HOME/.unraid-mcp}"
     local default_file="$creds_dir/.env"
     local env_file="${1:-${UNRAID_ENV_FILE:-$default_file}}"
 
-    if [[ ! -f "$env_file" && "$env_file" == "$default_file" && -f "$HOME/.lab/.env" ]]; then
-        env_file="$HOME/.lab/.env"
-    fi
     if [[ ! -f "$env_file" ]]; then
         echo "ERROR: $env_file not found" >&2
         echo "Set the plugin's Unraid GraphQL API URL / API Key in the config form" >&2

--- a/skills/unraid/load-env.sh
+++ b/skills/unraid/load-env.sh
@@ -4,8 +4,8 @@
 # Sources the credentials file that the plugin's setup hook materializes from the
 # userConfig form. Claude Code injects CLAUDE_PLUGIN_OPTION_* only into plugin
 # subprocesses (hooks/MCP/LSP), NOT into the Bash tool that runs skill scripts —
-# so the hook reads those vars and writes ~/.unraid-mcp/.env, and the skill
-# sources that file.
+# so the hook reads those vars and writes ~/.unraid-mcp/.env, and this library
+# parses that file (without executing it) into the environment.
 #
 # In skill scripts, source as:
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -34,10 +34,20 @@ load_env_file() {
         return 1
     fi
 
-    set -a
-    # shellcheck source=/dev/null
-    source "$env_file"
-    set +a
+    # Parse the file as data, not shell — export only UNRAID_* assignments. Avoids
+    # executing arbitrary code from a hand-edited or UNRAID_ENV_FILE-overridden file.
+    local line key val
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" =~ ^[[:space:]]*(export[[:space:]]+)?(UNRAID_[A-Za-z0-9_]+)[[:space:]]*=(.*)$ ]] || continue
+        key="${BASH_REMATCH[2]}"
+        val="${BASH_REMATCH[3]}"
+        val="${val%"${val##*[![:space:]]}"}"  # trim trailing whitespace
+        # Strip one layer of matching surrounding quotes
+        if [[ ${#val} -ge 2 && ( "$val" == \"*\" || "$val" == \'*\' ) ]]; then
+            val="${val:1:${#val}-2}"
+        fi
+        export "$key=$val"
+    done < "$env_file"
 }
 
 # Validate that required environment variables are set and non-empty.

--- a/skills/unraid/references/quick-reference.md
+++ b/skills/unraid/references/quick-reference.md
@@ -7,7 +7,7 @@ All operations use: `unraid(action="<domain>", subaction="<operation>", [params]
 ### Health & Status
 
 ```python
-unraid(action="health",  subaction="setup")            # First-time credential setup
+unraid(action="health",  subaction="setup")            # Credential status + instructions (read-only)
 unraid(action="health",  subaction="check")            # Full health check
 unraid(action="health",  subaction="test_connection")  # Quick connectivity test
 unraid(action="system",  subaction="overview")         # Complete server summary

--- a/skills/unraid/references/troubleshooting.md
+++ b/skills/unraid/references/troubleshooting.md
@@ -4,13 +4,17 @@
 
 **Error:** `CredentialsNotConfiguredError` or message containing `~/.unraid-mcp/.env`
 
-**Fix:** Run setup to configure credentials interactively:
+**Fix:** Set credentials, then restart the server (they are read once at startup):
+
+1. **Claude Code plugin:** set *Unraid GraphQL API URL* and *Unraid API Key* in the plugin's
+   configuration form. The setup hook writes them to `~/.unraid-mcp/.env` on the next session.
+2. **Manual / Docker:** create `~/.unraid-mcp/.env` with `UNRAID_API_URL` and `UNRAID_API_KEY`.
+
+Check status any time (read-only — does not prompt or write):
 
 ```python
 unraid(action="health", subaction="setup")
 ```
-
-This writes `UNRAID_API_URL` and `UNRAID_API_KEY` to `~/.unraid-mcp/.env`. Re-run at any time to update or rotate credentials.
 
 ---
 

--- a/skills/unraid/scripts/dashboard.sh
+++ b/skills/unraid/scripts/dashboard.sh
@@ -20,7 +20,9 @@ load_env_file || exit 1
 # Falls back to a single "default" server using UNRAID_API_URL / UNRAID_API_KEY.
 SERVERS=()
 while IFS='=' read -r var_name _; do
-    if [[ "$var_name" =~ ^UNRAID_(.+)_URL$ ]]; then
+    # Discover fleet pairs UNRAID_<NAME>_URL, but exclude the canonical single-server
+    # UNRAID_API_URL (whose "API" capture is not a fleet instance).
+    if [[ "$var_name" =~ ^UNRAID_(.+)_URL$ && "${BASH_REMATCH[1]}" != "API" ]]; then
         SERVERS+=("${BASH_REMATCH[1]}")
     fi
 done < <(env)
@@ -40,11 +42,20 @@ if [ ${#SERVERS[@]} -eq 0 ]; then
     fi
 fi
 
+# Drop servers missing their API key (warn, don't abort the whole fleet).
+VALID_SERVERS=()
 for server in "${SERVERS[@]}"; do
-    url_var="UNRAID_${server}_URL"
-    key_var="UNRAID_${server}_API_KEY"
-    validate_env_vars "$url_var" "$key_var" || exit 1
+    if validate_env_vars "UNRAID_${server}_URL" "UNRAID_${server}_API_KEY" 2>/dev/null; then
+        VALID_SERVERS+=("$server")
+    else
+        echo "Skipping $server: missing UNRAID_${server}_URL or UNRAID_${server}_API_KEY" >&2
+    fi
 done
+SERVERS=("${VALID_SERVERS[@]}")
+if [ ${#SERVERS[@]} -eq 0 ]; then
+    echo "Error: no fully-configured servers to query." >&2
+    exit 1
+fi
 
 # Ensure output directory exists
 mkdir -p "$(dirname "$OUTPUT_FILE")"
@@ -62,10 +73,12 @@ process_server() {
 
     echo "Querying server: $NAME..."
     
-    UNRAID_URL="$URL"
+    # Set the canonical names so unraid-query.sh targets THIS server (a stale
+    # UNRAID_API_URL from the initial load would otherwise win the fallback chain).
+    UNRAID_API_URL="$URL"
     UNRAID_API_KEY="$API_KEY"
     IGNORE_ERRORS="true"
-    export UNRAID_URL UNRAID_API_KEY IGNORE_ERRORS
+    export UNRAID_API_URL UNRAID_API_KEY IGNORE_ERRORS
 
     QUERY='query Dashboard {
       info {
@@ -98,8 +111,22 @@ process_server() {
       isSSOEnabled
     }'
 
-    RESPONSE=$("$QUERY_SCRIPT" -q "$QUERY" -f json)
-    
+    # Don't let one server's failure abort the whole fleet (script runs under set -e).
+    if ! RESPONSE=$("$QUERY_SCRIPT" -q "$QUERY" -f json 2>"/tmp/${NAME}_query.err"); then
+        echo "Error querying $NAME (details in /tmp/${NAME}_query.err)"
+        {
+            echo "## Server: $NAME (⚠️ Error)"
+            echo "Query failed:"
+            echo '```'
+            cat "/tmp/${NAME}_query.err"
+            echo '```'
+            echo ""
+            echo "---"
+            echo ""
+        } >> "$OUTPUT_FILE"
+        return 0
+    fi
+
     # Debug output (only when DEBUG is set)
     if [ "${DEBUG:-}" = "true" ]; then
         echo "$RESPONSE" > "/tmp/${NAME}_debug.json"

--- a/skills/unraid/scripts/dashboard.sh
+++ b/skills/unraid/scripts/dashboard.sh
@@ -5,16 +5,19 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-source "$REPO_ROOT/lib/load-env.sh"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/../load-env.sh"
 
 QUERY_SCRIPT="$SCRIPT_DIR/unraid-query.sh"
 OUTPUT_FILE="$HOME/memory/bank/unraid-inventory.md"
 
-# Load credentials from .env for all servers
+# Load credentials. Single-server installs use ~/.unraid-mcp/.env (UNRAID_API_URL /
+# UNRAID_API_KEY). Multi-server (fleet) installs additionally export UNRAID_<NAME>_URL /
+# UNRAID_<NAME>_API_KEY pairs in that file, one per server.
 load_env_file || exit 1
 
-# Discover configured servers dynamically from UNRAID_<NAME>_URL env vars
+# Discover configured servers dynamically from UNRAID_<NAME>_URL env vars.
+# Falls back to a single "default" server using UNRAID_API_URL / UNRAID_API_KEY.
 SERVERS=()
 while IFS='=' read -r var_name _; do
     if [[ "$var_name" =~ ^UNRAID_(.+)_URL$ ]]; then
@@ -23,8 +26,18 @@ while IFS='=' read -r var_name _; do
 done < <(env)
 
 if [ ${#SERVERS[@]} -eq 0 ]; then
-    echo "Error: No servers found. Set UNRAID_<NAME>_URL and UNRAID_<NAME>_API_KEY env vars."
-    exit 1
+    # No multi-server pairs — fall back to the single default server.
+    if [ -n "${UNRAID_API_URL:-}" ] && [ -n "${UNRAID_API_KEY:-}" ]; then
+        UNRAID_DEFAULT_URL="$UNRAID_API_URL"
+        UNRAID_DEFAULT_API_KEY="$UNRAID_API_KEY"
+        UNRAID_DEFAULT_NAME="${UNRAID_DEFAULT_NAME:-unraid}"
+        export UNRAID_DEFAULT_URL UNRAID_DEFAULT_API_KEY UNRAID_DEFAULT_NAME
+        SERVERS=("DEFAULT")
+    else
+        echo "Error: No servers found. Configure ~/.unraid-mcp/.env (UNRAID_API_URL /" >&2
+        echo "UNRAID_API_KEY), or set UNRAID_<NAME>_URL / UNRAID_<NAME>_API_KEY pairs for a fleet." >&2
+        exit 1
+    fi
 fi
 
 for server in "${SERVERS[@]}"; do

--- a/skills/unraid/scripts/dashboard.sh
+++ b/skills/unraid/scripts/dashboard.sh
@@ -9,7 +9,8 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../load-env.sh"
 
 QUERY_SCRIPT="$SCRIPT_DIR/unraid-query.sh"
-OUTPUT_FILE="$HOME/memory/bank/unraid-inventory.md"
+# Output path is overridable; defaults to the current directory (no hardcoded personal path).
+OUTPUT_FILE="${UNRAID_DASHBOARD_OUTPUT:-$PWD/unraid-inventory.md}"
 
 # Load credentials. Single-server installs use ~/.unraid-mcp/.env (UNRAID_API_URL /
 # UNRAID_API_KEY). Multi-server (fleet) installs additionally export UNRAID_<NAME>_URL /

--- a/skills/unraid/scripts/unraid-query.sh
+++ b/skills/unraid/scripts/unraid-query.sh
@@ -2,9 +2,9 @@
 # Unraid GraphQL API Query Helper
 # Makes it easy to query the Unraid API from the command line.
 #
-# Credentials default to UNRAID_API_URL / UNRAID_API_KEY, sourced from
-# ~/.unraid-mcp/.env via the co-located load-env.sh when not already in the
-# environment. Override per-call with -u/-k.
+# Credentials default to UNRAID_API_URL / UNRAID_API_KEY, loaded from
+# ~/.unraid-mcp/.env via the co-located load-env.sh (which parses the file) when
+# not already in the environment. Override per-call with -u/-k.
 
 set -e
 
@@ -35,7 +35,7 @@ ENVIRONMENT VARIABLES:
     UNRAID_URL             Legacy alias for UNRAID_API_URL
 
 EXAMPLES:
-    # Use credentials from ~/.unraid-mcp/.env (sourced automatically)
+    # Use credentials from ~/.unraid-mcp/.env (loaded automatically)
     $0 -q "{ online }"
 
     # Override credentials per-call
@@ -94,21 +94,20 @@ while [[ $# -gt 0 ]]; do
 done
 
 # If credentials weren't supplied via flags or environment, load them from
-# ~/.unraid-mcp/.env (load_env_file is provided by load-env.sh).
-if [[ ( -z "$URL" || -z "$API_KEY" ) ]] && declare -f load_env_file >/dev/null; then
-    load_env_file >/dev/null 2>&1 || true
+# ~/.unraid-mcp/.env (load_env_file is provided by load-env.sh). Capture its
+# diagnostics so we can surface the specific reason if creds are still missing.
+LOAD_ERR=""
+if [[ -z "$URL" || -z "$API_KEY" ]] && declare -f load_env_file >/dev/null; then
+    LOAD_ERR="$(load_env_file 2>&1)" || true
     URL="${URL:-${UNRAID_API_URL:-${UNRAID_URL:-}}}"
     API_KEY="${API_KEY:-${UNRAID_API_KEY:-}}"
 fi
 
 # Validate required arguments
-if [[ -z "$URL" ]]; then
-    echo "Error: Unraid URL is required (use -u, set UNRAID_API_URL, or configure ~/.unraid-mcp/.env)"
-    exit 1
-fi
-
-if [[ -z "$API_KEY" ]]; then
-    echo "Error: API key is required (use -k, set UNRAID_API_KEY, or configure ~/.unraid-mcp/.env)"
+if [[ -z "$URL" || -z "$API_KEY" ]]; then
+    [[ -n "$LOAD_ERR" ]] && echo "$LOAD_ERR" >&2
+    [[ -z "$URL" ]] && echo "Error: Unraid URL is required (use -u, set UNRAID_API_URL, or configure ~/.unraid-mcp/.env)" >&2
+    [[ -z "$API_KEY" ]] && echo "Error: API key is required (use -k, set UNRAID_API_KEY, or configure ~/.unraid-mcp/.env)" >&2
     exit 1
 fi
 

--- a/skills/unraid/scripts/unraid-query.sh
+++ b/skills/unraid/scripts/unraid-query.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 # Unraid GraphQL API Query Helper
-# Makes it easy to query the Unraid API from the command line
+# Makes it easy to query the Unraid API from the command line.
+#
+# Credentials default to UNRAID_API_URL / UNRAID_API_KEY, sourced from
+# ~/.unraid-mcp/.env via the co-located load-env.sh when not already in the
+# environment. Override per-call with -u/-k.
 
 set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_LOAD_ENV="$SCRIPT_DIR/../load-env.sh"
+# shellcheck source=/dev/null
+[[ -f "$_LOAD_ENV" ]] && source "$_LOAD_ENV"
 
 # Usage function
 usage() {
@@ -21,17 +30,16 @@ OPTIONS:
     -h, --help             Show this help message
 
 ENVIRONMENT VARIABLES:
-    UNRAID_URL             Default Unraid server URL
-    UNRAID_API_KEY         Default API key
+    UNRAID_API_URL         Default Unraid GraphQL URL (from ~/.unraid-mcp/.env)
+    UNRAID_API_KEY         Default API key (from ~/.unraid-mcp/.env)
+    UNRAID_URL             Legacy alias for UNRAID_API_URL
 
 EXAMPLES:
-    # Get system status
-    $0 -u https://unraid.local/graphql -k YOUR_KEY -q "{ online }"
+    # Use credentials from ~/.unraid-mcp/.env (sourced automatically)
+    $0 -q "{ online }"
 
-    # Use environment variables
-    export UNRAID_URL="https://unraid.local/graphql"
-    export UNRAID_API_KEY="your-api-key"
-    $0 -q "{ metrics { cpu { percentTotal } } }"
+    # Override credentials per-call
+    $0 -u https://unraid.local/graphql -k YOUR_KEY -q "{ online }"
 
     # Pretty print output
     $0 -q "{ array { state } }" -f pretty
@@ -40,8 +48,8 @@ EOF
     exit 1
 }
 
-# Default values
-URL="${UNRAID_URL:-}"
+# Default values — prefer canonical UNRAID_API_URL, accept legacy UNRAID_URL.
+URL="${UNRAID_API_URL:-${UNRAID_URL:-}}"
 API_KEY="${UNRAID_API_KEY:-}"
 QUERY=""
 FORMAT="json"
@@ -85,14 +93,22 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# If credentials weren't supplied via flags or environment, load them from
+# ~/.unraid-mcp/.env (load_env_file is provided by load-env.sh).
+if [[ ( -z "$URL" || -z "$API_KEY" ) ]] && declare -f load_env_file >/dev/null; then
+    load_env_file >/dev/null 2>&1 || true
+    URL="${URL:-${UNRAID_API_URL:-${UNRAID_URL:-}}}"
+    API_KEY="${API_KEY:-${UNRAID_API_KEY:-}}"
+fi
+
 # Validate required arguments
 if [[ -z "$URL" ]]; then
-    echo "Error: Unraid URL is required (use -u or set UNRAID_URL)"
+    echo "Error: Unraid URL is required (use -u, set UNRAID_API_URL, or configure ~/.unraid-mcp/.env)"
     exit 1
 fi
 
 if [[ -z "$API_KEY" ]]; then
-    echo "Error: API key is required (use -k or set UNRAID_API_KEY)"
+    echo "Error: API key is required (use -k, set UNRAID_API_KEY, or configure ~/.unraid-mcp/.env)"
     exit 1
 fi
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -248,198 +248,73 @@ class TestSafeDisplayUrl:
         assert result == "<unparseable>"
 
 
-@pytest.mark.asyncio
-async def test_health_setup_action_calls_elicitation() -> None:
-    """setup subaction triggers elicit_and_configure when no credentials exist."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = False
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_and_configure", new=AsyncMock(return_value=True)
-        ) as mock_elicit,
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
-
-    assert mock_elicit.called
-    assert "configured" in result.lower() or "success" in result.lower()
 
 
 @pytest.mark.asyncio
-async def test_health_setup_action_returns_declined_message() -> None:
-    """setup subaction with declined elicitation returns appropriate message."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = False
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch("unraid_mcp.tools.unraid.elicit_and_configure", new=AsyncMock(return_value=False)),
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
-
-    assert (
-        "not configured" in result.lower()
-        or "declined" in result.lower()
-        or "cancel" in result.lower()
-    )
-
-
-@pytest.mark.asyncio
-async def test_health_setup_already_configured_and_working_no_reset() -> None:
-    """setup returns early when credentials exist, connection works, and user declines reset."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch(
-            "unraid_mcp.core.client.make_graphql_request",
-            new=AsyncMock(return_value={"online": True}),
-        ),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_reset_confirmation",
-            new=AsyncMock(return_value=False),
-        ),
-        patch("unraid_mcp.tools.unraid.elicit_and_configure") as mock_configure,
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
-
-    mock_configure.assert_not_called()
-    assert "already configured" in result.lower()
-    assert "no changes" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_health_setup_already_configured_user_confirms_reset() -> None:
-    """setup proceeds with elicitation when credentials exist but user confirms reset."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch(
-            "unraid_mcp.core.client.make_graphql_request",
-            new=AsyncMock(return_value={"online": True}),
-        ),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_reset_confirmation",
-            new=AsyncMock(return_value=True),
-        ),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_and_configure", new=AsyncMock(return_value=True)
-        ) as mock_configure,
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
-
-    mock_configure.assert_called_once()
-    assert "configured" in result.lower() or "success" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_health_setup_credentials_exist_but_connection_fails_user_confirms() -> None:
-    """setup prompts for confirmation even on failed probe, then reconfigures if confirmed."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch(
-            "unraid_mcp.core.client.make_graphql_request",
-            new=AsyncMock(side_effect=Exception("connection refused")),
-        ),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_reset_confirmation",
-            new=AsyncMock(return_value=True),
-        ),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_and_configure", new=AsyncMock(return_value=True)
-        ) as mock_configure,
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
-
-    mock_configure.assert_called_once()
-    assert "configured" in result.lower() or "success" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_health_setup_credentials_exist_connection_fails_user_declines() -> None:
-    """setup returns 'no changes' when credentials exist (even with failed probe) and user declines."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch(
-            "unraid_mcp.core.client.make_graphql_request",
-            new=AsyncMock(side_effect=Exception("connection refused")),
-        ),
-        patch(
-            "unraid_mcp.tools.unraid.elicit_reset_confirmation",
-            new=AsyncMock(return_value=False),
-        ),
-        patch("unraid_mcp.tools.unraid.elicit_and_configure") as mock_configure,
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
-
-    mock_configure.assert_not_called()
-    assert "no changes" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_health_setup_ctx_none_already_configured_returns_no_changes() -> None:
-    """When ctx=None and credentials are working, setup returns 'already configured' gracefully."""
-    tool_fn = _make_tool()
-
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-
-    with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch(
-            "unraid_mcp.core.client.make_graphql_request",
-            new=AsyncMock(return_value={"online": True}),
-        ),
-        patch("unraid_mcp.tools.unraid.elicit_and_configure") as mock_configure,
-    ):
-        result = await tool_fn(action="health", subaction="setup", ctx=None)
-
-    mock_configure.assert_not_called()
-    assert "already configured" in result.lower()
-    assert "no changes" in result.lower()
-
-
-@pytest.mark.asyncio
-async def test_health_setup_declined_message_includes_manual_path() -> None:
-    """Declined setup message includes the exact credentials file path and variable names."""
+async def test_health_setup_not_configured_returns_manual_instructions() -> None:
+    """setup returns plugin + manual .env instructions when credentials are absent."""
     from unraid_mcp.config.settings import CREDENTIALS_ENV_PATH
 
     tool_fn = _make_tool()
-
-    real_path_str = str(CREDENTIALS_ENV_PATH)
-    mock_path = MagicMock()
-    mock_path.exists.return_value = False
-    # Override __str__ on the instance's mock directly — avoids mutating the shared MagicMock class.
-    mock_path.__str__ = MagicMock(return_value=real_path_str)
-
     with (
-        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", mock_path),
-        patch("unraid_mcp.tools.unraid.elicit_and_configure", new=AsyncMock(return_value=False)),
+        patch("unraid_mcp.config.settings.UNRAID_API_URL", None),
+        patch("unraid_mcp.config.settings.UNRAID_API_KEY", None),
     ):
         result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
 
-    assert real_path_str in result
+    assert "not configured" in result.lower()
+    assert str(CREDENTIALS_ENV_PATH) in result
     assert "UNRAID_API_URL=" in result
     assert "UNRAID_API_KEY=" in result
+
+
+@pytest.mark.asyncio
+async def test_health_setup_configured_and_working_reports_status() -> None:
+    """setup reports configured + working status without any prompting."""
+    tool_fn = _make_tool()
+    with (
+        patch("unraid_mcp.config.settings.UNRAID_API_URL", "https://my-unraid.example.com:31337"),
+        patch("unraid_mcp.config.settings.UNRAID_API_KEY", "key123"),
+        patch(
+            "unraid_mcp.core.client.make_graphql_request",
+            new=AsyncMock(return_value={"online": True}),
+        ),
+    ):
+        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
+
+    assert "configured" in result.lower()
+    assert "succeeded" in result.lower()
+    assert "restart" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_health_setup_configured_but_connection_fails_reports_failure() -> None:
+    """setup reports configured-but-failing status without prompting."""
+    tool_fn = _make_tool()
+    with (
+        patch("unraid_mcp.config.settings.UNRAID_API_URL", "https://my-unraid.example.com:31337"),
+        patch("unraid_mcp.config.settings.UNRAID_API_KEY", "key123"),
+        patch(
+            "unraid_mcp.core.client.make_graphql_request",
+            new=AsyncMock(side_effect=Exception("connection refused")),
+        ),
+    ):
+        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
+
+    assert "configured" in result.lower()
+    assert "connection test failed" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_health_setup_never_calls_elicit() -> None:
+    """setup must not invoke ctx.elicit for any configuration state."""
+    tool_fn = _make_tool()
+    mock_ctx = MagicMock()
+    mock_ctx.elicit = AsyncMock()
+    with (
+        patch("unraid_mcp.config.settings.UNRAID_API_URL", None),
+        patch("unraid_mcp.config.settings.UNRAID_API_KEY", None),
+    ):
+        await tool_fn(action="health", subaction="setup", ctx=mock_ctx)
+
+    mock_ctx.elicit.assert_not_called()

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -248,8 +248,6 @@ class TestSafeDisplayUrl:
         assert result == "<unparseable>"
 
 
-
-
 @pytest.mark.asyncio
 async def test_health_setup_not_configured_returns_manual_instructions() -> None:
     """setup returns plugin + manual .env instructions when credentials are absent."""

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -249,21 +249,42 @@ class TestSafeDisplayUrl:
 
 
 @pytest.mark.asyncio
-async def test_health_setup_not_configured_returns_manual_instructions() -> None:
-    """setup returns plugin + manual .env instructions when credentials are absent."""
-    from unraid_mcp.config.settings import CREDENTIALS_ENV_PATH
+async def test_health_setup_not_configured_returns_manual_instructions(tmp_path) -> None:
+    """setup returns plugin + manual .env instructions when no creds and no file exist."""
+    missing_env = tmp_path / "absent" / ".env"  # guaranteed not to exist
 
     tool_fn = _make_tool()
     with (
         patch("unraid_mcp.config.settings.UNRAID_API_URL", None),
         patch("unraid_mcp.config.settings.UNRAID_API_KEY", None),
+        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", missing_env),
     ):
         result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
 
     assert "not configured" in result.lower()
-    assert str(CREDENTIALS_ENV_PATH) in result
+    assert str(missing_env) in result
     assert "UNRAID_API_URL=" in result
     assert "UNRAID_API_KEY=" in result
+
+
+@pytest.mark.asyncio
+async def test_health_setup_file_exists_but_not_loaded(tmp_path) -> None:
+    """setup distinguishes a present-but-unloaded .env (e.g. just written) from missing config."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("UNRAID_API_URL=https://x\nUNRAID_API_KEY=y\n")
+
+    tool_fn = _make_tool()
+    with (
+        # is_configured() is False (globals captured at startup), but the file is on disk.
+        patch("unraid_mcp.config.settings.UNRAID_API_URL", None),
+        patch("unraid_mcp.config.settings.UNRAID_API_KEY", None),
+        patch("unraid_mcp.config.settings.CREDENTIALS_ENV_PATH", env_file),
+    ):
+        result = await tool_fn(action="health", subaction="setup", ctx=MagicMock())
+
+    assert "not loaded" in result.lower()
+    assert "restart" in result.lower()
+    assert str(env_file) in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_load_env_sh.py
+++ b/tests/test_load_env_sh.py
@@ -99,6 +99,19 @@ def test_missing_file_returns_nonzero_with_guidance(tmp_path: Path) -> None:
     assert ".unraid-mcp/.env" in result.stderr or "config form" in result.stderr.lower()
 
 
+def test_rejects_symlinked_env(tmp_path: Path) -> None:
+    """A symlinked credentials file must be refused (planted-symlink defense)."""
+    target = tmp_path / "real.env"
+    target.write_text("UNRAID_API_URL=https://x\nUNRAID_API_KEY=k\n")
+    (tmp_path / ".env").symlink_to(target)
+
+    result = _run('load_env_file && echo "loaded"', tmp_path)
+
+    assert result.returncode != 0
+    assert "loaded" not in result.stdout
+    assert "symlink" in result.stderr.lower()
+
+
 def test_load_unraid_credentials_validates(tmp_path: Path) -> None:
     """load_unraid_credentials fails when required keys are absent from the file."""
     (tmp_path / ".env").write_text("UNRAID_OTHER=x\n")  # no API_URL/API_KEY

--- a/tests/test_load_env_sh.py
+++ b/tests/test_load_env_sh.py
@@ -1,0 +1,120 @@
+"""Subprocess tests for the skill's load-env.sh credential loader.
+
+load-env.sh is security-relevant: it must PARSE ~/.unraid-mcp/.env as data and
+export only UNRAID_* assignments, never `source`/execute it. These tests pin that
+behavior so a future refactor back to `source` (which would reintroduce arbitrary
+code execution from a hand-edited .env) fails loudly.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_LOAD_ENV = Path(__file__).resolve().parent.parent / "skills" / "unraid" / "load-env.sh"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("bash") is None or not _LOAD_ENV.exists(),
+    reason="bash and skills/unraid/load-env.sh are required",
+)
+
+
+def _run(script: str, creds_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run a bash snippet with load-env.sh sourced and UNRAID_CREDENTIALS_DIR set."""
+    full = f'set -uo pipefail\nsource "{_LOAD_ENV}"\n{script}'
+    return subprocess.run(
+        ["bash", "-c", full],
+        capture_output=True,
+        text=True,
+        env={
+            "HOME": str(creds_dir),
+            "UNRAID_CREDENTIALS_DIR": str(creds_dir),
+            "PATH": "/usr/bin:/bin",
+        },
+    )
+
+
+def test_does_not_execute_command_substitution(tmp_path: Path) -> None:
+    """A $(...) in a value must be stored literally, never executed."""
+    sentinel = tmp_path / "PWNED"
+    (tmp_path / ".env").write_text(
+        f"UNRAID_API_URL=https://ok.test/graphql\nUNRAID_API_KEY=secret$(touch {sentinel})\n"
+    )
+    result = _run('load_env_file; echo "KEY=[$UNRAID_API_KEY]"', tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert not sentinel.exists(), "command substitution was executed — injection!"
+    assert f"KEY=[secret$(touch {sentinel})]" in result.stdout
+
+
+def test_exports_only_unraid_vars(tmp_path: Path) -> None:
+    """Only UNRAID_* assignments are exported; other vars are ignored."""
+    (tmp_path / ".env").write_text(
+        "UNRAID_API_URL=https://ok.test/graphql\n"
+        "UNRAID_API_KEY=k\n"
+        "OTHER_SECRET=nope\n"
+        "# a comment\n"
+        "\n"
+    )
+    result = _run(
+        'load_env_file; echo "URL=[$UNRAID_API_URL]"; echo "OTHER=[${OTHER_SECRET:-<unset>}]"',
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "URL=[https://ok.test/graphql]" in result.stdout
+    assert "OTHER=[<unset>]" in result.stdout
+
+
+def test_strips_matching_quotes_and_trailing_space(tmp_path: Path) -> None:
+    (tmp_path / ".env").write_text(
+        'UNRAID_API_URL="https://quoted.test/graphql"\n'
+        "UNRAID_API_KEY=trailing   \n"
+        "export UNRAID_TOWER2_URL='https://tower2.test'\n"
+    )
+    result = _run(
+        'load_env_file; printf "URL=[%s] KEY=[%s] T2=[%s]\\n" '
+        '"$UNRAID_API_URL" "$UNRAID_API_KEY" "$UNRAID_TOWER2_URL"',
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    # quotes stripped, trailing whitespace trimmed, `export ` prefix handled
+    assert (
+        "URL=[https://quoted.test/graphql] KEY=[trailing] T2=[https://tower2.test]" in result.stdout
+    )
+
+
+def test_missing_file_returns_nonzero_with_guidance(tmp_path: Path) -> None:
+    """No .env (and no fallback) → return 1 with actionable stderr."""
+    result = _run('load_env_file && echo "should-not-print"', tmp_path)
+
+    assert result.returncode != 0
+    assert "should-not-print" not in result.stdout
+    assert "not found" in result.stderr.lower()
+    assert ".unraid-mcp/.env" in result.stderr or "config form" in result.stderr.lower()
+
+
+def test_load_unraid_credentials_validates(tmp_path: Path) -> None:
+    """load_unraid_credentials fails when required keys are absent from the file."""
+    (tmp_path / ".env").write_text("UNRAID_OTHER=x\n")  # no API_URL/API_KEY
+    result = _run("load_unraid_credentials && echo OK || echo FAIL", tmp_path)
+
+    assert "FAIL" in result.stdout
+    assert "Missing required variables" in result.stderr
+
+
+def test_direct_execution_is_blocked(tmp_path: Path) -> None:
+    """Running load-env.sh directly (not sourced) must exit non-zero."""
+    result = subprocess.run(
+        ["bash", str(_LOAD_ENV)],
+        capture_output=True,
+        text=True,
+        env={"HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
+    )
+    assert result.returncode != 0
+    assert "must be sourced" in result.stderr

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -7,6 +7,20 @@ from unittest.mock import patch
 import pytest
 
 
+# Both plugin-option env vars, so tests can clear them in one place. patch.dict
+# snapshots os.environ on entry and restores it on exit, so popping these inside a
+# `patch.dict(os.environ, ..., clear=False)` block never leaks to other tests.
+_OPTION_VARS = (
+    "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL",
+    "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY",
+)
+
+
+def _clear_option_vars() -> None:
+    for var in _OPTION_VARS:
+        os.environ.pop(var, None)
+
+
 def test_apply_plugin_options_maps_present_vars():
     from unraid_mcp.core.setup import apply_plugin_options
 
@@ -14,14 +28,14 @@ def test_apply_plugin_options_maps_present_vars():
         os.environ,
         {
             "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://tower.local/graphql/",
-            "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "  secret123  ",
+            "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "  secret123/  ",
         },
         clear=False,
     ):
         resolved = apply_plugin_options()
 
     assert resolved["UNRAID_API_URL"] == "https://tower.local/graphql"  # trailing slash stripped
-    assert resolved["UNRAID_API_KEY"] == "secret123"  # whitespace trimmed
+    assert resolved["UNRAID_API_KEY"] == "secret123/"  # trimmed, slash NOT stripped on key
 
 
 def test_apply_plugin_options_skips_missing_and_empty():
@@ -35,21 +49,38 @@ def test_apply_plugin_options_skips_missing_and_empty():
     assert "UNRAID_API_KEY" not in resolved
 
 
-def test_apply_plugin_options_rejects_newline_injection():
+# NUL (\0) cannot be placed in os.environ (the OS rejects it), so it can't reach
+# apply_plugin_options via a plugin option — it's covered by the direct _safe_env_value
+# unit test below. Newline/CR are the reachable injection vectors.
+@pytest.mark.parametrize("bad_char", ["\n", "\r"])
+def test_apply_plugin_options_rejects_control_char_injection(bad_char):
     from unraid_mcp.core.setup import apply_plugin_options
 
     with patch.dict(
         os.environ,
         {
-            "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://x\nUNRAID_API_KEY=evil",
+            "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": f"https://x{bad_char}UNRAID_API_KEY=evil",
             "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "ok",
         },
         clear=False,
     ):
         resolved = apply_plugin_options()
 
-    assert "UNRAID_API_URL" not in resolved  # rejected for newline
+    assert "UNRAID_API_URL" not in resolved  # rejected for control char
     assert resolved["UNRAID_API_KEY"] == "ok"
+
+
+@pytest.mark.parametrize("value", ["", "x\ny", "x\ry", "x\0y"])
+def test_safe_env_value_rejects_empty_and_control_chars(value):
+    from unraid_mcp.core.setup import _safe_env_value
+
+    assert _safe_env_value(value) is None
+
+
+def test_safe_env_value_accepts_normal():
+    from unraid_mcp.core.setup import _safe_env_value
+
+    assert _safe_env_value("https://tower.local/graphql") == "https://tower.local/graphql"
 
 
 def test_run_plugin_hook_writes_env_when_both_present(tmp_path, capsys):
@@ -83,6 +114,72 @@ def test_run_plugin_hook_writes_env_when_both_present(tmp_path, capsys):
     assert report["ran_repair"] is True
 
 
+def test_run_plugin_hook_idempotent_rewrite(tmp_path, capsys):
+    """Running the hook twice with identical input yields one entry per key, byte-identical."""
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://tower.local/graphql",
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "secret123",
+            },
+            clear=False,
+        ),
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+    ):
+        setup_mod.run_plugin_hook()
+        first = creds_file.read_text()
+        capsys.readouterr()  # drain
+        setup_mod.run_plugin_hook()
+        second = creds_file.read_text()
+
+    assert first == second  # idempotent
+    assert second.count("UNRAID_API_URL=") == 1
+    assert second.count("UNRAID_API_KEY=") == 1
+    assert stat.S_IMODE(creds_file.stat().st_mode) == 0o600
+
+
+@pytest.mark.parametrize(
+    ("present_var", "present_canonical", "missing_canonical"),
+    [
+        ("CLAUDE_PLUGIN_OPTION_UNRAID_API_URL", "UNRAID_API_URL", "UNRAID_API_KEY"),
+        ("CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY", "UNRAID_API_KEY", "UNRAID_API_URL"),
+    ],
+)
+def test_run_plugin_hook_advisory_when_only_one_present(
+    tmp_path, capsys, present_var, present_canonical, missing_canonical
+):
+    """One credential present must NOT write a partial .env; advisory names the missing one."""
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.dict(os.environ, {present_var: "value"}, clear=False),
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+    ):
+        _clear_option_vars()
+        os.environ[present_var] = "value"
+        rc = setup_mod.run_plugin_hook()
+
+    assert rc == 0
+    assert not creds_file.exists()
+    report = json.loads(capsys.readouterr().out)
+    assert report["ran_repair"] is False
+    assert len(report["advisory_failures"]) == 1
+    assert missing_canonical in report["advisory_failures"][0]
+
+
 def test_run_plugin_hook_advisory_when_missing(tmp_path, capsys):
     from unraid_mcp.core import setup as setup_mod
 
@@ -90,12 +187,12 @@ def test_run_plugin_hook_advisory_when_missing(tmp_path, capsys):
     creds_file = creds_dir / ".env"
 
     with (
+        patch.dict(os.environ, {}, clear=False),
         patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
         patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
         patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
     ):
-        os.environ.pop("CLAUDE_PLUGIN_OPTION_UNRAID_API_URL", None)
-        os.environ.pop("CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY", None)
+        _clear_option_vars()
         rc = setup_mod.run_plugin_hook()
 
     assert rc == 0
@@ -103,13 +200,82 @@ def test_run_plugin_hook_advisory_when_missing(tmp_path, capsys):
     report = json.loads(capsys.readouterr().out)
     assert report["ran_repair"] is False
     assert len(report["advisory_failures"]) == 2
+    # Advisory text is the operator's only guidance — it must name the vars + path.
+    joined = " ".join(report["advisory_failures"])
+    assert "UNRAID_API_URL" in joined
+    assert "UNRAID_API_KEY" in joined
+    assert str(creds_file) in joined
 
 
-def test_main_setup_dispatch_invokes_plugin_hook():
+def test_run_plugin_hook_reports_rejected_value_distinctly(tmp_path, capsys):
+    """A present-but-unsafe value is surfaced as 'rejected', not silently dropped."""
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://ok.local",
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "bad\nkey",
+            },
+            clear=False,
+        ),
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+    ):
+        rc = setup_mod.run_plugin_hook()
+
+    assert rc == 0
+    assert not creds_file.exists()
+    report = json.loads(capsys.readouterr().out)
+    assert report["ran_repair"] is False
+    assert len(report["advisory_failures"]) == 1
+    advisory = report["advisory_failures"][0]
+    assert "UNRAID_API_KEY" in advisory
+    assert "rejected" in advisory.lower()
+
+
+def test_run_plugin_hook_returns_zero_on_write_failure(tmp_path, capsys):
+    """A .env write error must be surfaced in advisory_failures, not escape (always exit 0)."""
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://tower.local/graphql",
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "secret123",
+            },
+            clear=False,
+        ),
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+        patch.object(setup_mod, "_write_env", side_effect=PermissionError("denied")),
+    ):
+        rc = setup_mod.run_plugin_hook()
+
+    assert rc == 0  # never blocks the session
+    report = json.loads(capsys.readouterr().out)
+    assert report["ran_repair"] is False
+    assert len(report["advisory_failures"]) == 1
+    assert "Failed to write" in report["advisory_failures"][0]
+    assert "PermissionError" in report["advisory_failures"][0]
+
+
+@pytest.mark.parametrize("argv", [["unraid-mcp", "setup", "plugin-hook"], ["unraid-mcp", "setup"]])
+def test_main_setup_dispatch_invokes_plugin_hook(argv):
     import unraid_mcp.main as main_mod
 
     with (
-        patch.object(sys, "argv", ["unraid-mcp", "setup", "plugin-hook"]),
+        patch.object(sys, "argv", argv),
         patch("unraid_mcp.core.setup.run_plugin_hook", return_value=0) as mock_hook,
         pytest.raises(SystemExit) as exc,
     ):
@@ -117,3 +283,32 @@ def test_main_setup_dispatch_invokes_plugin_hook():
 
     assert exc.value.code == 0
     mock_hook.assert_called_once()
+
+
+def test_main_setup_rejects_unknown_subcommand():
+    import unraid_mcp.main as main_mod
+
+    with (
+        patch.object(sys, "argv", ["unraid-mcp", "setup", "bogus"]),
+        patch("unraid_mcp.core.setup.run_plugin_hook") as mock_hook,
+        pytest.raises(SystemExit) as exc,
+    ):
+        main_mod.main()
+
+    assert exc.value.code == 2
+    mock_hook.assert_not_called()
+
+
+def test_main_without_setup_does_not_dispatch_hook():
+    """Normal startup must not be hijacked by the setup guard."""
+    import unraid_mcp.main as main_mod
+
+    with (
+        patch.object(sys, "argv", ["unraid-mcp"]),
+        patch("unraid_mcp.core.setup.run_plugin_hook") as mock_hook,
+        patch("unraid_mcp.server.run_server") as mock_run_server,
+    ):
+        main_mod.main()
+
+    mock_hook.assert_not_called()
+    mock_run_server.assert_called_once()

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -239,6 +239,37 @@ def test_run_plugin_hook_reports_rejected_value_distinctly(tmp_path, capsys):
     assert "rejected" in advisory.lower()
 
 
+def test_run_plugin_hook_reports_empty_value_as_rejected(tmp_path, capsys):
+    """An explicitly-empty option is 'rejected', not 'not supplied' (key-presence check)."""
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "",  # present but empty
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "secret123",
+            },
+            clear=False,
+        ),
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+    ):
+        rc = setup_mod.run_plugin_hook()
+
+    assert rc == 0
+    assert not creds_file.exists()
+    report = json.loads(capsys.readouterr().out)
+    assert len(report["advisory_failures"]) == 1
+    advisory = report["advisory_failures"][0]
+    assert "UNRAID_API_URL" in advisory
+    assert "rejected" in advisory.lower()
+
+
 def test_run_plugin_hook_returns_zero_on_write_failure(tmp_path, capsys):
     """A .env write error must be surfaced in advisory_failures, not escape (always exit 0)."""
     from unraid_mcp.core import setup as setup_mod

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -1,0 +1,121 @@
+import json
+import os
+import stat
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_apply_plugin_options_maps_present_vars():
+    from unraid_mcp.core.setup import apply_plugin_options
+
+    with patch.dict(
+        os.environ,
+        {
+            "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://tower.local/graphql/",
+            "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "  secret123  ",
+        },
+        clear=False,
+    ):
+        resolved = apply_plugin_options()
+
+    assert resolved["UNRAID_API_URL"] == "https://tower.local/graphql"  # trailing slash stripped
+    assert resolved["UNRAID_API_KEY"] == "secret123"  # whitespace trimmed
+
+
+def test_apply_plugin_options_skips_missing_and_empty():
+    from unraid_mcp.core.setup import apply_plugin_options
+
+    with patch.dict(
+        os.environ, {"CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": ""}, clear=False
+    ):
+        os.environ.pop("CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY", None)
+        resolved = apply_plugin_options()
+
+    assert "UNRAID_API_URL" not in resolved
+    assert "UNRAID_API_KEY" not in resolved
+
+
+def test_apply_plugin_options_rejects_newline_injection():
+    from unraid_mcp.core.setup import apply_plugin_options
+
+    with patch.dict(
+        os.environ,
+        {
+            "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://x\nUNRAID_API_KEY=evil",
+            "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "ok",
+        },
+        clear=False,
+    ):
+        resolved = apply_plugin_options()
+
+    assert "UNRAID_API_URL" not in resolved  # rejected for newline
+    assert resolved["UNRAID_API_KEY"] == "ok"
+
+
+def test_run_plugin_hook_writes_env_when_both_present(tmp_path, capsys):
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.dict(
+            os.environ,
+            {
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "https://tower.local/graphql",
+                "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "secret123",
+            },
+            clear=False,
+        ),
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+    ):
+        rc = setup_mod.run_plugin_hook()
+
+    assert rc == 0
+    assert creds_file.exists()
+    content = creds_file.read_text()
+    assert "UNRAID_API_URL=https://tower.local/graphql" in content
+    assert "UNRAID_API_KEY=secret123" in content
+    assert stat.S_IMODE(creds_file.stat().st_mode) == 0o600
+    report = json.loads(capsys.readouterr().out)
+    assert report["ran_repair"] is True
+
+
+def test_run_plugin_hook_advisory_when_missing(tmp_path, capsys):
+    from unraid_mcp.core import setup as setup_mod
+
+    creds_dir = tmp_path / "creds"
+    creds_file = creds_dir / ".env"
+
+    with (
+        patch.object(setup_mod, "CREDENTIALS_DIR", creds_dir),
+        patch.object(setup_mod, "CREDENTIALS_ENV_PATH", creds_file),
+        patch.object(setup_mod, "PROJECT_ROOT", tmp_path),
+    ):
+        os.environ.pop("CLAUDE_PLUGIN_OPTION_UNRAID_API_URL", None)
+        os.environ.pop("CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY", None)
+        rc = setup_mod.run_plugin_hook()
+
+    assert rc == 0
+    assert not creds_file.exists()
+    report = json.loads(capsys.readouterr().out)
+    assert report["ran_repair"] is False
+    assert len(report["advisory_failures"]) == 2
+
+
+def test_main_setup_dispatch_invokes_plugin_hook():
+    import unraid_mcp.main as main_mod
+
+    with (
+        patch.object(sys, "argv", ["unraid-mcp", "setup", "plugin-hook"]),
+        patch("unraid_mcp.core.setup.run_plugin_hook", return_value=0) as mock_hook,
+        pytest.raises(SystemExit) as exc,
+    ):
+        main_mod.main()
+
+    assert exc.value.code == 0
+    mock_hook.assert_called_once()

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -27,9 +27,7 @@ def test_apply_plugin_options_maps_present_vars():
 def test_apply_plugin_options_skips_missing_and_empty():
     from unraid_mcp.core.setup import apply_plugin_options
 
-    with patch.dict(
-        os.environ, {"CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": ""}, clear=False
-    ):
+    with patch.dict(os.environ, {"CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": ""}, clear=False):
         os.environ.pop("CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY", None)
         resolved = apply_plugin_options()
 

--- a/tests/test_plugin_setup.py
+++ b/tests/test_plugin_setup.py
@@ -2,9 +2,39 @@ import json
 import os
 import stat
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_plugin_option_map_matches_manifest_userconfig():
+    """PLUGIN_OPTION_MAP, plugin.json userConfig, and .mcp.json must stay in sync.
+
+    Guards against a rename drifting the three apart and silently breaking
+    credential delivery (the plugin would collect a value the server never reads).
+    """
+    from unraid_mcp.core.setup import PLUGIN_OPTION_MAP
+
+    manifest = json.loads((_REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
+    user_keys = set(manifest["userConfig"])  # e.g. {"unraid_api_url", "unraid_api_key"}
+
+    expected = {f"CLAUDE_PLUGIN_OPTION_{k.upper()}": k.upper() for k in user_keys}
+    assert expected == PLUGIN_OPTION_MAP, (
+        "PLUGIN_OPTION_MAP is out of sync with plugin.json userConfig. "
+        f"expected {expected}, got {PLUGIN_OPTION_MAP}"
+    )
+
+    # .mcp.json must hand each canonical var the matching plugin option.
+    mcp = json.loads((_REPO_ROOT / ".mcp.json").read_text())
+    env = mcp["mcpServers"]["unraid-mcp"]["env"]
+    for option, canonical in PLUGIN_OPTION_MAP.items():
+        assert env.get(canonical) == f"${{{option}}}", (
+            f".mcp.json env[{canonical}] should be ${{{option}}}, got {env.get(canonical)!r}"
+        )
 
 
 # Both plugin-option env vars, so tests can clear them in one place. patch.dict
@@ -19,6 +49,22 @@ _OPTION_VARS = (
 def _clear_option_vars() -> None:
     for var in _OPTION_VARS:
         os.environ.pop(var, None)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("https://tower.local/graphql", "https://tower.local/graphql"),  # plain → unquoted
+        ("plainkey123", "plainkey123"),
+        ("has space", '"has space"'),  # whitespace → quoted
+        ("with#hash", '"with#hash"'),  # # would start a dotenv comment unquoted
+        ('a"b', '"a\\"b"'),  # embedded quote escaped
+    ],
+)
+def test_dotenv_value_quotes_only_when_needed(value, expected):
+    from unraid_mcp.core.setup import _dotenv_value
+
+    assert _dotenv_value(value) == expected
 
 
 def test_apply_plugin_options_maps_present_vars():

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -129,6 +129,31 @@ def test_credentials_env_path_is_dot_env_inside_credentials_dir():
     assert s.CREDENTIALS_ENV_PATH == s.CREDENTIALS_DIR / ".env"
 
 
+def test_load_env_files_skips_symlinked_env(tmp_path):
+    """A symlinked credentials .env must not be loaded (planted-symlink defense)."""
+    import importlib
+
+    import unraid_mcp.config.settings as s
+
+    target = tmp_path / "real.env"
+    target.write_text("UNRAID_API_URL=https://symlinked-sentinel\nUNRAID_API_KEY=sentinelkey\n")
+    creds = tmp_path / "creds"
+    creds.mkdir()
+    (creds / ".env").symlink_to(target)
+
+    os.environ.pop("UNRAID_API_URL", None)
+    os.environ.pop("UNRAID_API_KEY", None)
+    try:
+        with patch.dict(os.environ, {"UNRAID_CREDENTIALS_DIR": str(creds)}):
+            importlib.reload(s)
+            # The symlinked primary file is skipped, so the sentinel is never loaded.
+            assert s.UNRAID_API_URL != "https://symlinked-sentinel"
+            assert s.UNRAID_API_KEY != "sentinelkey"
+    finally:
+        os.environ.pop("UNRAID_CREDENTIALS_DIR", None)
+        importlib.reload(s)  # restore module state
+
+
 def test_write_env_creates_credentials_dir_with_700_permissions(tmp_path):
     """_write_env creates CREDENTIALS_DIR with mode 700 (owner-only)."""
     from unraid_mcp.core.setup import _write_env

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -64,9 +64,10 @@ def test_run_server_does_not_exit_when_creds_missing(monkeypatch):
             assert e.code == 0, f"Unexpected sys.exit({e.code}) — server crashed on missing creds"
         mock_logger.warning.assert_called()
         warning_msgs = [call[0][0] for call in mock_logger.warning.call_args_list]
-        assert any("elicitation" in msg for msg in warning_msgs), (
-            f"Expected a warning containing 'elicitation', got: {warning_msgs}"
+        assert any("restart" in msg.lower() for msg in warning_msgs), (
+            f"Expected a missing-config warning mentioning restart, got: {warning_msgs}"
         )
+        assert not any("elicitation" in msg.lower() for msg in warning_msgs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,7 +1,7 @@
 import os
 import stat
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -44,25 +44,6 @@ def test_settings_is_configured_false_when_missing():
         assert settings.is_configured() is False
 
 
-def test_settings_apply_runtime_config_updates_module_globals():
-    import os
-
-    from unraid_mcp.config import settings
-
-    original_url = settings.UNRAID_API_URL
-    original_key = settings.UNRAID_API_KEY
-    try:
-        settings.apply_runtime_config("https://newurl.com/graphql", "newkey")
-        assert settings.UNRAID_API_URL == "https://newurl.com/graphql"
-        assert settings.UNRAID_API_KEY == "newkey"
-        # Credentials must NOT leak to os.environ (security fix: unraid-mcp-cbc)
-        assert os.environ.get("UNRAID_API_URL") != "https://newurl.com/graphql"
-        assert os.environ.get("UNRAID_API_KEY") != "newkey"
-    finally:
-        settings.UNRAID_API_URL = original_url
-        settings.UNRAID_API_KEY = original_key
-
-
 def test_run_server_does_not_exit_when_creds_missing(monkeypatch):
     """Server should not sys.exit(1) when credentials are absent."""
     import unraid_mcp.config.settings as settings_mod
@@ -89,69 +70,9 @@ def test_run_server_does_not_exit_when_creds_missing(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_elicit_and_configure_writes_env_file(tmp_path):
-    """elicit_and_configure writes a .env file and calls apply_runtime_config."""
-    from unraid_mcp.core.setup import elicit_and_configure
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "accept"
-    mock_result.data = MagicMock()
-    mock_result.data.api_url = "https://myunraid.example.com/graphql"
-    mock_result.data.api_key = "abc123secret"
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    creds_dir = tmp_path / "creds"
-    creds_file = creds_dir / ".env"
-
-    with (
-        patch("unraid_mcp.core.setup.CREDENTIALS_DIR", creds_dir),
-        patch("unraid_mcp.core.setup.CREDENTIALS_ENV_PATH", creds_file),
-        patch("unraid_mcp.core.setup.PROJECT_ROOT", tmp_path),
-        patch("unraid_mcp.core.setup.apply_runtime_config") as mock_apply,
-    ):
-        result = await elicit_and_configure(mock_ctx)
-
-    assert result is True
-    assert creds_file.exists()
-    content = creds_file.read_text()
-    assert "UNRAID_API_URL=https://myunraid.example.com/graphql" in content
-    assert "UNRAID_API_KEY=abc123secret" in content
-    mock_apply.assert_called_once_with("https://myunraid.example.com/graphql", "abc123secret")
-
-
-@pytest.mark.asyncio
-async def test_elicit_and_configure_returns_false_on_decline():
-
-    from unraid_mcp.core.setup import elicit_and_configure
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "decline"
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    result = await elicit_and_configure(mock_ctx)
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_elicit_and_configure_returns_false_on_cancel():
-
-    from unraid_mcp.core.setup import elicit_and_configure
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "cancel"
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    result = await elicit_and_configure(mock_ctx)
-    assert result is False
-
-
-@pytest.mark.asyncio
 async def test_make_graphql_request_raises_sentinel_when_unconfigured():
     """make_graphql_request raises CredentialsNotConfiguredError (not ToolError) when
-    credentials are absent, so callers can trigger elicitation."""
+    credentials are absent, so callers can surface setup instructions."""
     from unraid_mcp.config import settings as settings_mod
     from unraid_mcp.core.client import make_graphql_request
     from unraid_mcp.core.exceptions import CredentialsNotConfiguredError
@@ -320,19 +241,6 @@ def test_write_env_updates_existing_credentials_in_place(tmp_path):
     assert "old" not in content
 
 
-@pytest.mark.asyncio
-async def test_elicit_and_configure_returns_false_when_client_not_supported():
-    """elicit_and_configure returns False when client raises NotImplementedError."""
-
-    from unraid_mcp.core.setup import elicit_and_configure
-
-    mock_ctx = MagicMock()
-    mock_ctx.elicit = AsyncMock(side_effect=NotImplementedError("elicitation not supported"))
-
-    result = await elicit_and_configure(mock_ctx)
-    assert result is False
-
-
 def test_tool_error_handler_converts_credentials_not_configured_to_tool_error():
     """tool_error_handler wraps CredentialsNotConfiguredError in a ToolError."""
     import logging
@@ -365,118 +273,6 @@ def test_tool_error_handler_credentials_error_message_includes_path():
 
     assert str(CREDENTIALS_ENV_PATH) in str(exc_info.value)
     assert "setup" in str(exc_info.value).lower()
-
-
-# ---------------------------------------------------------------------------
-# elicit_reset_confirmation
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_returns_false_when_ctx_none():
-    """Returns False immediately when no MCP context is available."""
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    result = await elicit_reset_confirmation(None, "https://example.com")
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_returns_true_when_user_confirms():
-    """Returns True when the user accepts and answers True."""
-
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "accept"
-    mock_result.data = True
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    result = await elicit_reset_confirmation(mock_ctx, "https://example.com")
-    assert result is True
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_returns_false_when_user_answers_false():
-    """Returns False when the user accepts but answers False (does not want to reset)."""
-
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "accept"
-    mock_result.data = False
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    result = await elicit_reset_confirmation(mock_ctx, "https://example.com")
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_returns_false_when_declined():
-    """Returns False when the user declines via action (dismisses the prompt)."""
-
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "decline"
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    result = await elicit_reset_confirmation(mock_ctx, "https://example.com")
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_returns_false_when_cancelled():
-    """Returns False when the user cancels the prompt."""
-
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "cancel"
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    result = await elicit_reset_confirmation(mock_ctx, "https://example.com")
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_returns_false_when_not_implemented():
-    """Returns False (decline reset) when the MCP client does not support elicitation.
-
-    Auto-approving a destructive credential reset on non-interactive clients would
-    silently overwrite working credentials. Callers must use a client that supports
-    elicitation or configure credentials directly via the .env file.
-    """
-
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    mock_ctx = MagicMock()
-    mock_ctx.elicit = AsyncMock(side_effect=NotImplementedError("elicitation not supported"))
-
-    result = await elicit_reset_confirmation(mock_ctx, "https://example.com")
-    assert result is False
-
-
-@pytest.mark.asyncio
-async def test_elicit_reset_confirmation_includes_current_url_in_prompt():
-    """The elicitation message includes the current URL so the user knows what they're replacing."""
-
-    from unraid_mcp.core.setup import elicit_reset_confirmation
-
-    mock_ctx = MagicMock()
-    mock_result = MagicMock()
-    mock_result.action = "decline"
-    mock_ctx.elicit = AsyncMock(return_value=mock_result)
-
-    await elicit_reset_confirmation(mock_ctx, "https://my-unraid.example.com:31337")
-
-    call_kwargs = mock_ctx.elicit.call_args
-    message = call_kwargs.kwargs.get("message") or call_kwargs.args[0]
-    assert "https://my-unraid.example.com:31337" in message
 
 
 @pytest.mark.asyncio

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -57,9 +57,20 @@ def _load_env_files() -> None:
     ]
 
     for dotenv_path in dotenv_paths:
-        if dotenv_path.exists():
-            load_dotenv(dotenv_path=dotenv_path)
-            break
+        if not dotenv_path.exists():
+            continue
+        # Refuse a symlinked credentials/env file — it holds secrets and a planted
+        # symlink could redirect the read to attacker-controlled content (CWE-22).
+        # Mirrors the rmcp-template / axon convention.
+        if dotenv_path.is_symlink():
+            print(
+                f"WARNING: refusing to load symlinked env file {dotenv_path} "
+                "(potential symlink attack); skipping.",
+                file=sys.stderr,
+            )
+            continue
+        load_dotenv(dotenv_path=dotenv_path)
+        break
 
 
 _load_env_files()

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -65,10 +65,10 @@ def _load_env_files() -> None:
 _load_env_files()
 
 # Core API Configuration
-# IMPORTANT: UNRAID_API_URL and UNRAID_API_KEY are mutated at runtime by apply_runtime_config().
-# Never import these names at module level in code that runs after startup.
-# Instead, use a local import: from ..config import settings as _settings; _settings.UNRAID_API_URL
-# Or call get_api_credentials() which always returns the current values.
+# Loaded once at startup from the .env hierarchy / process env. Consumers should
+# read the current value via a local import (from ..config import settings as
+# _settings; _settings.UNRAID_API_URL) or get_api_credentials(), so a future
+# reload picks up the latest binding rather than a stale module-import snapshot.
 UNRAID_API_URL = os.getenv("UNRAID_API_URL")
 UNRAID_API_KEY = os.getenv("UNRAID_API_KEY")
 
@@ -153,21 +153,8 @@ def is_configured() -> bool:
     return bool(UNRAID_API_URL and UNRAID_API_KEY)
 
 
-def apply_runtime_config(api_url: str, api_key: str) -> None:
-    """Update module-level credential globals at runtime (post-elicitation).
-
-    Credentials are intentionally NOT written to os.environ to prevent
-    leaking secrets to subprocesses or error reporters that capture
-    environment snapshots.  All internal consumers read from this module's
-    globals via ``from ..config import settings as _settings``.
-    """
-    global UNRAID_API_URL, UNRAID_API_KEY
-    UNRAID_API_URL = api_url
-    UNRAID_API_KEY = api_key
-
-
 def get_api_credentials() -> tuple[str | None, str | None]:
-    """Return current (UNRAID_API_URL, UNRAID_API_KEY) — safe to call after apply_runtime_config."""
+    """Return the current (UNRAID_API_URL, UNRAID_API_KEY) module globals."""
     return UNRAID_API_URL, UNRAID_API_KEY
 
 

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -78,8 +78,8 @@ _load_env_files()
 # Core API Configuration
 # Loaded once at startup from the .env hierarchy / process env. Consumers should
 # read the current value via a local import (from ..config import settings as
-# _settings; _settings.UNRAID_API_URL) or get_api_credentials(), so a future
-# reload picks up the latest binding rather than a stale module-import snapshot.
+# _settings; _settings.UNRAID_API_URL), so a future reload picks up the latest
+# binding rather than a stale module-import snapshot.
 UNRAID_API_URL = os.getenv("UNRAID_API_URL")
 UNRAID_API_KEY = os.getenv("UNRAID_API_KEY")
 
@@ -162,11 +162,6 @@ def validate_required_config() -> tuple[bool, list[str]]:
 def is_configured() -> bool:
     """Return True if both required credentials are present."""
     return bool(UNRAID_API_URL and UNRAID_API_KEY)
-
-
-def get_api_credentials() -> tuple[str | None, str | None]:
-    """Return the current (UNRAID_API_URL, UNRAID_API_KEY) module globals."""
-    return UNRAID_API_URL, UNRAID_API_KEY
 
 
 def apply_bearer_token(token: str) -> None:

--- a/unraid_mcp/core/client.py
+++ b/unraid_mcp/core/client.py
@@ -302,8 +302,8 @@ async def make_graphql_request(
         CredentialsNotConfiguredError: When UNRAID_API_URL or UNRAID_API_KEY are absent at call time
         ToolError: For HTTP errors, network errors, or non-idempotent GraphQL errors
     """
-    # Local import to get current runtime values — module-level names are captured at import time
-    # and won't reflect runtime changes (e.g., after elicitation sets them via apply_runtime_config).
+    # Local import to read the current values — module-level names are captured at import time
+    # and would not reflect a settings reload.
     from ..config import settings as _settings
 
     if not _settings.UNRAID_API_URL or not _settings.UNRAID_API_KEY:

--- a/unraid_mcp/core/exceptions.py
+++ b/unraid_mcp/core/exceptions.py
@@ -26,7 +26,7 @@ class ToolError(FastMCPToolError):
 class CredentialsNotConfiguredError(Exception):
     """Raised when UNRAID_API_URL or UNRAID_API_KEY are not set.
 
-    Used as a sentinel to trigger elicitation rather than a hard crash.
+    Used as a sentinel so callers can surface setup instructions rather than crashing.
     """
 
     def __str__(self) -> str:

--- a/unraid_mcp/core/setup.py
+++ b/unraid_mcp/core/setup.py
@@ -89,9 +89,7 @@ def run_plugin_hook() -> int:
         report["ran_repair"] = True
         logger.info("Plugin setup hook wrote credentials to %s", CREDENTIALS_ENV_PATH)
     else:
-        missing = [
-            name for name in ("UNRAID_API_URL", "UNRAID_API_KEY") if name not in resolved
-        ]
+        missing = [name for name in ("UNRAID_API_URL", "UNRAID_API_KEY") if name not in resolved]
         report["advisory_failures"] = [
             f"{name} not supplied via plugin userConfig — set it in the plugin "
             f"config form or edit {CREDENTIALS_ENV_PATH} directly."

--- a/unraid_mcp/core/setup.py
+++ b/unraid_mcp/core/setup.py
@@ -1,130 +1,109 @@
-"""Interactive credential setup via MCP elicitation.
+"""Non-interactive credential setup for the Unraid MCP server.
 
-When UNRAID_API_URL or UNRAID_API_KEY are absent, tools call
-`elicit_and_configure(ctx)` to collect them from the user and persist
-them to ~/.unraid-mcp/.env with restricted permissions.
+Configuration is delivered by the plugin's ``userConfig`` form (Claude Code
+injects it as ``CLAUDE_PLUGIN_OPTION_*`` environment variables) or by a
+hand-edited ``~/.unraid-mcp/.env``. This module maps those plugin options to
+the canonical ``.env`` file with restricted permissions, mirroring the
+``setup plugin-hook`` pattern used across the rmcp-template Rust servers.
+
+There is no interactive elicitation: the plugin config form is the UI, and
+``run_plugin_hook()`` persists it to disk so the server, the CLI, and Docker
+all read the same source of truth at startup.
 """
 
 from __future__ import annotations
 
+import json
 import os
-from typing import TYPE_CHECKING
-
-from pydantic import BaseModel, Field
-
-
-if TYPE_CHECKING:
-    from fastmcp import Context
 
 from ..config.logging import logger
 from ..config.settings import (
     CREDENTIALS_DIR,
     CREDENTIALS_ENV_PATH,
     PROJECT_ROOT,
-    apply_runtime_config,
 )
 
 
-class _UnraidCredentials(BaseModel):
-    """Credentials model for MCP elicitation form rendering."""
+# Maps Claude Code plugin-option env vars -> canonical server env vars.
+# Mirrors rmcp-template's env_registry plugin_option_mappings().
+PLUGIN_OPTION_MAP: dict[str, str] = {
+    "CLAUDE_PLUGIN_OPTION_UNRAID_API_URL": "UNRAID_API_URL",
+    "CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY": "UNRAID_API_KEY",
+}
 
-    api_url: str = Field(..., description="Unraid GraphQL endpoint URL")
-    api_key: str = Field(..., description="Unraid API key")
 
+def _safe_env_value(value: str) -> str | None:
+    """Return the value if safe to write to a .env file, else None.
 
-async def elicit_reset_confirmation(ctx: Context | None, current_url: str) -> bool:
-    """Ask the user whether to overwrite existing credentials.
-
-    Args:
-        ctx: The MCP context for elicitation. If None, returns False immediately.
-        current_url: The currently configured URL and status (displayed for context).
-
-    Returns:
-        True if the user confirmed the reset, False otherwise.
+    Rejects empty values and values containing newlines, carriage returns, or
+    NUL bytes (which could inject extra .env lines). Mirrors apply_plugin_options
+    in the Rust template.
     """
-    if ctx is None:
-        return False
-
-    try:
-        result = await ctx.elicit(
-            message=(
-                "Credentials are already configured.\n\n"
-                f"**Current URL:** `{current_url}`\n\n"
-                "Do you want to reset your API URL and key?"
-            ),
-            response_type=bool,
-        )
-    except NotImplementedError:
-        # Client doesn't support elicitation — return False (decline the reset).
-        # Auto-approving a destructive credential reset on non-interactive clients
-        # could silently overwrite working credentials; callers must use a client
-        # that supports elicitation or configure credentials directly in the .env file.
-        logger.warning(
-            "MCP client does not support elicitation for reset confirmation — declining reset. "
-            "To reconfigure credentials, edit %s directly.",
-            CREDENTIALS_ENV_PATH,
-        )
-        return False
-
-    if result.action != "accept":
-        logger.info("Credential reset declined by user (%s).", result.action)
-        return False
-
-    confirmed: bool = result.data  # type: ignore[union-attr]
-    return confirmed
+    if not value:
+        return None
+    if any(ch in value for ch in ("\n", "\r", "\0")):
+        return None
+    return value
 
 
-async def elicit_and_configure(ctx: Context | None) -> bool:
-    """Prompt the user for Unraid credentials via MCP elicitation.
+def apply_plugin_options() -> dict[str, str]:
+    """Resolve canonical credentials from CLAUDE_PLUGIN_OPTION_* env vars.
 
-    Writes accepted credentials to CREDENTIALS_ENV_PATH and applies them
-    to the running process via apply_runtime_config().
-
-    Args:
-        ctx: The MCP context for elicitation. If None, returns False immediately
-             (no context available to prompt the user).
-
-    Returns:
-        True if credentials were accepted and applied, False if declined/cancelled
-        or if the MCP client does not support elicitation.
+    Returns a dict of ``{canonical_env_name: value}`` for every plugin option
+    that is present and safe. Missing, empty, or unsafe options are skipped.
+    The URL has any trailing slash stripped; all values are whitespace-trimmed.
     """
-    if ctx is None:
-        logger.warning(
-            "Cannot elicit credentials: no MCP context available. "
-            "Run unraid(action=health, subaction=setup) to configure credentials."
+    resolved: dict[str, str] = {}
+    for option, canonical in PLUGIN_OPTION_MAP.items():
+        raw = os.environ.get(option)
+        if raw is None:
+            continue
+        safe = _safe_env_value(raw.strip())
+        if safe is None:
+            continue
+        resolved[canonical] = safe.rstrip("/") if canonical == "UNRAID_API_URL" else safe
+    return resolved
+
+
+def run_plugin_hook() -> int:
+    """Persist plugin userConfig credentials to CREDENTIALS_ENV_PATH.
+
+    Designed to run from the plugin's SessionStart / ConfigChange hooks. When
+    both URL and key are supplied via CLAUDE_PLUGIN_OPTION_*, writes them to
+    ``~/.unraid-mcp/.env`` (mode 600). Always returns 0 (advisory) so a missing
+    config never blocks the session — the server reports the unconfigured state
+    at request time instead. Emits a JSON report to stdout.
+    """
+    resolved = apply_plugin_options()
+    report: dict[str, object] = {
+        "ran_repair": False,
+        "env_path": str(CREDENTIALS_ENV_PATH),
+        "advisory_failures": [],
+    }
+
+    api_url = resolved.get("UNRAID_API_URL")
+    api_key = resolved.get("UNRAID_API_KEY")
+
+    if api_url and api_key:
+        _write_env(api_url, api_key)
+        report["ran_repair"] = True
+        logger.info("Plugin setup hook wrote credentials to %s", CREDENTIALS_ENV_PATH)
+    else:
+        missing = [
+            name for name in ("UNRAID_API_URL", "UNRAID_API_KEY") if name not in resolved
+        ]
+        report["advisory_failures"] = [
+            f"{name} not supplied via plugin userConfig — set it in the plugin "
+            f"config form or edit {CREDENTIALS_ENV_PATH} directly."
+            for name in missing
+        ]
+        logger.info(
+            "Plugin setup hook: credentials not fully supplied (%s); no .env written.",
+            ", ".join(missing),
         )
-        return False
 
-    try:
-        result = await ctx.elicit(
-            message=(
-                "Unraid MCP needs your Unraid server credentials to connect.\n\n"
-                "• **API URL**: Your Unraid GraphQL endpoint "
-                "(e.g. `https://10-1-0-2.xxx.myunraid.net:31337`)\n"
-                "• **API Key**: Found in Unraid → Settings → Management Access → API Keys"
-            ),
-            response_type=_UnraidCredentials,
-        )
-    except NotImplementedError:
-        logger.warning(
-            "MCP client does not support elicitation. "
-            "Use unraid(action=health, subaction=setup) or create %s manually.",
-            CREDENTIALS_ENV_PATH,
-        )
-        return False
-
-    if result.action != "accept":
-        logger.warning("Credential elicitation %s — server remains unconfigured.", result.action)
-        return False
-
-    api_url: str = result.data.api_url.rstrip("/")  # type: ignore[union-attr]
-    api_key: str = result.data.api_key.strip()  # type: ignore[union-attr]
-
-    _write_env(api_url, api_key)
-    apply_runtime_config(api_url, api_key)
-
-    logger.info("Credentials configured via elicitation and persisted to %s.", CREDENTIALS_ENV_PATH)
-    return True
+    print(json.dumps(report, indent=2))
+    return 0
 
 
 def _write_env(api_url: str, api_key: str) -> None:

--- a/unraid_mcp/core/setup.py
+++ b/unraid_mcp/core/setup.py
@@ -85,19 +85,45 @@ def run_plugin_hook() -> int:
     api_key = resolved.get("UNRAID_API_KEY")
 
     if api_url and api_key:
-        _write_env(api_url, api_key)
-        report["ran_repair"] = True
-        logger.info("Plugin setup hook wrote credentials to %s", CREDENTIALS_ENV_PATH)
+        try:
+            _write_env(api_url, api_key)
+            report["ran_repair"] = True
+            logger.info("Plugin setup hook wrote credentials to %s", CREDENTIALS_ENV_PATH)
+        except OSError as e:
+            # Record the write failure in the advisory channel rather than letting it
+            # escape — the documented contract is "always returns 0" so the hook never
+            # blocks a session. The server still reports unconfigured at request time.
+            report["advisory_failures"] = [
+                f"Failed to write {CREDENTIALS_ENV_PATH}: {type(e).__name__}: {e}"
+            ]
+            logger.error(
+                "Plugin setup hook failed to write %s: %s",
+                CREDENTIALS_ENV_PATH,
+                e,
+                exc_info=True,
+            )
     else:
-        missing = [name for name in ("UNRAID_API_URL", "UNRAID_API_KEY") if name not in resolved]
-        report["advisory_failures"] = [
-            f"{name} not supplied via plugin userConfig — set it in the plugin "
-            f"config form or edit {CREDENTIALS_ENV_PATH} directly."
-            for name in missing
-        ]
+        # Distinguish "not supplied" from "supplied but rejected as unsafe": a present
+        # env var that failed _safe_env_value is absent from `resolved` but should still
+        # be surfaced so the operator knows why it was dropped.
+        failures: list[str] = []
+        for option, canonical in PLUGIN_OPTION_MAP.items():
+            if canonical in resolved:
+                continue
+            if os.environ.get(option):
+                failures.append(
+                    f"{canonical} was supplied but rejected (empty or unsafe characters) — "
+                    "check the value in the plugin config form."
+                )
+            else:
+                failures.append(
+                    f"{canonical} not supplied via plugin userConfig — set it in the plugin "
+                    f"config form or edit {CREDENTIALS_ENV_PATH} directly."
+                )
+        report["advisory_failures"] = failures
         logger.info(
-            "Plugin setup hook: credentials not fully supplied (%s); no .env written.",
-            ", ".join(missing),
+            "Plugin setup hook: credentials not fully supplied; no .env written. %s",
+            " ".join(failures),
         )
 
     print(json.dumps(report, indent=2))
@@ -149,7 +175,10 @@ def _write_env(api_url: str, api_key: str) -> None:
         tmp_path.chmod(0o600)
         os.replace(tmp_path, CREDENTIALS_ENV_PATH)  # noqa: PTH105
     finally:
-        # Clean up tmp on failure (may not exist if os.replace succeeded)
-        if tmp_path.exists():
-            tmp_path.unlink()
+        # Clean up tmp on failure (may not exist if os.replace succeeded). Swallow any
+        # cleanup error so it can't mask the real write exception propagating from try.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError as cleanup_err:
+            logger.warning("Could not remove temp env file %s: %s", tmp_path, cleanup_err)
     logger.info("Credentials written to %s (mode 600)", CREDENTIALS_ENV_PATH)

--- a/unraid_mcp/core/setup.py
+++ b/unraid_mcp/core/setup.py
@@ -133,6 +133,21 @@ def run_plugin_hook() -> int:
     return 0
 
 
+def _dotenv_value(value: str) -> str:
+    """Render a value for a .env assignment, quoting only when necessary.
+
+    Plain values (the common case — alphanumeric keys, scheme://host URLs) are
+    written unquoted. Values containing whitespace or characters that would break
+    unquoted parsing (`#`, quotes, backslash) are double-quoted with backslash and
+    double-quote escaped, so they round-trip through python-dotenv and the skill's
+    load-env.sh parser. Mirrors rmcp-template's dotenv_value.
+    """
+    if value and not any(ch in value for ch in (" ", "\t", "#", '"', "'", "\\")):
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 def _write_env(api_url: str, api_key: str) -> None:
     """Write or update credentials in CREDENTIALS_ENV_PATH.
 
@@ -156,19 +171,19 @@ def _write_env(api_url: str, api_key: str) -> None:
     for line in template_lines:
         stripped = line.strip()
         if stripped.startswith("UNRAID_API_URL="):
-            new_lines.append(f"UNRAID_API_URL={api_url}")
+            new_lines.append(f"UNRAID_API_URL={_dotenv_value(api_url)}")
             url_written = True
         elif stripped.startswith("UNRAID_API_KEY="):
-            new_lines.append(f"UNRAID_API_KEY={api_key}")
+            new_lines.append(f"UNRAID_API_KEY={_dotenv_value(api_key)}")
             key_written = True
         else:
             new_lines.append(line)
 
     # If not found in template (empty or missing keys), append at end
     if not url_written:
-        new_lines.append(f"UNRAID_API_URL={api_url}")
+        new_lines.append(f"UNRAID_API_URL={_dotenv_value(api_url)}")
     if not key_written:
-        new_lines.append(f"UNRAID_API_KEY={api_key}")
+        new_lines.append(f"UNRAID_API_KEY={_dotenv_value(api_key)}")
 
     # Atomic write: write to tmp file, set permissions, then rename into place.
     # os.replace is atomic on POSIX — prevents a crash from leaving a partial .env.

--- a/unraid_mcp/core/setup.py
+++ b/unraid_mcp/core/setup.py
@@ -110,7 +110,10 @@ def run_plugin_hook() -> int:
         for option, canonical in PLUGIN_OPTION_MAP.items():
             if canonical in resolved:
                 continue
-            if os.environ.get(option):
+            if option in os.environ:
+                # Present (key set) but absent from `resolved` → empty or unsafe value.
+                # Use key presence, not truthiness, so an explicit empty value is
+                # classified as "rejected", not "not supplied".
                 failures.append(
                     f"{canonical} was supplied but rejected (empty or unsafe characters) — "
                     "check the value in the plugin config form."

--- a/unraid_mcp/main.py
+++ b/unraid_mcp/main.py
@@ -42,9 +42,18 @@ def main() -> None:
     """Main entry point for the Unraid MCP Server."""
     argv = sys.argv[1:]
     if argv and argv[0] == "setup":
-        # `setup` and `setup plugin-hook` both run the non-interactive plugin hook,
-        # which maps CLAUDE_PLUGIN_OPTION_* -> ~/.unraid-mcp/.env. Used by the
-        # plugin's SessionStart / ConfigChange hooks.
+        # `setup` (bare) and `setup plugin-hook` run the non-interactive plugin hook,
+        # which maps CLAUDE_PLUGIN_OPTION_* -> ~/.unraid-mcp/.env. Used by the plugin's
+        # SessionStart / ConfigChange hooks. Reject unknown subcommands so a typo
+        # (e.g. `setup plugin-hookk`) fails loudly instead of silently succeeding.
+        subcommand = argv[1] if len(argv) > 1 else "plugin-hook"
+        if subcommand != "plugin-hook":
+            print(
+                f"Unknown setup subcommand: {subcommand!r}. Valid: 'plugin-hook'.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
         from .core.setup import run_plugin_hook
 
         sys.exit(run_plugin_hook())

--- a/unraid_mcp/main.py
+++ b/unraid_mcp/main.py
@@ -40,6 +40,15 @@ def _run_shutdown_cleanup() -> None:
 
 def main() -> None:
     """Main entry point for the Unraid MCP Server."""
+    argv = sys.argv[1:]
+    if argv and argv[0] == "setup":
+        # `setup` and `setup plugin-hook` both run the non-interactive plugin hook,
+        # which maps CLAUDE_PLUGIN_OPTION_* -> ~/.unraid-mcp/.env. Used by the
+        # plugin's SessionStart / ConfigChange hooks.
+        from .core.setup import run_plugin_hook
+
+        sys.exit(run_plugin_hook())
+
     try:
         from .server import run_server
 

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -199,8 +199,9 @@ def run_server() -> None:
         is_valid, missing = validate_required_config()
         if not is_valid:
             logger.warning(
-                "Missing configuration: %s. "
-                "Server will prompt for credentials on first tool call via elicitation.",
+                "Missing configuration: %s. Set the plugin's userConfig fields "
+                "(or UNRAID_API_URL / UNRAID_API_KEY in ~/.unraid-mcp/.env), then restart. "
+                "Tools will return a setup message until configured.",
                 ", ".join(missing),
             )
 

--- a/unraid_mcp/tools/_health.py
+++ b/unraid_mcp/tools/_health.py
@@ -1,8 +1,8 @@
 """Health domain constants and helpers for the Unraid MCP tool.
 
 The _handle_health function lives in unraid.py (not here) because tests patch
-elicit_and_configure at unraid_mcp.tools.unraid — keeping the handler there
-ensures patches resolve correctly without circular imports.
+settings and client symbols at unraid_mcp.tools.unraid — keeping the handler
+there ensures patches resolve correctly without circular imports.
 """
 
 import datetime

--- a/unraid_mcp/tools/_health.py
+++ b/unraid_mcp/tools/_health.py
@@ -1,8 +1,9 @@
 """Health domain constants and helpers for the Unraid MCP tool.
 
-The _handle_health function lives in unraid.py (not here) because tests patch
-settings and client symbols at unraid_mcp.tools.unraid — keeping the handler
-there ensures patches resolve correctly without circular imports.
+The _handle_health function lives in unraid.py (not here) to avoid a circular
+import between the aggregator module and the _* domain helper modules. It reads
+settings/client symbols via local imports, so tests patch them at their source
+modules (unraid_mcp.config.settings, unraid_mcp.core.client).
 """
 
 import datetime

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -30,7 +30,6 @@ from fastmcp import Context, FastMCP
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
-from ..core.setup import elicit_and_configure, elicit_reset_confirmation
 from ..core.utils import validate_subaction
 
 # Re-exports: domain modules' constants and helpers needed by tests
@@ -86,8 +85,7 @@ from ._vm import _VM_DESTRUCTIVE, _VM_MUTATIONS, _VM_QUERIES, _handle_vm  # noqa
 
 
 # ===========================================================================
-# HEALTH handler — kept here so test patches on unraid_mcp.tools.unraid.*
-# intercept elicit_and_configure / elicit_reset_confirmation correctly
+# HEALTH handler
 # ===========================================================================
 
 
@@ -97,44 +95,39 @@ async def _handle_health(subaction: str, ctx: Context | None) -> dict[str, Any] 
     from ..config.settings import (
         CREDENTIALS_ENV_PATH,
         UNRAID_API_URL,
+        is_configured,
     )
     from ..core.utils import safe_display_url
     from ..subscriptions.utils import _analyze_subscription_status
 
     if subaction == "setup":
-        if CREDENTIALS_ENV_PATH.exists():
-            connection_error_type: str | None = None
+        if is_configured():
             try:
                 await _client.make_graphql_request(_SYSTEM_QUERIES["online"])
-                connection_ok = True
+                status = "and the connection test succeeded"
             except Exception as e:
-                connection_ok = False
-                connection_error_type = type(e).__name__
-                logger.debug(f"health/setup connection probe failed: {connection_error_type}: {e}")
-            if connection_ok:
-                status_note = "and working"
-            elif connection_error_type:
-                status_note = f"but the connection test failed ({connection_error_type}) — may be a transient outage or misconfiguration"
-            else:
-                status_note = "but the connection test failed — may be a transient outage"
-            reset = await elicit_reset_confirmation(
-                ctx,
-                f"{safe_display_url(UNRAID_API_URL) or ''} ({status_note})",
-            )
-            if not reset:
-                return (
-                    f"✅ Credentials already configured ({status_note}).\n"
-                    f"URL: `{safe_display_url(UNRAID_API_URL)}`\n\nNo changes made."
+                status = (
+                    f"but the connection test failed ({type(e).__name__}) — "
+                    "this may be a transient outage or a misconfiguration"
                 )
-        configured = await elicit_and_configure(ctx)
-        if configured:
-            return "✅ Credentials configured successfully. You can now use all Unraid MCP tools."
+            return (
+                f"✅ Credentials are configured ({status}).\n"
+                f"URL: `{safe_display_url(UNRAID_API_URL)}`\n"
+                f"File: `{CREDENTIALS_ENV_PATH}`\n\n"
+                "To change them, update the plugin's userConfig form "
+                "(Unraid GraphQL API URL / Unraid API Key) or edit that file, "
+                "then restart the server."
+            )
         return (
-            f"⚠️ Credentials not configured.\n\n"
-            f"Your MCP client may not support elicitation, or setup was cancelled.\n\n"
-            f"**Manual setup** — create `{CREDENTIALS_ENV_PATH}` with:\n"
-            f"```\nUNRAID_API_URL=https://your-unraid-server:port\nUNRAID_API_KEY=your-api-key\n```\n\n"
-            "Then run any Unraid tool to connect."
+            "⚠️ Credentials are not configured.\n\n"
+            "**Claude Code plugin:** set *Unraid GraphQL API URL* and *Unraid API Key* "
+            "in the plugin's configuration form — they are applied automatically on the "
+            "next session and persisted to disk.\n\n"
+            f"**Manual / Docker:** create `{CREDENTIALS_ENV_PATH}` with:\n"
+            "```\nUNRAID_API_URL=https://your-unraid-server:port\n"
+            "UNRAID_API_KEY=your-api-key\n```\n\n"
+            "Then restart the server and run "
+            '`unraid(action="health", subaction="test_connection")` to verify.'
         )
 
     with tool_error_handler("health", subaction, logger):

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -106,6 +106,7 @@ async def _handle_health(subaction: str, ctx: Context | None) -> dict[str, Any] 
                 await _client.make_graphql_request(_SYSTEM_QUERIES["online"])
                 status = "and the connection test succeeded"
             except Exception as e:
+                logger.debug("health/setup connection probe failed: %s: %s", type(e).__name__, e)
                 status = (
                     f"but the connection test failed ({type(e).__name__}) — "
                     "this may be a transient outage or a misconfiguration"
@@ -117,6 +118,18 @@ async def _handle_health(subaction: str, ctx: Context | None) -> dict[str, Any] 
                 "To change them, update the plugin's userConfig form "
                 "(Unraid GraphQL API URL / Unraid API Key) or edit that file, "
                 "then restart the server."
+            )
+        # Not loaded in this session. Credentials load once at startup, so a .env that
+        # exists on disk (e.g. just written by the ConfigChange hook) is not active until
+        # the next restart — report that distinctly from a genuinely-missing config.
+        if CREDENTIALS_ENV_PATH.exists():
+            return (
+                f"⚠️ A credentials file exists (`{CREDENTIALS_ENV_PATH}`) but is not loaded "
+                "in this session — credentials are read once at startup.\n\n"
+                "Restart the server (or your MCP client), then run "
+                '`unraid(action="health", subaction="test_connection")` to verify. '
+                "If it still fails, check that the file contains non-empty "
+                "`UNRAID_API_URL` and `UNRAID_API_KEY` values."
             )
         return (
             "⚠️ Credentials are not configured.\n\n"


### PR DESCRIPTION
## Summary

Removes MCP **elicitation** as the credential-configuration mechanism and replaces it with the `rmcp-template` env + userConfig pattern: the plugin's `userConfig` form is the configuration UI, and a non-interactive `setup plugin-hook` command persists those values to `~/.unraid-mcp/.env`.

**Destructive-action elicitation in `core/guards.py` is intentionally retained** — that confirms dangerous operations, not server configuration.

## What changed

- **`core/setup.py`** — deleted `elicit_and_configure`, `elicit_reset_confirmation`, and the `_UnraidCredentials` model. Added:
  - `apply_plugin_options()` — maps `CLAUDE_PLUGIN_OPTION_UNRAID_API_URL/KEY` → canonical env names (trims, strips trailing `/`, rejects newline/NUL injection).
  - `run_plugin_hook()` — persists both creds to `~/.unraid-mcp/.env` (atomic, mode 600 via the retained `_write_env`), prints a JSON report, always exits 0 (advisory).
- **`main.py`** — `unraid-mcp setup [plugin-hook]` dispatches to `run_plugin_hook()`.
- **Plugin hooks** — new `bin/plugin-setup.sh`; wired into `SessionStart` (after uv sync) and `ConfigChange(user_settings)` in `.claude-plugin/plugin.json` (authoritative) and mirrored in `hooks/hooks.json`. The wrapper is idempotent, so the documented hook-merge double-run is harmless.
- **`tools/unraid.py`** — `health/setup` is now a non-interactive status + instructions reporter (no `ctx.elicit`).
- **`config/settings.py`** — removed the now-orphaned `apply_runtime_config()`; credentials load from `.env`/env at startup.
- **Wording** — startup warning and `CredentialsNotConfiguredError` docstring no longer reference elicitation.
- **Docs** — `SETUP.md`, `README.md`, `ELICITATION.md` (now scoped to destructive-action confirmation), and a sweep across `docs/` describe the userConfig + `.env` flow. Credential-elicitation references removed; destructive-action elicitation docs preserved.

No version strings were hand-edited (release-please owns versioning). Gemini/Codex manifests need no change — they deliver creds via env directly.

## Verification

- `uv run pytest` → **1040 passed**
- `uv run ruff check` / `ruff format --check` → clean (83 files formatted)
- `uv run ty check unraid_mcp/` → clean
- Greps: no `elicit_and_configure`/`elicit_reset_confirmation`/`_UnraidCredentials`/`apply_runtime_config` anywhere; `ctx.elicit` only in `core/guards.py`.
- New tests in `tests/test_plugin_setup.py` cover option mapping (incl. injection rejection), `.env` persistence + 600 perms, advisory-on-missing, and CLI dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced interactive credential setup with a plugin `userConfig` + non‑interactive `.env` setup hook. Health/setup is read‑only, and the Unraid skill’s HTTP fallback now loads `~/.unraid-mcp/.env`. This also hardens env handling (symlink checks, safe parsing/quoting) and improves dashboard output.

- **New Features**
  - Hooks: `bin/plugin-setup.sh` runs on SessionStart and `ConfigChange(user_settings)` from `.claude-plugin/plugin.json` and mirrored `hooks/hooks.json`; it invokes `unraid-mcp setup plugin-hook` and is idempotent.
  - CLI: `unraid-mcp setup plugin-hook` maps `CLAUDE_PLUGIN_OPTION_UNRAID_API_URL`/`CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY` → `UNRAID_API_URL`/`UNRAID_API_KEY`, writes `~/.unraid-mcp/.env` atomically (600), and prints a JSON report.
  - Health/setup: non‑interactive status; reports configured/not, connection probe, and when an `.env` exists but isn’t loaded yet (asks to restart).

- **Bug Fixes**
  - Security: `.env` is parsed as data (never sourced) and only `UNRAID_*` vars are exported; refuse symlinked env files in both server and skill; `_write_env` quotes/escapes values so they round‑trip; tests pin injection‑safety, symlink rejection, and quoting.
  - HTTP fallback: `skills/unraid/load-env.sh` loads `~/.unraid-mcp/.env`; `unraid-query.sh` prefers `UNRAID_API_URL`/`UNRAID_API_KEY` and surfaces loader errors.
  - Dashboard: fixed single‑server detection, added per‑server guards/warnings, and default output to `$PWD/unraid-inventory.md` (override with `UNRAID_DASHBOARD_OUTPUT`).
  - Consistency: manifest/userConfig mapping kept in sync via tests; unknown `setup` subcommands exit 2.
  - Cleanup: removed dead `get_api_credentials` helper.

<sup>Written for commit 0e91c6ef36dc83fabac1c98cf5ea10388e108604. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-interactive `setup plugin-hook` flow that persists plugin-configured credentials into the local credentials `.env`.
* **Improvements**
  * `health/setup` is now read-only: reports configured/unconfigured states, includes connection probe results, and prints setup instructions without interactive prompts.
  * Credential loading is hardened by refusing symlinked `.env` files.
  * Clearer guidance when credentials are missing or not loaded yet.
* **Documentation**
  * Updated setup/auth/MCP skill docs to reflect plugin `userConfig` → persisted `.env`, and redefined “elicitation” for destructive confirmation only.
* **Tests**
  * Added end-to-end plugin setup and expanded health/setup scenario coverage, plus security tests for `.env` loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->