### PR TITLE
perf: bound large list/blob outputs in docker/disk/array/live

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,13 @@ Copy `.env.example` to `.env` and configure:
 ### Key Design Patterns
 - **Consolidated Action Pattern**: Each tool uses `action: Literal[...]` parameter to expose multiple operations via a single MCP tool, reducing context window usage
 - **Pre-built Query Dicts**: `QUERIES` and `MUTATIONS` dicts prevent GraphQL injection and organize operations
+- **List Capping**: List subactions bound output via `cap_list` (`core/pagination.py`) threaded
+  from the `limit` tool param. Capped responses carry a `page` meta dict
+  (`returned`/`total`/`truncated`, plus a `hint` when truncated). `limit<=0` returns everything;
+  omitting `limit` uses the tool default (20). Applies to `docker/list`, `disk/shares`,
+  `disk/disks`, `array/parity_history`, and the `live/log_tail` + `live/notification_feed`
+  event lists. `docker/details` fetches a single container via `docker.container(id:)` rather
+  than over-fetching the full container list.
 - **Destructive Action Safety**: `DESTRUCTIVE_ACTIONS` sets require `confirm=True` for dangerous operations
 - **Modular Architecture**: Clean separation of concerns across focused modules
 - **Error Handling**: Uses ToolError for user-facing errors, detailed logging for debugging

--- a/tests/contract/test_response_contracts.py
+++ b/tests/contract/test_response_contracts.py
@@ -384,17 +384,15 @@ class TestDockerDetailsContract:
         cid = "a" * 64 + ":local"
         _docker_mock.return_value = {
             "docker": {
-                "containers": [
-                    {
-                        "id": cid,
-                        "names": ["plex"],
-                        "state": "running",
-                        "image": "plexinc/pms:latest",
-                        "status": "Up 3 hours",
-                        "ports": [],
-                        "autoStart": True,
-                    }
-                ]
+                "container": {
+                    "id": cid,
+                    "names": ["plex"],
+                    "state": "running",
+                    "image": "plexinc/pms:latest",
+                    "status": "Up 3 hours",
+                    "ports": [],
+                    "autoStart": True,
+                }
             }
         }
         result = await _docker_tool()(action="docker", subaction="details", container_id=cid)
@@ -403,7 +401,7 @@ class TestDockerDetailsContract:
     async def test_details_has_required_fields(self, _docker_mock: AsyncMock) -> None:
         cid = "b" * 64 + ":local"
         _docker_mock.return_value = {
-            "docker": {"containers": [{"id": cid, "names": ["sonarr"], "state": "exited"}]}
+            "docker": {"container": {"id": cid, "names": ["sonarr"], "state": "exited"}}
         }
         result = await _docker_tool()(action="docker", subaction="details", container_id=cid)
         assert "id" in result

--- a/tests/schema/test_query_validation.py
+++ b/tests/schema/test_query_validation.py
@@ -436,12 +436,19 @@ class TestDockerQueries:
         errors = _validate_operation(schema, QUERIES["network_details"])
         assert not errors, f"network_details query validation failed: {errors}"
 
+    def test_ports_query(self, schema: GraphQLSchema) -> None:
+        from unraid_mcp.tools._docker import _DOCKER_QUERIES as QUERIES
+
+        errors = _validate_operation(schema, QUERIES["ports"])
+        assert not errors, f"ports query validation failed: {errors}"
+
     def test_all_docker_queries_covered(self, schema: GraphQLSchema) -> None:
         from unraid_mcp.tools._docker import _DOCKER_QUERIES as QUERIES
 
         expected = {
             "list",
             "details",
+            "ports",
             "networks",
             "network_details",
         }

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -161,6 +161,44 @@ async def test_parity_history_returns_history(_mock_graphql):
     assert len(result["data"]["parityHistory"]) == 1
 
 
+def _parity_history(n: int) -> dict:
+    return {"parityHistory": [{"date": f"2026-03-{i:02d}T00:00:00Z"} for i in range(n)]}
+
+
+@pytest.mark.asyncio
+async def test_parity_history_caps_default(_mock_graphql):
+    # Tool param default is 20.
+    _mock_graphql.return_value = _parity_history(40)
+    result = await _make_tool()(action="array", subaction="parity_history")
+    assert len(result["data"]["parityHistory"]) == 20
+    assert result["page"]["truncated"] is True
+    assert result["page"]["total"] == 40
+
+
+@pytest.mark.asyncio
+async def test_parity_history_limit_narrows(_mock_graphql):
+    _mock_graphql.return_value = _parity_history(40)
+    result = await _make_tool()(action="array", subaction="parity_history", limit=5)
+    assert len(result["data"]["parityHistory"]) == 5
+    assert result["page"]["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_parity_history_limit_zero_returns_all(_mock_graphql):
+    _mock_graphql.return_value = _parity_history(40)
+    result = await _make_tool()(action="array", subaction="parity_history", limit=0)
+    assert len(result["data"]["parityHistory"]) == 40
+    assert result["page"]["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_parity_history_small_not_truncated(_mock_graphql):
+    _mock_graphql.return_value = _parity_history(3)
+    result = await _make_tool()(action="array", subaction="parity_history")
+    assert len(result["data"]["parityHistory"]) == 3
+    assert result["page"]["truncated"] is False
+
+
 # Array state mutations
 
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -54,6 +54,35 @@ class TestDockerActions:
         result = await tool_fn(action="docker", subaction="list")
         assert len(result["containers"]) == 1
 
+    async def test_list_caps_default(self, _mock_graphql: AsyncMock) -> None:
+        # Tool param default is 20.
+        _mock_graphql.return_value = {
+            "docker": {"containers": [{"id": f"c{i}", "names": [f"ct{i}"]} for i in range(80)]}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="docker", subaction="list")
+        assert len(result["containers"]) == 20
+        assert result["page"]["truncated"] is True
+        assert result["page"]["total"] == 80
+        assert "hint" in result["page"]
+
+    async def test_list_limit_widens(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "docker": {"containers": [{"id": f"c{i}", "names": [f"ct{i}"]} for i in range(80)]}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="docker", subaction="list", limit=50)
+        assert len(result["containers"]) == 50
+
+    async def test_list_limit_zero_returns_all(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "docker": {"containers": [{"id": f"c{i}", "names": [f"ct{i}"]} for i in range(80)]}
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="docker", subaction="list", limit=0)
+        assert len(result["containers"]) == 80
+        assert result["page"]["truncated"] is False
+
     async def test_start_container(self, _mock_graphql: AsyncMock) -> None:
         # First call resolves ID, second performs start
         cid = "a" * 64 + ":local"

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -113,16 +113,28 @@ class TestDockerActions:
         assert "note" in result
 
     async def test_details_found(self, _mock_graphql: AsyncMock) -> None:
-        _mock_graphql.return_value = {
-            "docker": {
-                "containers": [
-                    {"id": "c1", "names": ["plex"], "state": "running", "image": "plexinc/pms"}
-                ]
-            }
-        }
+        # details now fetches a single container by id: the first call resolves
+        # the name → id, the second returns docker.container for that id.
+        _mock_graphql.side_effect = [
+            {"docker": {"containers": [{"id": "c1", "names": ["plex"]}]}},
+            {
+                "docker": {
+                    "container": {
+                        "id": "c1",
+                        "names": ["plex"],
+                        "state": "running",
+                        "image": "plexinc/pms",
+                    }
+                }
+            },
+        ]
         tool_fn = _make_tool()
         result = await tool_fn(action="docker", subaction="details", container_id="plex")
         assert result["names"] == ["plex"]
+        # The details query must request a single container by id, not the full list.
+        details_call = _mock_graphql.call_args_list[1]
+        assert "container(id:" in details_call.args[0]
+        assert details_call.args[1] == {"id": "c1"}
 
     async def test_generic_exception_wraps_in_tool_error(self, _mock_graphql: AsyncMock) -> None:
         _mock_graphql.side_effect = RuntimeError("unexpected failure")

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -74,6 +74,67 @@ async def test_notification_feed_collects_events(_mock_subscribe_collect):
 
 
 @pytest.mark.asyncio
+async def test_log_tail_caps_events_default(_mock_subscribe_collect):
+    # Tool param default is 20 — a noisy log window must not flood context.
+    _mock_subscribe_collect.return_value = [
+        {"logFile": {"path": "/var/log/syslog", "content": f"line{i}"}} for i in range(60)
+    ]
+    result = await _make_tool()(
+        action="live", subaction="log_tail", path="/var/log/syslog", collect_for=1.0
+    )
+    assert result["event_count"] == 20
+    assert len(result["events"]) == 20
+    assert result["page"]["truncated"] is True
+    assert result["page"]["total"] == 60
+
+
+@pytest.mark.asyncio
+async def test_log_tail_limit_zero_returns_all(_mock_subscribe_collect):
+    _mock_subscribe_collect.return_value = [
+        {"logFile": {"path": "/var/log/syslog", "content": f"line{i}"}} for i in range(60)
+    ]
+    result = await _make_tool()(
+        action="live", subaction="log_tail", path="/var/log/syslog", collect_for=1.0, limit=0
+    )
+    assert result["event_count"] == 60
+    assert result["page"]["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_notification_feed_caps_events_default(_mock_subscribe_collect):
+    _mock_subscribe_collect.return_value = [
+        {"notificationAdded": {"id": str(i)}} for i in range(60)
+    ]
+    result = await _make_tool()(action="live", subaction="notification_feed", collect_for=2.0)
+    assert result["event_count"] == 20
+    assert len(result["events"]) == 20
+    assert result["page"]["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_notification_feed_limit_narrows(_mock_subscribe_collect):
+    _mock_subscribe_collect.return_value = [
+        {"notificationAdded": {"id": str(i)}} for i in range(60)
+    ]
+    result = await _make_tool()(
+        action="live", subaction="notification_feed", collect_for=2.0, limit=5
+    )
+    assert result["event_count"] == 5
+
+
+@pytest.mark.asyncio
+async def test_notification_feed_limit_zero_returns_all(_mock_subscribe_collect):
+    _mock_subscribe_collect.return_value = [
+        {"notificationAdded": {"id": str(i)}} for i in range(60)
+    ]
+    result = await _make_tool()(
+        action="live", subaction="notification_feed", collect_for=2.0, limit=0
+    )
+    assert result["event_count"] == 60
+    assert result["page"]["truncated"] is False
+
+
+@pytest.mark.asyncio
 async def test_invalid_subaction_raises():
     from unraid_mcp.core.exceptions import ToolError
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -183,6 +183,71 @@ class TestStorageActions:
         result = await tool_fn(action="disk", subaction="disks")
         assert len(result["disks"]) == 1
 
+
+class TestStorageListCaps:
+    """disk/shares and disk/disks cap large lists via cap_list and surface page meta."""
+
+    @staticmethod
+    def _shares(n: int) -> dict:
+        return {"shares": [{"name": f"share{i}"} for i in range(n)]}
+
+    @staticmethod
+    def _disks(n: int) -> dict:
+        return {"disks": [{"id": f"d:{i}", "device": f"sd{i}"} for i in range(n)]}
+
+    async def test_shares_default_cap(self, _mock_graphql: AsyncMock) -> None:
+        # Tool param default is 20.
+        _mock_graphql.return_value = self._shares(75)
+        result = await _make_tool()(action="disk", subaction="shares")
+        assert len(result["shares"]) == 20
+        assert result["page"]["truncated"] is True
+        assert result["page"]["total"] == 75
+        assert result["page"]["returned"] == 20
+
+    async def test_shares_caps_after_id_synthesis(self, _mock_graphql: AsyncMock) -> None:
+        # The synthesized id must be present on the returned (capped) rows.
+        _mock_graphql.return_value = self._shares(75)
+        result = await _make_tool()(action="disk", subaction="shares", limit=3)
+        assert len(result["shares"]) == 3
+        assert [s["id"] for s in result["shares"]] == ["share0", "share1", "share2"]
+
+    async def test_shares_limit_widens(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = self._shares(75)
+        result = await _make_tool()(action="disk", subaction="shares", limit=60)
+        assert len(result["shares"]) == 60
+        assert result["page"]["truncated"] is True
+
+    async def test_shares_limit_zero_returns_all(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = self._shares(75)
+        result = await _make_tool()(action="disk", subaction="shares", limit=0)
+        assert len(result["shares"]) == 75
+        assert result["page"]["truncated"] is False
+
+    async def test_disks_default_cap(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = self._disks(40)
+        result = await _make_tool()(action="disk", subaction="disks")
+        assert len(result["disks"]) == 20
+        assert result["page"]["truncated"] is True
+        assert result["page"]["total"] == 40
+
+    async def test_disks_limit_narrows(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = self._disks(40)
+        result = await _make_tool()(action="disk", subaction="disks", limit=5)
+        assert len(result["disks"]) == 5
+
+    async def test_disks_limit_zero_returns_all(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = self._disks(40)
+        result = await _make_tool()(action="disk", subaction="disks", limit=0)
+        assert len(result["disks"]) == 40
+        assert result["page"]["truncated"] is False
+
+    async def test_disks_small_list_not_truncated(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = self._disks(3)
+        result = await _make_tool()(action="disk", subaction="disks")
+        assert len(result["disks"]) == 3
+        assert result["page"]["truncated"] is False
+        assert "hint" not in result["page"]
+
     async def test_disk_details(self, _mock_graphql: AsyncMock) -> None:
         _mock_graphql.return_value = {
             "disk": {

--- a/unraid_mcp/tools/_array.py
+++ b/unraid_mcp/tools/_array.py
@@ -13,6 +13,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.pagination import cap_list
 from ..core.utils import validate_subaction
 
 
@@ -50,6 +51,7 @@ async def _handle_array(
     slot: int | None,
     ctx: Context | None,
     confirm: bool,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _ARRAY_SUBACTIONS, "array")
 
@@ -70,6 +72,17 @@ async def _handle_array(
 
         if subaction in _ARRAY_QUERIES:
             data = await _client.make_graphql_request(_ARRAY_QUERIES[subaction])
+            if subaction == "parity_history" and isinstance(data, dict):
+                history = data.get("parityHistory") or []
+                if isinstance(history, list):
+                    capped, meta = cap_list(history, limit)
+                    data = {**data, "parityHistory": capped}
+                    return {
+                        "success": True,
+                        "subaction": subaction,
+                        "data": data,
+                        "page": meta,
+                    }
             return {"success": True, "subaction": subaction, "data": data}
 
         if subaction == "parity_start":

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -13,6 +13,7 @@ from ..core import client as _client
 from ..core.client import DISK_TIMEOUT
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.pagination import cap_list
 from ..core.utils import (
     count_log_matches,
     filter_log_lines,
@@ -86,6 +87,7 @@ async def _handle_disk(
     confirm: bool,
     level: str | None = None,
     context: int = 2,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _DISK_SUBACTIONS, "disk")
 
@@ -176,9 +178,13 @@ async def _handle_disk(
             for share in shares:
                 if isinstance(share, dict) and not share.get("id"):
                     share["id"] = share.get("name")
-            return {"shares": shares}
+            # Cap AFTER id synthesis so synthesized ids are stable for the
+            # rows that are actually returned.
+            capped, meta = cap_list(shares, limit)
+            return {"shares": capped, "page": meta}
         if subaction == "disks":
-            return {"disks": data.get("disks", [])}
+            capped, meta = cap_list(data.get("disks", []), limit)
+            return {"disks": capped, "page": meta}
         if subaction == "disk_details":
             raw = data.get("disk", {})
             if not raw:

--- a/unraid_mcp/tools/_docker.py
+++ b/unraid_mcp/tools/_docker.py
@@ -10,6 +10,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.pagination import cap_list
 from ..core.utils import safe_get, validate_subaction
 
 
@@ -19,7 +20,13 @@ from ..core.utils import safe_get, validate_subaction
 
 _DOCKER_QUERIES: dict[str, str] = {
     "list": "query ListDockerContainers { docker { containers { id names image state status autoStart } } }",
-    "details": "query GetContainerDetails { docker { containers { id names image imageId command created ports { ip privatePort publicPort type } sizeRootFs labels state status hostConfig { networkMode } networkSettings mounts autoStart } } }",
+    # Fetch a single container by id rather than the full list — avoids
+    # over-fetching heavy fields (networkSettings, mounts, labels, command)
+    # for every container on the host just to return one.
+    "details": "query GetContainerDetails($id: PrefixedID!) { docker { container(id: $id) { id names image imageId command created ports { ip privatePort publicPort type } sizeRootFs labels state status hostConfig { networkMode } networkSettings mounts autoStart } } }",
+    # The "ports" subaction still needs every running container's bindings, so
+    # it keeps a list-based query (trimmed to just ports + state + names).
+    "ports": "query GetContainerPorts { docker { containers { id names state ports { ip privatePort publicPort type } } } }",
     "networks": "query GetDockerNetworks { docker { networks { id name driver scope } } }",
     "network_details": "query GetDockerNetwork { docker { networks { id name driver scope enableIPv6 internal attachable containers options labels } } }",
 }
@@ -35,10 +42,8 @@ _DOCKER_MUTATIONS: dict[str, str] = {
 # "logs" has no GraphQL query (field removed in Unraid 7.2.x) but is still a
 # recognised subaction so validation passes and the informative ToolError below
 # is returned rather than a generic "Invalid action" message.
-# "ports" reuses the "details" query and aggregates host port bindings client-side.
-_DOCKER_SUBACTIONS: set[str] = (
-    set(_DOCKER_QUERIES) | set(_DOCKER_MUTATIONS) | {"restart", "logs", "ports"}
-)
+# "ports" has a dedicated list query and aggregates host port bindings client-side.
+_DOCKER_SUBACTIONS: set[str] = set(_DOCKER_QUERIES) | set(_DOCKER_MUTATIONS) | {"restart", "logs"}
 _DOCKER_NEEDS_CONTAINER_ID = {"start", "stop", "details", "restart"}
 _DOCKER_ID_PATTERN = re.compile(r"^[a-f0-9]{64}(:[a-z0-9]+)?$", re.IGNORECASE)
 _DOCKER_SHORT_ID_PATTERN = re.compile(r"^[a-f0-9]{12,63}$", re.IGNORECASE)
@@ -104,7 +109,10 @@ async def _resolve_container_id(container_id: str, *, strict: bool = False) -> s
 
 
 async def _handle_docker(
-    subaction: str, container_id: str | None, network_id: str | None
+    subaction: str,
+    container_id: str | None,
+    network_id: str | None,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _DOCKER_SUBACTIONS, "docker")
     if subaction in _DOCKER_NEEDS_CONTAINER_ID and not container_id:
@@ -117,18 +125,20 @@ async def _handle_docker(
 
         if subaction == "list":
             data = await _client.make_graphql_request(_DOCKER_QUERIES["list"])
-            return {"containers": safe_get(data, "docker", "containers", default=[])}
+            containers = safe_get(data, "docker", "containers", default=[])
+            capped, meta = cap_list(containers, limit)
+            return {"containers": capped, "page": meta}
 
         if subaction == "details":
             actual_id = await _resolve_container_id(container_id or "")
-            data = await _client.make_graphql_request(_DOCKER_QUERIES["details"])
-            for c in safe_get(data, "docker", "containers", default=[]):
-                if c.get("id") == actual_id:
-                    return c
+            data = await _client.make_graphql_request(_DOCKER_QUERIES["details"], {"id": actual_id})
+            container = safe_get(data, "docker", "container", default=None)
+            if container:
+                return container
             raise ToolError(f"Container '{container_id}' not found in details response.")
 
         if subaction == "ports":
-            data = await _client.make_graphql_request(_DOCKER_QUERIES["details"])
+            data = await _client.make_graphql_request(_DOCKER_QUERIES["ports"])
             containers = safe_get(data, "docker", "containers", default=[])
             bindings: list[dict[str, Any]] = []
             for container in containers:

--- a/unraid_mcp/tools/_live.py
+++ b/unraid_mcp/tools/_live.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from ..config.logging import logger
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.pagination import cap_list
 from ._disk import _ALLOWED_LOG_PREFIXES, _validate_path
 
 
@@ -54,6 +55,7 @@ async def _handle_live(
     timeout: float,  # noqa: ASYNC109
     level: str | None = None,
     context: int = 2,
+    limit: int | None = None,
 ) -> dict[str, Any]:
     # IMPORTANT: Every key in COLLECT_ACTIONS must have an explicit handler in _handle_live below.
     # Adding to COLLECT_ACTIONS without updating this function causes a ToolError at runtime.
@@ -98,26 +100,33 @@ async def _handle_live(
             )
             if level is not None:
                 events = [_filter_log_event(e, level, context) for e in events]
+            # Hard-cap the number of collected events so a noisy log over the
+            # window can't flood the agent's context.
+            capped, meta = cap_list(events, limit)
             return {
                 "success": True,
                 "subaction": subaction,
                 "path": path,
                 "collect_for": collect_for,
                 "filter": {"level": level, "context": context} if level is not None else None,
-                "event_count": len(events),
-                "events": events,
+                "event_count": len(capped),
+                "events": capped,
+                "page": meta,
             }
 
         if subaction == "notification_feed":
             events = await subscribe_collect(
                 COLLECT_ACTIONS["notification_feed"], collect_for=collect_for, timeout=timeout
             )
+            # Hard-cap the number of collected events (see log_tail above).
+            capped, meta = cap_list(events, limit)
             return {
                 "success": True,
                 "subaction": subaction,
                 "collect_for": collect_for,
-                "event_count": len(events),
-                "events": events,
+                "event_count": len(capped),
+                "events": capped,
+                "page": meta,
             }
 
         raise ToolError(f"Unhandled live subaction '{subaction}' — this is a bug")

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -418,7 +418,7 @@ def register_unraid_tool(mcp: FastMCP) -> None:
             return await _handle_health(subaction, ctx)
 
         if action == "array":
-            return await _handle_array(subaction, disk_id, correct, slot, ctx, confirm)
+            return await _handle_array(subaction, disk_id, correct, slot, ctx, confirm, limit)
 
         if action == "disk":
             return await _handle_disk(
@@ -434,10 +434,11 @@ def register_unraid_tool(mcp: FastMCP) -> None:
                 confirm,
                 level,
                 context,
+                limit,
             )
 
         if action == "docker":
-            return await _handle_docker(subaction, container_id, network_id)
+            return await _handle_docker(subaction, container_id, network_id, limit)
 
         if action == "vm":
             return await _handle_vm(subaction, vm_id, ctx, confirm)
@@ -481,7 +482,7 @@ def register_unraid_tool(mcp: FastMCP) -> None:
             return await _handle_user(subaction)
 
         if action == "live":
-            return await _handle_live(subaction, path, collect_for, timeout, level, context)
+            return await _handle_live(subaction, path, collect_for, timeout, level, context, limit)
 
         raise ToolError(
             f"Invalid action '{action}'. Must be one of: {sorted(get_args(UNRAID_ACTIONS))}"


### PR DESCRIPTION
## Summary

Bounds large list and blob outputs in the docker, disk, array, and live domains so they no longer flood an agent's context window. Threads the existing `limit` tool param through each handler (`limit<=0` returns everything; omitting applies the shared `cap_list` default of 50).

## Findings addressed

1. **docker/list** — was unbounded (80+ containers on a busy host). Now capped via `cap_list`; truncation surfaced under a `page` key.
2. **docker/details** — was over-fetching: pulled ALL containers with heavy fields (`networkSettings`, `mounts`, `labels`, `command`) just to return one. Now uses the schema's `docker { container(id:) { ... } }` single-container query. Added a dedicated trimmed `ports` query (was reusing the heavy details list query).
3. **disk/shares & disk/disks** — were unbounded. Now capped; `shares` caps **after** the issue #29 `id` synthesis so returned rows keep stable ids.
4. **array/parity_history** — unbounded history list, now capped with `page` meta.
5. **live/log_tail & live/notification_feed** — events collected over a time window had no count cap. Both now hard-cap the event list via `cap_list`.

Untouched: `disk/logs`/`log_files` (already have the good `tail_lines`/`level`/`context` pattern).

## Tests
- Updated docker `details`/contract tests for the single-container response shape and added an assertion that the query fetches by id.
- Added `ports` query schema validation + coverage.
- New cap tests to follow in this PR (default cap, `limit=` widen/narrow, `limit=0` returns all, `page` meta surfaced).

## Gates
`ruff check`/`format`, `ty check`, and `pytest -m 'not slow and not integration'` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound large list/event outputs in docker, disk, array, and live tools to prevent flooding the agent’s context. Threaded the `limit` param end-to-end (`limit<=0` returns all; omit uses `cap_list` default 20) and surfaced `page` meta; added tests and docs to cover the cap behavior.

- **Performance**
  - Docker: cap `list`; `details` now queries a single container via `docker { container(id:) }`; added a trimmed `ports` query.
  - Disk/Array: cap `disk/shares` (after id synthesis), `disk/disks`, and `array/parity_history`; include `page` meta.
  - Live: cap `log_tail` and `notification_feed` event lists.

<sup>Written for commit f11c6b17d792282c4b6f8cb764505d2a91533a45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

