### PR TITLE
fix: matchedLines counts only severity matches; add returnedLines (#48)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,15 @@ streams down to relevant severity:
 - `context` — lines of surrounding context kept before/after each match (default `2`).
   Non-contiguous matches are separated by a `---` marker.
 
-Filtered responses add `matchedLines` (count) and a `filter` echo. The pure helper is
-`filter_log_lines(lines, level=None, context=2)` in `unraid_mcp/core/utils.py`.
+Filtered responses add two counts plus a `filter` echo:
+- `matchedLines` — number of lines that actually matched the severity filter (excludes
+  context lines and `---` separators).
+- `returnedLines` — number of real log lines returned (matches + context, excluding `---`
+  separator markers). Expect `matchedLines <= returnedLines`.
+
+The pure helpers are `filter_log_lines(lines, level=None, context=2)` (returns matches +
+context + `---` separators) and `count_log_matches(lines, level=None)` (severity-match
+count only), both in `unraid_mcp/core/utils.py`.
 
 ### Destructive Actions (require `confirm=True`)
 - **array**: stop_array, remove_disk, clear_disk_stats

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -175,7 +175,11 @@ async def test_log_tail_level_filters_events(_mock_subscribe_collect):
     log_file = result["events"][0]["logFile"]
     # match at idx1, context 1 → idx 0..2
     assert log_file["content"] == "a info\nb [ERROR] boom\nc info"
-    assert log_file["matchedLines"] == 3
+    # only the single [ERROR] line actually matched the severity filter (#48)
+    assert log_file["matchedLines"] == 1
+    # 3 real lines returned (match + 2 context), no "---" separator
+    assert log_file["returnedLines"] == 3
+    assert log_file["matchedLines"] < log_file["returnedLines"]
     # original fields preserved
     assert log_file["path"] == "/var/log/syslog"
 

--- a/tests/test_log_filter.py
+++ b/tests/test_log_filter.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import pytest
 
-from unraid_mcp.core.utils import filter_log_lines
+from unraid_mcp.core.utils import count_log_matches, filter_log_lines
 
 
 def test_no_level_returns_unchanged():
@@ -140,3 +140,47 @@ def test_tolerant_level_shapes(fmt):
     lines = ["ok info", fmt]
     result = filter_log_lines(lines, level="error", context=0)
     assert result == [fmt]
+
+
+# --- count_log_matches (issue #48) ---
+
+
+def test_count_no_level_counts_all_lines():
+    lines = ["a", "b", "c"]
+    assert count_log_matches(lines) == 3
+    assert count_log_matches(lines, level=None) == 3
+
+
+def test_count_only_matches_excludes_context_and_separators():
+    # Two non-contiguous error lines among info lines. With context, filter_log_lines
+    # returns extra context lines plus a "---" separator, but the match count is 2.
+    lines = [
+        "line0 info",
+        "line1 info",
+        "line2 [ERROR] boom",
+        "line3 info",
+        "line4 info",
+        "line5 info",
+        "line6 info",
+        "line7 [ERROR] kaboom",
+        "line8 info",
+    ]
+    assert count_log_matches(lines, level="error") == 2
+
+    filtered = filter_log_lines(lines, level="error", context=1)
+    # filtered pulls in surrounding context + a "---" separator between the
+    # two non-contiguous groups; returned-line count excludes "---".
+    returned = sum(1 for line in filtered if line != "---")
+    assert "---" in filtered
+    assert returned > count_log_matches(lines, level="error")
+
+
+def test_count_respects_severity_threshold():
+    lines = ["info x", "warning y", "error z", "critical w"]
+    # warning threshold matches warning, error, critical
+    assert count_log_matches(lines, level="warning") == 3
+    assert count_log_matches(lines, level="error") == 2
+
+
+def test_count_no_match_is_zero():
+    assert count_log_matches(["info a", "debug b"], level="error") == 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -264,6 +264,64 @@ class TestStorageActions:
         result = await tool_fn(action="disk", subaction="logs", log_path="/var/log/syslog")
         assert result["content"] == "log line"
 
+    async def test_logs_level_filter_counts(self, _mock_graphql: AsyncMock) -> None:
+        """matchedLines counts only severity matches; returnedLines adds context (#48)."""
+        content = "\n".join(
+            [
+                "line0 info",
+                "line1 info",
+                "line2 [ERROR] boom",
+                "line3 info",
+                "line4 info",
+            ]
+        )
+        _mock_graphql.return_value = {
+            "logFile": {"path": "/var/log/syslog", "content": content, "totalLines": 5}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(
+            action="disk",
+            subaction="logs",
+            log_path="/var/log/syslog",
+            level="error",
+            context=2,
+        )
+        # only the single [ERROR] line matched the severity filter
+        assert result["matchedLines"] == 1
+        # match + 2 lines context on each side → 5 real lines returned
+        assert result["returnedLines"] == 5
+        assert result["matchedLines"] < result["returnedLines"]
+        assert result["filter"] == {"level": "error", "context": 2}
+
+    async def test_logs_level_filter_excludes_separators(self, _mock_graphql: AsyncMock) -> None:
+        """returnedLines excludes the '---' markers between non-contiguous groups (#48)."""
+        content = "\n".join(
+            [
+                "[ERROR] a",
+                "b",
+                "c",
+                "d",
+                "e",
+                "f",
+                "[ERROR] g",
+            ]
+        )
+        _mock_graphql.return_value = {
+            "logFile": {"path": "/var/log/syslog", "content": content, "totalLines": 7}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(
+            action="disk",
+            subaction="logs",
+            log_path="/var/log/syslog",
+            level="error",
+            context=1,
+        )
+        # two matching lines; groups [0..1] and [5..6] → 4 real lines + one "---"
+        assert result["matchedLines"] == 2
+        assert "---" in result["content"]
+        assert result["returnedLines"] == 4
+
 
 class TestStorageNetworkErrors:
     """Tests for network-level failures in storage operations."""
@@ -384,7 +442,9 @@ class TestLogsFiltering:
         )
         # match at line2, context 1 → lines 1..3
         assert result["content"] == "line1 info\nline2 [ERROR] boom\nline3 info"
-        assert result["matchedLines"] == 3
+        # only the single [ERROR] line matched the severity filter (#48)
+        assert result["matchedLines"] == 1
+        assert result["returnedLines"] == 3
         assert result["filter"] == {"level": "error", "context": 1}
 
     async def test_logs_level_no_match(self, _mock_graphql: AsyncMock) -> None:

--- a/unraid_mcp/core/utils.py
+++ b/unraid_mcp/core/utils.py
@@ -66,6 +66,52 @@ def _line_severity_rank(line: str) -> int | None:
     return best
 
 
+def _make_matcher(level: str):
+    """Build a predicate that decides whether a log line matches ``level``.
+
+    Shared by :func:`filter_log_lines` and :func:`count_log_matches` so the two
+    always agree on what "matches the severity filter" means. A line matches when
+    its detected structured level is at-or-above ``level``; lines with no
+    detectable level fall back to a case-insensitive keyword match against the
+    requested level name and its aliases.
+    """
+    canonical = _SEVERITY_ALIASES.get(level.lower(), level.lower())
+    threshold = _SEVERITY_RANK.get(canonical)
+
+    keywords = {level.lower(), canonical}
+    keywords.update(a for a, c in _SEVERITY_ALIASES.items() if c == canonical)
+
+    def _matches(line: str) -> bool:
+        rank = _line_severity_rank(line)
+        if rank is not None and threshold is not None:
+            return rank >= threshold
+        lowered = line.lower()
+        return any(kw in lowered for kw in keywords)
+
+    return _matches
+
+
+def count_log_matches(lines: list[str], level: str | None = None) -> int:
+    """Count log lines that actually match the severity filter.
+
+    Unlike :func:`filter_log_lines`, this counts ONLY the lines that match
+    ``level`` — it excludes the surrounding context lines and the ``"---"``
+    separators that ``filter_log_lines`` adds to its output.
+
+    Args:
+        lines: The raw log lines (without trailing newlines).
+        level: Minimum severity to match (see :func:`filter_log_lines`). When
+            None, every line is considered a match.
+
+    Returns:
+        The number of severity-matching lines.
+    """
+    if level is None:
+        return len(lines)
+    matcher = _make_matcher(level)
+    return sum(1 for line in lines if matcher(line))
+
+
 def filter_log_lines(
     lines: list[str],
     level: str | None = None,
@@ -99,22 +145,8 @@ def filter_log_lines(
     if context < 0:
         context = 0
 
-    canonical = _SEVERITY_ALIASES.get(level.lower(), level.lower())
-    threshold = _SEVERITY_RANK.get(canonical)
-
-    # Keyword fallback set: the requested level plus any aliases pointing at the
-    # same canonical level (so level="warning" also keyword-matches "warn").
-    keywords = {level.lower(), canonical}
-    keywords.update(a for a, c in _SEVERITY_ALIASES.items() if c == canonical)
-
-    def _matches(line: str) -> bool:
-        rank = _line_severity_rank(line)
-        if rank is not None and threshold is not None:
-            return rank >= threshold
-        lowered = line.lower()
-        return any(kw in lowered for kw in keywords)
-
-    match_indices = [i for i, line in enumerate(lines) if _matches(line)]
+    matches = _make_matcher(level)
+    match_indices = [i for i, line in enumerate(lines) if matches(line)]
     if not match_indices:
         return []
 

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -13,7 +13,12 @@ from ..core import client as _client
 from ..core.client import DISK_TIMEOUT
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
-from ..core.utils import filter_log_lines, format_bytes, validate_subaction
+from ..core.utils import (
+    count_log_matches,
+    filter_log_lines,
+    format_bytes,
+    validate_subaction,
+)
 
 
 # ===========================================================================
@@ -202,7 +207,8 @@ async def _handle_disk(
                 lines = out["content"].split("\n")
                 filtered = filter_log_lines(lines, level=level, context=context)
                 out["content"] = "\n".join(filtered)
-                out["matchedLines"] = len(filtered)
+                out["matchedLines"] = count_log_matches(lines, level=level)
+                out["returnedLines"] = sum(1 for line in filtered if line != "---")
                 out["filter"] = {"level": level, "context": context}
             return out
 

--- a/unraid_mcp/tools/_live.py
+++ b/unraid_mcp/tools/_live.py
@@ -22,10 +22,12 @@ def _filter_log_event(event: dict[str, Any], level: str, context: int) -> dict[s
 
     Each event is shaped ``{"logFile": {"content": "...", ...}}``. The ``content``
     field is a newline-joined block of log lines. Returns a shallow-copied event
-    with the filtered content and a ``matchedLines`` count. Events lacking a
+    with the filtered content, a ``matchedLines`` count (lines that actually
+    matched the severity filter) and a ``returnedLines`` count (real log lines
+    returned including context, excluding ``"---"`` separators). Events lacking a
     string ``content`` are returned unchanged.
     """
-    from ..core.utils import filter_log_lines
+    from ..core.utils import count_log_matches, filter_log_lines
 
     log_file = event.get("logFile")
     if not isinstance(log_file, dict):
@@ -36,7 +38,12 @@ def _filter_log_event(event: dict[str, Any], level: str, context: int) -> dict[s
 
     lines = content.split("\n")
     filtered = filter_log_lines(lines, level=level, context=context)
-    new_log_file = {**log_file, "content": "\n".join(filtered), "matchedLines": len(filtered)}
+    new_log_file = {
+        **log_file,
+        "content": "\n".join(filtered),
+        "matchedLines": count_log_matches(lines, level=level),
+        "returnedLines": sum(1 for line in filtered if line != "---"),
+    }
     return {**event, "logFile": new_log_file}
 
 


### PR DESCRIPTION
## Summary
Follow-up to #26. `matchedLines` previously reported `len(filter_log_lines(...))`, which includes surrounding context lines and `---` separators — overstating how many lines actually matched the severity filter (verified live: `disk/logs level=error context=2` reported 472, equal to total returned, not the ~200 true matches).

## Changes
- Add `count_log_matches(lines, level)` helper in `core/utils.py`, sharing match logic with `filter_log_lines` via a new internal `_make_matcher`. `filter_log_lines`'s public signature and default return type are unchanged.
- `matchedLines` now = true count of severity-matching lines (excludes context + separators).
- New `returnedLines` field = real log lines returned (matches + context, excluding `---` markers).
- Applied consistently in both `_disk.py` (`logs`) and `_live.py` (`log_tail`).
- Tests for the helper and both handlers; docs updated.

Closes #48

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes inflated log counts. matchedLines now counts only severity-matching lines, and returnedLines reports real lines returned (matches + context, excludes "---"). Closes #48.

- **Bug Fixes**
  - matchedLines excludes context and "---" separators; applied to disk logs and live tail.

- **New Features**
  - returnedLines added for accurate UI totals; tests cover counts and docs updated.

<sup>Written for commit 503f4446e2a28c381e7e47de966a448b349246c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

