### PR TITLE
perf(system): trim system handler output to reduce context bloat

### DIFF
--- a/tests/contract/test_response_contracts.py
+++ b/tests/contract/test_response_contracts.py
@@ -102,8 +102,9 @@ class InfoOverviewSummary(BaseModel):
 class InfoOverviewResult(BaseModel):
     """Top-level shape of info/overview."""
 
+    model_config = {"extra": "forbid"}
+
     summary: dict[str, Any]
-    details: dict[str, Any]
 
 
 class ArraySummary(BaseModel):
@@ -119,8 +120,9 @@ class ArraySummary(BaseModel):
 class InfoArrayResult(BaseModel):
     """Top-level shape of info/array."""
 
+    model_config = {"extra": "forbid"}
+
     summary: dict[str, Any]
-    details: dict[str, Any]
 
 
 class CpuMetrics(BaseModel):
@@ -473,7 +475,7 @@ class TestDockerMutationContract:
 
 
 class TestInfoOverviewContract:
-    """info/overview returns {"summary": {...}, "details": {...}}."""
+    """info/overview returns {"summary": {...}} with no raw details echo."""
 
     async def test_overview_has_summary_and_details(self, _info_mock: AsyncMock) -> None:
         _info_mock.return_value = {
@@ -498,7 +500,7 @@ class TestInfoOverviewContract:
         result = await _info_tool()(action="system", subaction="overview")
         validated = InfoOverviewResult(**result)
         assert isinstance(validated.summary, dict)
-        assert isinstance(validated.details, dict)
+        assert "details" not in result
 
     async def test_overview_summary_contains_hostname(self, _info_mock: AsyncMock) -> None:
         _info_mock.return_value = {
@@ -519,7 +521,8 @@ class TestInfoOverviewContract:
         InfoOverviewSummary(**result["summary"])
         assert result["summary"]["hostname"] == "myserver"
 
-    async def test_overview_details_mirrors_raw_info(self, _info_mock: AsyncMock) -> None:
+    async def test_overview_omits_raw_details_echo(self, _info_mock: AsyncMock) -> None:
+        """The full raw info object must not be echoed back as `details`."""
         raw_info = {
             "os": {
                 "hostname": "srv",
@@ -530,14 +533,20 @@ class TestInfoOverviewContract:
             },
             "cpu": {"manufacturer": "Intel", "brand": "Xeon", "cores": 16, "threads": 32},
             "memory": {"layout": []},
+            "versions": {"core": {"unraid": "6.12.0", "api": "4.0", "kernel": "6.1"}},
+            "machineId": "mid-123",
+            "time": "2026-01-01T00:00:00Z",
         }
         _info_mock.return_value = {"info": raw_info}
         result = await _info_tool()(action="system", subaction="overview")
-        assert result["details"] == raw_info
+        assert "details" not in result
+        # Genuinely-useful scalar fields are folded into the curated summary.
+        assert result["summary"]["machine_id"] == "mid-123"
+        assert result["summary"]["versions"] == raw_info["versions"]["core"]
 
 
 class TestInfoArrayContract:
-    """info/array returns {"summary": {...}, "details": {...}} with health analysis."""
+    """info/array returns {"summary": {...}} with health analysis, no raw echo."""
 
     async def test_array_result_shape(self, _info_mock: AsyncMock) -> None:
         _info_mock.return_value = {
@@ -554,7 +563,7 @@ class TestInfoArrayContract:
         result = await _info_tool()(action="system", subaction="array")
         validated = InfoArrayResult(**result)
         assert isinstance(validated.summary, dict)
-        assert isinstance(validated.details, dict)
+        assert "details" not in result
 
     async def test_array_summary_contains_required_fields(self, _info_mock: AsyncMock) -> None:
         _info_mock.return_value = {

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -85,6 +85,61 @@ class TestUnraidInfoTool:
         assert "summary" in result
         _mock_graphql.assert_called_once()
 
+    async def test_overview_omits_raw_details(self, _mock_graphql: AsyncMock) -> None:
+        """overview no longer echoes the full raw info object as `details`."""
+        _mock_graphql.return_value = {
+            "info": {
+                "os": {"distro": "Unraid", "release": "7.2", "hostname": "t"},
+                "cpu": {"manufacturer": "Intel", "brand": "i7", "cores": 4, "threads": 8},
+                "baseboard": {"manufacturer": "ASUS", "model": "X", "version": "1"},
+                "versions": {"core": {"unraid": "7.2.0"}},
+                "machineId": "mid-1",
+                "time": "2026-01-01T00:00:00Z",
+            }
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="system", subaction="overview")
+        assert "details" not in result
+        assert result["summary"]["machine_id"] == "mid-1"
+        assert result["summary"]["versions"] == {"unraid": "7.2.0"}
+
+    async def test_array_omits_raw_details(self, _mock_graphql: AsyncMock) -> None:
+        """array returns the computed summary without the raw disk object echo."""
+        _mock_graphql.return_value = {
+            "array": {
+                "state": "STARTED",
+                "capacity": {"kilobytes": {"free": 1000, "used": 500, "total": 1500}},
+                "parities": [{"id": "p1", "status": "DISK_OK"}],
+                "disks": [{"id": "d1", "status": "DISK_OK"}],
+                "caches": [],
+            }
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="system", subaction="array")
+        assert "details" not in result
+        assert result["summary"]["state"] == "STARTED"
+        assert result["summary"]["overall_health"] == "HEALTHY"
+
+    async def test_timezones_capped_with_meta(self, _mock_graphql: AsyncMock) -> None:
+        """timezones is capped to the limit and surfaces truncation meta."""
+        opts = [{"value": f"Zone/{i}", "label": f"Zone {i}"} for i in range(100)]
+        _mock_graphql.return_value = {"timeZoneOptions": opts}
+        tool_fn = _make_tool()
+        result = await tool_fn(action="system", subaction="timezones", limit=5)
+        assert len(result["timezones"]) == 5
+        assert result["page"]["returned"] == 5
+        assert result["page"]["total"] == 100
+        assert result["page"]["truncated"] is True
+
+    async def test_timezones_limit_zero_returns_all(self, _mock_graphql: AsyncMock) -> None:
+        """limit=0 disables capping (give-me-all escape hatch)."""
+        opts = [{"value": f"Zone/{i}", "label": f"Zone {i}"} for i in range(30)]
+        _mock_graphql.return_value = {"timeZoneOptions": opts}
+        tool_fn = _make_tool()
+        result = await tool_fn(action="system", subaction="timezones", limit=0)
+        assert len(result["timezones"]) == 30
+        assert result["page"]["truncated"] is False
+
     async def test_ups_device_requires_device_id(self, _mock_graphql: AsyncMock) -> None:
         tool_fn = _make_tool()
         with pytest.raises(ToolError, match="device_id is required"):

--- a/unraid_mcp/tools/_system.py
+++ b/unraid_mcp/tools/_system.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.pagination import cap_list
 from ..core.utils import format_kb, safe_get, validate_subaction
 
 
@@ -79,6 +80,8 @@ _SYSTEM_QUERIES: dict[str, str] = {
     "config": "query GetConfig { config { valid error } }",
     "online": "query GetOnline { online }",
     "owner": "query GetOwner { owner { username avatar url } }",
+    # settings.unified.values is an opaque JSON! scalar in the GraphQL schema
+    # (no selectable subfields), so field-level narrowing is not possible here.
     "settings": "query GetSettings { settings { unified { values } } }",
     "server": """
         query GetServer {
@@ -126,7 +129,7 @@ def _analyze_disk_health(disks: list[dict[str, Any]]) -> dict[str, int]:
     return counts
 
 
-async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any]:
+async def _handle_system(subaction: str, device_id: str | None, limit: int = 20) -> dict[str, Any]:
     validate_subaction(subaction, _SYSTEM_SUBACTIONS, "system")
 
     if subaction == "ups_device" and not device_id:
@@ -161,7 +164,25 @@ async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any
                     f"Bank {s.get('bank')}: {s.get('type')}, {s.get('clockSpeed')}MHz, {s.get('manufacturer')}, {s.get('partNum')}"
                     for s in raw["memory"]["layout"]
                 ]
-            return {"summary": summary, "details": raw}
+            # Fold the genuinely-useful scalar fields that only appear in the raw
+            # object into the summary rather than echoing the entire raw payload.
+            if raw.get("baseboard"):
+                bb = raw["baseboard"]
+                summary["baseboard"] = (
+                    f"{bb.get('manufacturer')} {bb.get('model')} ({bb.get('version')})"
+                )
+            if raw.get("system"):
+                sysinfo = raw["system"]
+                summary["system"] = (
+                    f"{sysinfo.get('manufacturer')} {sysinfo.get('model')} ({sysinfo.get('version')})"
+                )
+            if raw.get("versions") and raw["versions"].get("core"):
+                summary["versions"] = raw["versions"]["core"]
+            if raw.get("machineId"):
+                summary["machine_id"] = raw["machineId"]
+            if raw.get("time"):
+                summary["time"] = raw["time"]
+            return {"summary": summary}
 
         if subaction == "array":
             raw = data.get("array") or {}
@@ -198,7 +219,7 @@ async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any
                 else "HEALTHY"
             )
             summary["health_summary"] = health
-            return {"summary": summary, "details": raw}
+            return {"summary": summary}
 
         if subaction == "display":
             return dict(safe_get(data, "info", "display", default={}))
@@ -280,7 +301,13 @@ async def _handle_system(subaction: str, device_id: str | None) -> dict[str, Any
         }
         if subaction in list_actions:
             response_key, output_key = list_actions[subaction]
-            items = data.get(response_key) or []
-            return {output_key: list(items) if isinstance(items, list) else []}
+            raw_items = data.get(response_key) or []
+            items = list(raw_items) if isinstance(raw_items, list) else []
+            # timezones returns 400+ unbounded IANA entries — cap it and surface
+            # truncation meta so the agent can widen the window when needed.
+            if subaction == "timezones":
+                capped, meta = cap_list(items, limit)
+                return {output_key: capped, "page": meta}
+            return {output_key: items}
 
         raise ToolError(f"Unhandled system subaction '{subaction}' — this is a bug")

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -412,7 +412,7 @@ def register_unraid_tool(mcp: FastMCP) -> None:
         unchanged output.
         """
         if action == "system":
-            return await _handle_system(subaction, device_id)
+            return await _handle_system(subaction, device_id, limit)
 
         if action == "health":
             return await _handle_health(subaction, ctx)


### PR DESCRIPTION
## Summary

Output-audit follow-up on the `unraid` tool's `system` domain (`unraid_mcp/tools/_system.py`). Reduces context-window bloat for four subactions:

1. **`system/overview`** — dropped the wholesale raw `details` echo. The genuinely-useful scalar fields that previously only appeared in the raw blob (`baseboard`, `system`, `versions`, `machine_id`, `time`) are now folded into the curated `summary`. Net: roughly halves the payload, keeps the useful data.
2. **`system/array`** — dropped the raw `details` echo (the full disk objects). The handler already computes a complete `summary` (capacity, disk counts, per-pool health, overall health). Per-disk detail remains available via the `disk` domain.
3. **`system/timezones`** — was returning 400+ unbounded IANA entries. Now capped with the shared `cap_list` helper (`core/pagination.py`), surfacing `returned`/`total`/`truncated` meta under a `page` key. The tool's existing `limit` param (default 20) is threaded through `_handle_system`; `limit=0` returns all.
4. **`system/settings`** — investigated: `settings.unified.values` is an opaque `JSON!` scalar in the GraphQL schema with no selectable subfields, so field-level narrowing isn't possible. Documented in a code comment; left functionally untouched.

## Changes
- `unraid_mcp/tools/_system.py` — handler changes above + `limit` param + `cap_list` import.
- `unraid_mcp/tools/unraid.py` — single dispatch line now passes `limit` to `_handle_system`.
- `tests/test_info.py` — new unit tests: overview/array omit raw `details`, timezones capped + meta, `limit=0` escape hatch.
- `tests/contract/test_response_contracts.py` — overview/array contract models drop `details` (now `extra=forbid`); raw-echo test replaced with no-echo + folded-field assertions.

## Verification
- `uv run ruff check` / `ruff format` — clean
- `uv run ty check unraid_mcp/` — clean
- `uv run pytest -m "not slow and not integration"` — 1011 passed

No version bump (handled by release-please via the `perf:` commit).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed `system` handler output in `unraid` to reduce response size and context bloat. Drops raw details for overview/array, folds key fields into summary, and caps timezones with paging meta.

- **Migration**
  - `system/overview` and `system/array`: removed `details`. Use `summary`. For per-disk data, use the `disk` domain.
  - `system/timezones`: respects `limit` (default 20), returns `page` meta (`returned`, `total`, `truncated`). Set `limit=0` to return all.
  - `system/settings`: unchanged (schema exposes an opaque `JSON!` value).

<sup>Written for commit 9e1c5f261f6c5f9a24f1901172bccacf391ed7ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

