### PR TITLE
fix: structured, parseable response-size truncation marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Copy `.env.example` to `.env` and configure:
 **Server:**
 - `UNRAID_MCP_LOG_LEVEL`: Log verbosity (default: INFO)
 - `UNRAID_MCP_LOG_FILE`: Log filename in logs/ (default: unraid-mcp.log)
+- `UNRAID_MCP_MAX_RESPONSE_BYTES`: Max serialized tool-response size in bytes (default: 131072 = 128 KB). Responses over the cap are replaced with a structured, parseable JSON truncation marker (`{"error": "response_truncated", "truncated": true, ...}`) rather than hard-cut mid-JSON. See `unraid_mcp/core/response_limit.py`.
 
 **SSL/TLS:**
 - `UNRAID_VERIFY_SSL`: SSL verification (default: true; set `false` for self-signed certs)
@@ -165,7 +166,7 @@ The server loads environment variables from multiple locations in order:
 1. **LoggingMiddleware** — logs every `tools/call` and `resources/read` with duration
 2. **ErrorHandlingMiddleware** — converts unhandled exceptions to proper MCP errors
 3. **SlidingWindowRateLimitingMiddleware** — 540 req/min sliding window
-4. **ResponseLimitingMiddleware** — truncates responses > 512 KB with a clear suffix
+4. **StructuredResponseLimitingMiddleware** (`core/response_limit.py`) — replaces responses over the cap (default 128 KB, override via `UNRAID_MCP_MAX_RESPONSE_BYTES`) with a complete, parseable JSON truncation marker instead of a lossy mid-JSON byte cut
 
 Note: `ResponseCachingMiddleware` was removed — the consolidated `unraid` tool mixes reads and mutations under one name, making per-subaction cache exclusion impossible.
 

--- a/tests/test_response_limit.py
+++ b/tests/test_response_limit.py
@@ -1,0 +1,110 @@
+"""Tests for the structured response-size limiting middleware.
+
+The middleware is unit-tested in isolation by driving ``on_call_tool`` with a stub
+context and a stub ``call_next`` that returns a controlled ``ToolResult``. No
+running server or GraphQL backend is needed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+import pytest
+from fastmcp.tools.base import ToolResult
+from mcp.types import TextContent
+
+from unraid_mcp.core.response_limit import StructuredResponseLimitingMiddleware
+
+
+@dataclass
+class _StubMessage:
+    name: str = "unraid"
+
+
+@dataclass
+class _StubContext:
+    message: _StubMessage
+
+
+def _text_result(text: str) -> ToolResult:
+    return ToolResult(content=[TextContent(type="text", text=text)])
+
+
+def _call_next_returning(result: ToolResult):
+    async def _call_next(_context):
+        return result
+
+    return _call_next
+
+
+def _context(name: str = "unraid") -> _StubContext:
+    return _StubContext(message=_StubMessage(name=name))
+
+
+async def test_small_response_passes_through_unchanged():
+    """A response under the cap is returned untouched."""
+    mw = StructuredResponseLimitingMiddleware(max_size=131072)
+    original = _text_result(json.dumps({"ok": True, "data": [1, 2, 3]}))
+
+    out = await mw.on_call_tool(_context(), _call_next_returning(original))
+
+    assert out is original
+    block = out.content[0]
+    assert isinstance(block, TextContent)
+    assert json.loads(block.text) == {"ok": True, "data": [1, 2, 3]}
+
+
+async def test_oversized_response_replaced_with_structured_marker():
+    """An oversized response becomes a complete, parseable JSON marker."""
+    cap = 2_000
+    mw = StructuredResponseLimitingMiddleware(max_size=cap)
+    # Build a large valid-JSON payload well over the cap.
+    payload = json.dumps({"items": ["x" * 100 for _ in range(200)]})
+    assert len(payload.encode("utf-8")) > cap
+    original = _text_result(payload)
+
+    out = await mw.on_call_tool(_context(), _call_next_returning(original))
+
+    assert out is not original
+    assert len(out.content) == 1
+    block = out.content[0]
+    assert isinstance(block, TextContent)
+
+    # The replacement must be COMPLETE, valid JSON — not a mid-string byte cut.
+    marker = json.loads(block.text)
+    assert marker["error"] == "response_truncated"
+    assert marker["truncated"] is True
+    assert marker["limit_bytes"] == cap
+    assert marker["original_bytes"] > cap
+    assert marker.get("hint")
+    # The marker must NOT contain a salvaged slice of the original payload.
+    assert "xxxxxxxxxx" not in block.text
+
+
+async def test_marker_text_is_smaller_than_limit():
+    """The marker itself stays comfortably under the cap."""
+    cap = 1_000
+    mw = StructuredResponseLimitingMiddleware(max_size=cap)
+    original = _text_result("y" * 5_000)
+
+    out = await mw.on_call_tool(_context(), _call_next_returning(original))
+
+    block = out.content[0]
+    assert isinstance(block, TextContent)
+    assert len(block.text.encode("utf-8")) < cap
+
+
+async def test_other_tools_skipped_when_tools_filter_set():
+    """When a tools allowlist is set, non-listed tools are not limited."""
+    mw = StructuredResponseLimitingMiddleware(max_size=10, tools=["unraid"])
+    original = _text_result("z" * 5_000)
+
+    out = await mw.on_call_tool(_context(name="other_tool"), _call_next_returning(original))
+
+    assert out is original
+
+
+def test_non_positive_max_size_rejected():
+    with pytest.raises(ValueError):
+        StructuredResponseLimitingMiddleware(max_size=0)

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -88,9 +88,37 @@ def _parse_port(env_var: str, default: int) -> int:
     return port
 
 
+def _parse_positive_int(env_var: str, default: int) -> int:
+    """Parse a positive integer from an environment variable, falling back on error."""
+    raw = os.getenv(env_var)
+    if raw is None or raw.strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(
+            f"WARNING: {env_var}={raw!r} is not a valid integer; using default {default}",
+            file=sys.stderr,
+        )
+        return default
+    if value <= 0:
+        print(
+            f"WARNING: {env_var}={value} must be positive; using default {default}",
+            file=sys.stderr,
+        )
+        return default
+    return value
+
+
 UNRAID_MCP_PORT = _parse_port("UNRAID_MCP_PORT", 6970)
 UNRAID_MCP_HOST = os.getenv("UNRAID_MCP_HOST", "0.0.0.0")  # noqa: S104 — intentional for Docker
 UNRAID_MCP_TRANSPORT = os.getenv("UNRAID_MCP_TRANSPORT", "streamable-http").lower()
+
+# Maximum serialized tool-response size in bytes. Responses larger than this are
+# replaced with a structured, still-parseable truncation marker (see
+# core/response_limit.py) rather than hard-cut mid-JSON. Default 128 KB keeps a
+# single response well under the client context window.
+UNRAID_MCP_MAX_RESPONSE_BYTES = _parse_positive_int("UNRAID_MCP_MAX_RESPONSE_BYTES", 131072)
 
 # HTTP Authentication
 # Bearer token for HTTP transport (streamable-http / sse).

--- a/unraid_mcp/core/response_limit.py
+++ b/unraid_mcp/core/response_limit.py
@@ -1,0 +1,114 @@
+"""Structured response-size limiting middleware.
+
+fastmcp's stock ``ResponseLimitingMiddleware`` joins all text blocks and hard-cuts
+the UTF-8 byte string mid-content, then appends a plain-text suffix. The ``unraid``
+tool returns its payload as a JSON string in a single text block, so a mid-string
+cut yields **invalid JSON** with no structured signal telling the agent to narrow
+its query.
+
+This middleware keeps the same trigger semantics (replace the result when its
+serialized size exceeds ``max_size``) but, instead of salvaging a partial JSON
+slice, returns a clean, complete, valid JSON marker the agent can parse:
+
+    {
+        "error": "response_truncated",
+        "truncated": true,
+        "original_bytes": <n>,
+        "limit_bytes": <cap>,
+        "hint": "Response exceeded the size limit. Narrow the query: ..."
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pydantic_core
+from fastmcp.server.middleware.middleware import Middleware
+from fastmcp.tools.base import ToolResult
+from mcp.types import TextContent
+
+
+if TYPE_CHECKING:
+    import mcp.types as mt
+    from fastmcp.server.middleware.middleware import CallNext, MiddlewareContext
+
+__all__ = ["StructuredResponseLimitingMiddleware"]
+
+logger = logging.getLogger(__name__)
+
+_TRUNCATION_HINT = (
+    "Response exceeded the size limit. Narrow the query: pass limit=, "
+    "level=/context= for logs, or a more specific subaction/id."
+)
+
+
+class StructuredResponseLimitingMiddleware(Middleware):
+    """Cap tool responses, replacing oversized ones with a parseable JSON marker.
+
+    Unlike fastmcp's ``ResponseLimitingMiddleware``, this does not attempt to
+    salvage a partial slice of the original payload (which produces invalid JSON).
+    When a response exceeds ``max_size`` it is replaced wholesale with a small,
+    complete JSON object carrying ``truncated: true`` and a remediation hint, so
+    the agent gets a structured signal to narrow its query.
+
+    Args:
+        max_size: Maximum serialized response size in bytes.
+        tools: Optional set of tool names to apply limiting to. If ``None``,
+            applies to all tools.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_size: int = 131072,
+        tools: list[str] | None = None,
+    ) -> None:
+        if max_size <= 0:
+            raise ValueError(f"max_size must be positive, got {max_size}")
+        self.max_size = max_size
+        self.tools = set(tools) if tools is not None else None
+
+    def _marker_result(self, original_bytes: int) -> ToolResult:
+        """Build a ToolResult wrapping the structured truncation marker."""
+        marker = {
+            "error": "response_truncated",
+            "truncated": True,
+            "original_bytes": original_bytes,
+            "limit_bytes": self.max_size,
+            "hint": _TRUNCATION_HINT,
+        }
+        # meta={} ensures to_mcp_result() returns a CallToolResult, bypassing MCP
+        # SDK outputSchema validation — a truncation marker is not the tool's
+        # declared structured output shape.
+        return ToolResult(
+            content=[TextContent(type="text", text=json.dumps(marker))],
+            meta={},
+        )
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        """Intercept tool calls and replace oversized responses with a marker."""
+        result = await call_next(context)
+
+        if self.tools is not None and context.message.name not in self.tools:
+            return result
+
+        serialized = pydantic_core.to_json(result, fallback=str)
+        size = len(serialized)
+        if size <= self.max_size:
+            return result
+
+        logger.warning(
+            "Tool %r response exceeds size limit: %d bytes > %d bytes, "
+            "replacing with structured truncation marker",
+            context.message.name,
+            size,
+            self.max_size,
+        )
+        return self._marker_result(size)

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -14,7 +14,6 @@ from fastmcp import FastMCP
 from fastmcp.server.middleware.error_handling import ErrorHandlingMiddleware
 from fastmcp.server.middleware.logging import LoggingMiddleware
 from fastmcp.server.middleware.rate_limiting import SlidingWindowRateLimitingMiddleware
-from fastmcp.server.middleware.response_limiting import ResponseLimitingMiddleware
 from starlette.middleware import Middleware as ASGIMiddleware
 
 from .config import settings as _settings
@@ -24,6 +23,7 @@ from .config.settings import (
     CREDENTIALS_ENV_PATH,
     LOG_LEVEL_STR,
     UNRAID_MCP_HOST,
+    UNRAID_MCP_MAX_RESPONSE_BYTES,
     UNRAID_MCP_PORT,
     UNRAID_VERIFY_SSL,
     VERSION,
@@ -32,6 +32,7 @@ from .config.settings import (
 )
 from .core import middleware_refs as _middleware_refs
 from .core.auth import BearerAuthMiddleware, HealthMiddleware, WellKnownMiddleware
+from .core.response_limit import StructuredResponseLimitingMiddleware
 from .subscriptions.diagnostics import register_diagnostic_tools
 from .subscriptions.resources import register_subscription_resources
 from .tools.unraid import register_unraid_tool
@@ -78,9 +79,13 @@ _middleware_refs.error_middleware = _error_middleware
 #    in front of this server (e.g. nginx limit_req) if tighter burst control is needed.
 _rate_limiter = SlidingWindowRateLimitingMiddleware(max_requests=540, window_minutes=1)
 
-# 4. Cap tool responses at 512 KB to protect the client context window.
-#    Oversized responses are truncated with a clear suffix rather than erroring.
-_response_limiter = ResponseLimitingMiddleware(max_size=512_000)
+# 4. Cap tool responses (default 128 KB, override via UNRAID_MCP_MAX_RESPONSE_BYTES)
+#    to protect the client context window. Unlike fastmcp's stock limiter — which
+#    hard-cuts the UTF-8 byte string mid-JSON and appends a plain-text suffix,
+#    yielding invalid JSON — oversized responses are replaced wholesale with a
+#    complete, parseable JSON marker ({"error": "response_truncated", ...}) that
+#    signals the agent to narrow its query. See core/response_limit.py.
+_response_limiter = StructuredResponseLimitingMiddleware(max_size=UNRAID_MCP_MAX_RESPONSE_BYTES)
 
 # Note: ResponseCachingMiddleware was removed because all caching was disabled for
 # the `unraid` tool. The consolidated tool mixes reads and mutations under one name,


### PR DESCRIPTION
## Problem (from an output audit)

`unraid_mcp/server.py` configured `ResponseLimitingMiddleware(max_size=512_000)` from fastmcp. An output audit flagged two issues:

1. **512 KB is too large** — roughly an entire agent context window. A ~400 KB valid response sails under the cap and floods context.
2. **Truncation was lossy + silent.** The stock fastmcp middleware joins text blocks and hard-cuts the serialized UTF-8 byte string mid-JSON, then appends the plain-text suffix `\n\n[Response truncated due to size limit]`. The `unraid` tool returns its data as a JSON string in a single text block, so a mid-string cut yields **invalid JSON** with no structured signal telling the agent to narrow its query.

## Change

- **Lower the cap to 128 KB** (`131072`), context-safe by default, overridable via the new `UNRAID_MCP_MAX_RESPONSE_BYTES` env var (parsed in `config/settings.py`, matching the existing port-parsing style).
- **Replace the lossy hard-cut** with a new `StructuredResponseLimitingMiddleware` in `unraid_mcp/core/response_limit.py`. When a response exceeds the cap, it is replaced **wholesale** with a complete, valid JSON marker — no partial-slice salvage (that's what was broken):
  ```json
  {"error": "response_truncated", "truncated": true, "original_bytes": <n>, "limit_bytes": <cap>, "hint": "Response exceeded the size limit. Narrow the query: pass limit=, level=/context= for logs, or a more specific subaction/id."}
  ```
- **Middleware order preserved** — still the innermost response-shaping layer in the 4-layer stack (logging → error_handling → rate_limiter → response_limiter → tool). Same `on_call_tool` trigger semantics and `meta={}` outputSchema-bypass behavior as the stock middleware.

## Tests

New `tests/test_response_limit.py` (unit-tests the middleware in isolation via a stub context + `call_next`):
- small response passes through unchanged
- oversized response → complete, parseable JSON marker carrying `truncated: true` + hint, asserting it is **not** a mid-JSON byte cut and contains no salvaged slice of the original payload
- marker stays under the cap; tools-allowlist filter skips non-listed tools; non-positive `max_size` rejected

## Gates

- `uv run ruff check unraid_mcp/` + `ruff format` — clean
- `uv run ty check unraid_mcp/` — clean
- `uv run pytest -m "not slow and not integration"` — **1012 passed**

No version strings touched (release-please handles versioning). `CLAUDE.md` env-var + middleware-stack sections updated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces response truncation with a structured, parseable JSON marker and lowers the default cap to 128 KB. This prevents invalid JSON and reduces context bloat for large `unraid` tool outputs.

- **Bug Fixes**
  - Added `StructuredResponseLimitingMiddleware` to replace oversized results with a valid JSON marker (`{"error":"response_truncated","truncated":true,...}`) instead of `fastmcp`’s lossy mid-JSON cut.
  - Preserves middleware order and `on_call_tool` semantics; uses `meta={}` to bypass output schema validation.

- **New Features**
  - Cap is now configurable via `UNRAID_MCP_MAX_RESPONSE_BYTES` (default `131072` = 128 KB).
  - Added unit tests for pass-through, truncation marker behavior, tool filtering, and input validation.

<sup>Written for commit 6c40bf615df38dacfd65cfc40dfa14f4cea2679a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

