### PR TITLE
perf: bound list/blob outputs in oidc, rclone, key, plugin, notification

### DIFF
--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -55,6 +55,17 @@ class TestKeysActions:
         tool_fn = _make_tool()
         result = await tool_fn(action="key", subaction="list")
         assert len(result["keys"]) == 1
+        assert result["page"]["truncated"] is False
+
+    async def test_list_caps_and_surfaces_page(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "apiKeys": [{"id": f"k:{i}", "name": f"key{i}", "roles": []} for i in range(10)]
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="key", subaction="list", limit=4)
+        assert len(result["keys"]) == 4
+        assert result["page"]["truncated"] is True
+        assert result["page"]["total"] == 10
 
     async def test_get(self, _mock_graphql: AsyncMock) -> None:
         _mock_graphql.return_value = {

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -146,6 +146,25 @@ class TestNotificationsActions:
         assert filter_var["limit"] == 10
         assert filter_var["offset"] == 5
 
+    async def test_list_limit_clamped_to_max(self, _mock_graphql: AsyncMock) -> None:
+        """A huge caller limit must be clamped so it can't dump thousands of rows."""
+        from unraid_mcp.tools._notification import _MAX_NOTIFICATION_LIMIT
+
+        _mock_graphql.return_value = {"notifications": {"list": []}}
+        tool_fn = _make_tool()
+        await tool_fn(action="notification", subaction="list", limit=5000)
+        filter_var = _mock_graphql.call_args[0][1]["filter"]
+        assert filter_var["limit"] == _MAX_NOTIFICATION_LIMIT
+
+    async def test_list_limit_zero_uses_max(self, _mock_graphql: AsyncMock) -> None:
+        from unraid_mcp.tools._notification import _MAX_NOTIFICATION_LIMIT
+
+        _mock_graphql.return_value = {"notifications": {"list": []}}
+        tool_fn = _make_tool()
+        await tool_fn(action="notification", subaction="list", limit=0)
+        filter_var = _mock_graphql.call_args[0][1]["filter"]
+        assert filter_var["limit"] == _MAX_NOTIFICATION_LIMIT
+
     async def test_delete_archived(self, _mock_graphql: AsyncMock) -> None:
         _mock_graphql.return_value = {
             "deleteArchivedNotifications": {

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -29,6 +29,41 @@ async def test_providers_returns_list(_mock_graphql):
     result = await _make_tool()(action="oidc", subaction="providers")
     assert "providers" in result
     assert len(result["providers"]) == 1
+    assert result["page"]["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_providers_caps_and_surfaces_page(_mock_graphql):
+    _mock_graphql.return_value = {
+        "oidcProviders": [
+            {"id": f"{i}:p", "name": f"p{i}", "clientId": "abc", "scopes": []} for i in range(10)
+        ]
+    }
+    result = await _make_tool()(action="oidc", subaction="providers", limit=3)
+    assert len(result["providers"]) == 3
+    assert result["page"]["truncated"] is True
+    assert result["page"]["total"] == 10
+
+
+def test_providers_list_query_trims_ui_and_endpoints():
+    """LIST query drops endpoint URLs + button fields; detail query keeps them."""
+    from unraid_mcp.tools._oidc import _OIDC_QUERIES
+
+    list_q = _OIDC_QUERIES["providers"]
+    for field in (
+        "authorizationEndpoint",
+        "tokenEndpoint",
+        "jwksUri",
+        "buttonText",
+        "buttonIcon",
+        "buttonVariant",
+        "buttonStyle",
+    ):
+        assert field not in list_q, f"{field} must not be in the providers LIST query"
+
+    detail_q = _OIDC_QUERIES["provider"]
+    for field in ("authorizationEndpoint", "tokenEndpoint", "jwksUri", "buttonText"):
+        assert field in detail_q, f"{field} should remain on the provider detail query"
 
 
 @pytest.mark.asyncio

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -28,7 +28,24 @@ async def test_list_returns_plugins(_mock_graphql):
     }
     result = await _make_tool()(action="plugin", subaction="list")
     assert result["success"] is True
-    assert len(result["data"]["plugins"]) == 1
+    assert len(result["plugins"]) == 1
+    assert result["page"]["truncated"] is False
+
+
+@pytest.mark.asyncio
+async def test_list_caps_and_surfaces_page(_mock_graphql):
+    _mock_graphql.return_value = {
+        "plugins": [
+            {"name": f"p{i}", "version": "1.0.0", "hasApiModule": True, "hasCliModule": False}
+            for i in range(10)
+        ]
+    }
+    result = await _make_tool()(action="plugin", subaction="list", limit=3)
+    assert len(result["plugins"]) == 3
+    assert result["page"]["truncated"] is True
+    assert result["page"]["total"] == 10
+    # Response must be a clean dict, not a raw GraphQL envelope.
+    assert "data" not in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_rclone.py
+++ b/tests/test_rclone.py
@@ -46,13 +46,12 @@ class TestRcloneActions:
         result = await tool_fn(action="rclone", subaction="list_remotes")
         assert len(result["remotes"]) == 1
 
-    async def test_config_form(self, _mock_graphql: AsyncMock) -> None:
-        _mock_graphql.return_value = {
-            "rclone": {"configForm": {"id": "form:1", "dataSchema": {}, "uiSchema": {}}}
-        }
+    async def test_config_form_requires_provider_type(self, _mock_graphql: AsyncMock) -> None:
+        """Unscoped config_form is the largest payload; provider_type is required."""
         tool_fn = _make_tool()
-        result = await tool_fn(action="rclone", subaction="config_form")
-        assert result["id"] == "form:1"
+        with pytest.raises(ToolError, match="requires provider_type"):
+            await tool_fn(action="rclone", subaction="config_form")
+        _mock_graphql.assert_not_awaited()
 
     async def test_config_form_with_provider(self, _mock_graphql: AsyncMock) -> None:
         _mock_graphql.return_value = {
@@ -191,3 +190,31 @@ class TestRcloneConfigDataValidation:
             config_data={"port": 22},
         )
         assert result["success"] is True
+
+
+class TestRcloneListCapping:
+    async def test_list_query_drops_parameters_and_config(self) -> None:
+        """LIST query must not over-select per-remote parameters/config (secrets)."""
+        from unraid_mcp.tools._rclone import _RCLONE_QUERIES
+
+        query = _RCLONE_QUERIES["list_remotes"]
+        assert "parameters" not in query
+        assert "config" not in query
+        assert "name" in query and "type" in query
+
+    async def test_list_remotes_caps_and_surfaces_page(self, _mock_graphql: AsyncMock) -> None:
+        remotes = [{"name": f"r{i}", "type": "s3"} for i in range(10)]
+        _mock_graphql.return_value = {"rclone": {"remotes": remotes}}
+        tool_fn = _make_tool()
+        result = await tool_fn(action="rclone", subaction="list_remotes", limit=3)
+        assert len(result["remotes"]) == 3
+        assert result["page"]["truncated"] is True
+        assert result["page"]["total"] == 10
+
+    async def test_list_remotes_limit_zero_returns_all(self, _mock_graphql: AsyncMock) -> None:
+        remotes = [{"name": f"r{i}", "type": "s3"} for i in range(10)]
+        _mock_graphql.return_value = {"rclone": {"remotes": remotes}}
+        tool_fn = _make_tool()
+        result = await tool_fn(action="rclone", subaction="list_remotes", limit=0)
+        assert len(result["remotes"]) == 10
+        assert result["page"]["truncated"] is False

--- a/unraid_mcp/tools/_key.py
+++ b/unraid_mcp/tools/_key.py
@@ -11,6 +11,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.pagination import cap_list
 from ..core.utils import safe_get, validate_subaction
 
 
@@ -44,6 +45,7 @@ async def _handle_key(
     permissions: list[str] | None,
     ctx: Context | None,
     confirm: bool,
+    limit: int = 20,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _KEY_SUBACTIONS, "key")
 
@@ -61,7 +63,9 @@ async def _handle_key(
         if subaction == "list":
             data = await _client.make_graphql_request(_KEY_QUERIES["list"])
             keys = data.get("apiKeys", [])
-            return {"keys": list(keys) if isinstance(keys, list) else []}
+            keys = list(keys) if isinstance(keys, list) else []
+            capped, page = cap_list(keys, limit)
+            return {"keys": capped, "page": page}
 
         if subaction == "possible_roles":
             data = await _client.make_graphql_request(_KEY_QUERIES["possible_roles"])

--- a/unraid_mcp/tools/_notification.py
+++ b/unraid_mcp/tools/_notification.py
@@ -42,6 +42,9 @@ _NOTIFICATION_SUBACTIONS: set[str] = set(_NOTIFICATION_QUERIES) | set(_NOTIFICAT
 _NOTIFICATION_DESTRUCTIVE: set[str] = {"delete", "delete_archived"}
 _VALID_IMPORTANCE = frozenset({"ALERT", "WARNING", "INFO"})
 _VALID_LIST_TYPES = frozenset({"UNREAD", "ARCHIVE"})
+# Upper clamp on the server-side `limit` so e.g. limit=5000 can't dump thousands
+# of rows into the agent's context. The good default (20) is set by the caller.
+_MAX_NOTIFICATION_LIMIT = 200
 
 
 async def _handle_notification(
@@ -93,10 +96,15 @@ async def _handle_notification(
             return dict(safe_get(data, "notifications", "overview", default={}))
 
         if subaction == "list":
+            # limit<=0 means "as many as the clamp allows"; otherwise clamp the
+            # caller value down to the max so it can't request thousands of rows.
+            effective_limit = (
+                _MAX_NOTIFICATION_LIMIT if limit <= 0 else min(limit, _MAX_NOTIFICATION_LIMIT)
+            )
             filter_vars: dict[str, Any] = {
                 "type": list_type.upper(),
                 "offset": offset,
-                "limit": limit,
+                "limit": effective_limit,
             }
             if importance:
                 filter_vars["importance"] = importance.upper()

--- a/unraid_mcp/tools/_oidc.py
+++ b/unraid_mcp/tools/_oidc.py
@@ -8,6 +8,7 @@ from typing import Any
 from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
+from ..core.pagination import cap_list
 from ..core.utils import validate_subaction
 
 
@@ -16,8 +17,11 @@ from ..core.utils import validate_subaction
 # ===========================================================================
 
 _OIDC_QUERIES: dict[str, str] = {
-    "providers": "query GetOidcProviders { oidcProviders { id name clientId issuer authorizationEndpoint tokenEndpoint jwksUri scopes authorizationRules { claim operator value } authorizationRuleMode buttonText buttonIcon buttonVariant buttonStyle } }",
-    "provider": "query GetOidcProvider($id: PrefixedID!) { oidcProvider(id: $id) { id name clientId issuer scopes authorizationRules { claim operator value } authorizationRuleMode buttonText buttonIcon } }",
+    # LIST stays lean: endpoint URLs (authorizationEndpoint/tokenEndpoint/jwksUri)
+    # and the pure-presentation button fields are dropped here — they live on the
+    # `provider` (singular) detail query below.
+    "providers": "query GetOidcProviders { oidcProviders { id name clientId issuer scopes authorizationRules { claim operator value } authorizationRuleMode } }",
+    "provider": "query GetOidcProvider($id: PrefixedID!) { oidcProvider(id: $id) { id name clientId issuer authorizationEndpoint tokenEndpoint jwksUri scopes authorizationRules { claim operator value } authorizationRuleMode buttonText buttonIcon buttonVariant buttonStyle } }",
     "configuration": "query GetOidcConfiguration { oidcConfiguration { providers { id name clientId scopes } defaultAllowedOrigins } }",
     "public_providers": "query GetPublicOidcProviders { publicOidcProviders { id name buttonText buttonIcon buttonVariant buttonStyle } }",
     "validate_session": "query ValidateOidcSession($token: String!) { validateOidcSession(token: $token) { valid username } }",
@@ -27,7 +31,7 @@ _OIDC_SUBACTIONS: set[str] = set(_OIDC_QUERIES)
 
 
 async def _handle_oidc(
-    subaction: str, provider_id: str | None, token: str | None
+    subaction: str, provider_id: str | None, token: str | None, limit: int = 20
 ) -> dict[str, Any]:
     validate_subaction(subaction, _OIDC_SUBACTIONS, "oidc")
 
@@ -47,7 +51,9 @@ async def _handle_oidc(
         data = await _client.make_graphql_request(_OIDC_QUERIES[subaction], variables)
 
         if subaction == "providers":
-            return {"providers": data.get("oidcProviders", [])}
+            providers = data.get("oidcProviders") or []
+            capped, page = cap_list(providers, limit)
+            return {"providers": capped, "page": page}
         if subaction == "provider":
             result = data.get("oidcProvider")
             if result is None:

--- a/unraid_mcp/tools/_plugin.py
+++ b/unraid_mcp/tools/_plugin.py
@@ -11,6 +11,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.pagination import cap_list
 from ..core.utils import validate_subaction
 
 
@@ -38,6 +39,7 @@ async def _handle_plugin(
     restart: bool,
     ctx: Context | None,
     confirm: bool,
+    limit: int = 20,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _PLUGIN_SUBACTIONS, "plugin")
 
@@ -54,7 +56,15 @@ async def _handle_plugin(
 
         if subaction == "list":
             data = await _client.make_graphql_request(_PLUGIN_QUERIES["list"])
-            return {"success": True, "subaction": subaction, "data": data}
+            plugins = data.get("plugins") or []
+            plugins = list(plugins) if isinstance(plugins, list) else []
+            capped, page = cap_list(plugins, limit)
+            return {
+                "success": True,
+                "subaction": subaction,
+                "plugins": capped,
+                "page": page,
+            }
 
         if subaction in ("add", "remove"):
             if not names:

--- a/unraid_mcp/tools/_rclone.py
+++ b/unraid_mcp/tools/_rclone.py
@@ -11,6 +11,7 @@ from ..config.logging import logger
 from ..core import client as _client
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.guards import gate_destructive_action
+from ..core.pagination import cap_list
 from ..core.utils import safe_get, validate_subaction
 from ..core.validation import DANGEROUS_KEY_PATTERN, validate_scalar_mapping
 
@@ -20,7 +21,9 @@ from ..core.validation import DANGEROUS_KEY_PATTERN, validate_scalar_mapping
 # ===========================================================================
 
 _RCLONE_QUERIES: dict[str, str] = {
-    "list_remotes": "query ListRCloneRemotes { rclone { remotes { name type parameters config } } }",
+    # List stays lean: full per-remote `parameters`/`config` (endpoints, secrets)
+    # are intentionally omitted — they bloat the payload and leak config on a LIST.
+    "list_remotes": "query ListRCloneRemotes { rclone { remotes { name type } } }",
     "config_form": "query GetRCloneConfigForm($formOptions: RCloneConfigFormInput) { rclone { configForm(formOptions: $formOptions) { id dataSchema uiSchema } } }",
 }
 
@@ -50,6 +53,7 @@ async def _handle_rclone(
     config_data: dict[str, Any] | None,
     ctx: Context | None,
     confirm: bool,
+    limit: int = 20,
 ) -> dict[str, Any]:
     validate_subaction(subaction, _RCLONE_SUBACTIONS, "rclone")
 
@@ -67,15 +71,24 @@ async def _handle_rclone(
         if subaction == "list_remotes":
             data = await _client.make_graphql_request(_RCLONE_QUERIES["list_remotes"])
             remotes = safe_get(data, "rclone", "remotes", default=[])
-            return {"remotes": list(remotes) if isinstance(remotes, list) else []}
+            remotes = list(remotes) if isinstance(remotes, list) else []
+            capped, page = cap_list(remotes, limit)
+            # Full per-remote config (parameters/config) is intentionally dropped
+            # here; a per-remote detail subaction could expose it if ever needed.
+            return {"remotes": capped, "page": page}
 
         if subaction == "config_form":
-            variables: dict[str, Any] = {}
-            if provider_type:
-                variables["formOptions"] = {"providerType": provider_type}
-            data = await _client.make_graphql_request(
-                _RCLONE_QUERIES["config_form"], variables or None
-            )
+            # Unscoped, configForm can return JSON-Schema blobs for every provider —
+            # the single largest payload in the server. Require a provider_type so
+            # the response stays bounded to one provider's schema.
+            if not provider_type:
+                raise ToolError(
+                    "rclone/config_form requires provider_type (e.g. provider_type='s3'). "
+                    "Pass the rclone backend type to scope the returned config schema."
+                )
+            _validate_rclone_name(provider_type, "provider_type")
+            variables: dict[str, Any] = {"formOptions": {"providerType": provider_type}}
+            data = await _client.make_graphql_request(_RCLONE_QUERIES["config_form"], variables)
             form = safe_get(data, "rclone", "configForm", default={})
             if not form:
                 raise ToolError("No RClone config form data received")

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -460,13 +460,17 @@ def register_unraid_tool(mcp: FastMCP) -> None:
             )
 
         if action == "key":
-            return await _handle_key(subaction, key_id, name, roles, permissions, ctx, confirm)
+            return await _handle_key(
+                subaction, key_id, name, roles, permissions, ctx, confirm, limit
+            )
 
         if action == "plugin":
-            return await _handle_plugin(subaction, names, bundled, restart, ctx, confirm)
+            return await _handle_plugin(subaction, names, bundled, restart, ctx, confirm, limit)
 
         if action == "rclone":
-            return await _handle_rclone(subaction, name, provider_type, config_data, ctx, confirm)
+            return await _handle_rclone(
+                subaction, name, provider_type, config_data, ctx, confirm, limit
+            )
 
         if action == "setting":
             return await _handle_setting(subaction, settings_input, ups_config, ctx, confirm)
@@ -475,7 +479,7 @@ def register_unraid_tool(mcp: FastMCP) -> None:
             return await _handle_customization(subaction, theme_name)
 
         if action == "oidc":
-            return await _handle_oidc(subaction, provider_id, token)
+            return await _handle_oidc(subaction, provider_id, token, limit)
 
         if action == "user":
             return await _handle_user(subaction)


### PR DESCRIPTION
## Summary

Bounds large list/blob payloads across five domain handlers so they don't flood the agent's context window. Uses the shared `cap_list` helper and threads the existing `unraid` tool `limit` (default 20) into each handler.

## Findings addressed

1. **`rclone/config_form`** — Unscoped, this returns JSON-Schema (`dataSchema`/`uiSchema`) blobs for *every* provider, the single largest payload in the server. Now **requires `provider_type`**; omitting it raises a guiding `ToolError`. Scoped calls work exactly as before. The `provider_type` is also validated (length + dangerous-char check).
2. **`rclone/list_remotes`** — Was over-selecting per-remote `parameters`+`config` (full remote config incl. endpoints/secrets) on a LIST. **Dropped `parameters`/`config`** from the list query (keeps `name`/`type`). Applied `cap_list` + `limit`. A per-remote detail subaction could expose the full config later if needed (not built).
3. **`oidc/providers`** — Trimmed endpoint URLs (`authorizationEndpoint`/`tokenEndpoint`/`jwksUri`) and the 4 pure-presentation button fields from the LIST query; they remain on the `oidc/provider` (singular) detail query. Applied `cap_list` + `limit`.
4. **`key/list`** — Applied `cap_list` + `limit` (permissions matrix retained per instructions, but list is now capped).
5. **`plugin/list`** — Applied `cap_list` + `limit`; now returns a clean `{plugins, page}` dict instead of the raw GraphQL envelope (`{data: {...}}`).
6. **`notification/list`** — Server-side filtering was good but the caller `limit` had **no upper clamp**. Clamped to `min(limit, 200)` (and `limit<=0` -> 200) so `limit=5000` can't dump thousands of rows. Good defaults (limit=20, UNREAD) unchanged.

All list subactions now surface a `page` meta dict (`returned`/`total`/`truncated` + `hint`). `limit<=0` returns everything (except notification, which is server-clamped).

## Tests

Extended `test_rclone.py`, `test_oidc.py`, `test_keys.py`, `test_plugins.py`, `test_notifications.py`:
- caps applied + `page` meta surfaced (+ `limit=0` returns all)
- trimmed queries no longer select removed fields (schema-style assertions on the query strings; detail query retains them)
- `config_form` requires `provider_type`
- notification `limit` clamped to the 200 max (and `limit=0` uses the max)

## Gates

- `ruff check` + `ruff format` clean
- `ty check` clean
- `pytest -m "not slow and not integration"`: **1016 passed** (incl. `tests/schema/` query validation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds large list/blob responses across `oidc`, `rclone`, `key`, `plugin`, and `notification` to keep payloads small and predictable. Adds a consistent `page` meta object and trims oversized fields; `rclone/config_form` now requires `provider_type`, and notification list limits are clamped.

- **New Features**
  - Applied `cap_list` to `oidc/providers`, `rclone/list_remotes`, `key/list`, and `plugin/list`; each returns `page` with `returned`, `total`, and `truncated`.
  - `rclone/config_form` requires and validates `provider_type`; payload is scoped to one provider.
  - Trimmed list fields: `rclone/list_remotes` drops `parameters`/`config`; `oidc/providers` drops endpoint URLs and button fields (still available via `oidc/provider`).
  - `plugin/list` now returns `{success, subaction, plugins, page}` instead of a GraphQL envelope.
  - `notification/list` clamps `limit` to 200; `limit<=0` uses 200. Defaults (limit=20, UNREAD) unchanged.

- **Migration**
  - Pass `provider_type` to `rclone/config_form`.
  - Update consumers of `plugin/list` to read top-level `plugins`.
  - Use `page.truncated` to detect caps; `limit<=0` returns all for lists except notifications (max 200).

<sup>Written for commit d0d4f2b2089bba44bcd25a6b90f28e972b89fd5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

