### PR TITLE
chore: add shared cap_list helper for client-side list capping

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,63 @@
+"""Unit tests for the shared client-side list-capping helper."""
+
+from unraid_mcp.core.pagination import DEFAULT_LIST_LIMIT, cap_list
+
+
+def test_under_limit_returns_all_not_truncated():
+    items = [1, 2, 3]
+    capped, meta = cap_list(items, limit=10)
+    assert capped == items
+    assert meta == {"returned": 3, "total": 3, "truncated": False}
+
+
+def test_over_limit_truncates_with_hint():
+    items = list(range(100))
+    capped, meta = cap_list(items, limit=10)
+    assert capped == list(range(10))
+    assert meta["returned"] == 10
+    assert meta["total"] == 100
+    assert meta["truncated"] is True
+    assert "limit=" in meta["hint"]
+
+
+def test_none_limit_applies_default():
+    items = list(range(DEFAULT_LIST_LIMIT + 5))
+    capped, meta = cap_list(items, limit=None)
+    assert len(capped) == DEFAULT_LIST_LIMIT
+    assert meta["truncated"] is True
+    assert meta["total"] == DEFAULT_LIST_LIMIT + 5
+
+
+def test_zero_limit_returns_everything():
+    items = list(range(200))
+    capped, meta = cap_list(items, limit=0)
+    assert capped == items
+    assert meta["truncated"] is False
+    assert meta["returned"] == 200
+
+
+def test_negative_limit_returns_everything():
+    items = list(range(30))
+    capped, meta = cap_list(items, limit=-1)
+    assert capped == items
+    assert meta["truncated"] is False
+
+
+def test_exactly_at_limit_not_truncated():
+    items = list(range(10))
+    capped, meta = cap_list(items, limit=10)
+    assert capped == items
+    assert meta["truncated"] is False
+
+
+def test_empty_list():
+    capped, meta = cap_list([], limit=10)
+    assert capped == []
+    assert meta == {"returned": 0, "total": 0, "truncated": False}
+
+
+def test_custom_default():
+    items = list(range(20))
+    capped, meta = cap_list(items, limit=None, default=5)
+    assert len(capped) == 5
+    assert meta["truncated"] is True

--- a/unraid_mcp/core/pagination.py
+++ b/unraid_mcp/core/pagination.py
@@ -1,0 +1,52 @@
+"""Client-side list capping for tool responses.
+
+The Unraid GraphQL API exposes no server-side pagination for most collections
+(only ``notifications.list`` accepts ``offset``/``limit``). To keep large lists
+from flooding an agent's context window, list subactions slice the result in the
+handler and surface a small metadata dict describing the truncation.
+
+This is the shared primitive every list subaction should use so the truncation
+signal is consistent across the whole tool surface.
+"""
+
+from typing import Any
+
+
+# Default number of items returned when the caller does not specify a limit.
+DEFAULT_LIST_LIMIT: int = 50
+
+
+def cap_list(
+    items: list[Any], limit: int | None, *, default: int = DEFAULT_LIST_LIMIT
+) -> tuple[list[Any], dict[str, Any]]:
+    """Cap a list client-side and describe the result.
+
+    Args:
+        items: The full list returned by the upstream query.
+        limit: Caller-requested maximum. ``None`` applies ``default``. A value
+            ``<= 0`` disables capping (returns everything) — use it as an
+            explicit "give me all" escape hatch.
+        default: Limit applied when ``limit`` is ``None``.
+
+    Returns:
+        A ``(capped_items, meta)`` tuple. ``meta`` always carries ``returned``,
+        ``total`` and ``truncated``; when truncated it also carries a ``hint``
+        telling the agent how to widen the window. Surface ``meta`` in the
+        subaction response (e.g. under a ``page`` key) so the agent knows whether
+        more rows exist.
+    """
+    total = len(items)
+    effective = default if limit is None else limit
+
+    if effective is not None and effective > 0 and total > effective:
+        return items[:effective], {
+            "returned": effective,
+            "total": total,
+            "truncated": True,
+            "hint": (
+                f"showing {effective} of {total} items; pass a larger limit= "
+                "to see more (limit=0 for all)"
+            ),
+        }
+
+    return items, {"returned": total, "total": total, "truncated": False}


### PR DESCRIPTION
Foundational primitive for the output-audit remediation. Adds `unraid_mcp/core/pagination.py` with `cap_list(items, limit, default=50)` → `(capped, meta)` where `meta` carries `returned`/`total`/`truncated` (+ a `hint` when truncated). `limit<=0` returns everything.

New module + tests only — no behavior change to existing tools. Domain subactions will adopt it in follow-up PRs to cap unbounded lists (docker/list, disk/shares, key/list, plugin/list, oidc/providers, rclone/list_remotes, array/parity_history, system/timezones).

8 unit tests; ruff/ty/pytest clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared client-side list capping helper to standardize pagination metadata across tools without changing current behavior. Introduces `unraid_mcp/core/pagination.py` with `cap_list(items, limit, default=50)` returning `(capped, meta)` where `meta` includes `returned`, `total`, `truncated`, and a `hint` when truncated; `limit=None` uses `DEFAULT_LIST_LIMIT=50`, `limit<=0` returns all, and 8 unit tests are included.

<sup>Written for commit 147d036b6f1f36bdd4a929eb10520dca9bff2575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

