### PR TITLE
fix: lower response-size backstop to 40KB (~10K tokens)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Copy `.env.example` to `.env` and configure:
 **Server:**
 - `UNRAID_MCP_LOG_LEVEL`: Log verbosity (default: INFO)
 - `UNRAID_MCP_LOG_FILE`: Log filename in logs/ (default: unraid-mcp.log)
-- `UNRAID_MCP_MAX_RESPONSE_BYTES`: Max serialized tool-response size in bytes (default: 131072 = 128 KB). Responses over the cap are replaced with a structured, parseable JSON truncation marker (`{"error": "response_truncated", "truncated": true, ...}`) rather than hard-cut mid-JSON. See `unraid_mcp/core/response_limit.py`.
+- `UNRAID_MCP_MAX_RESPONSE_BYTES`: Max serialized tool-response size in bytes (default: 40000 = 40 KB ≈ 10K tokens). Responses over the cap are replaced with a structured, parseable JSON truncation marker (`{"error": "response_truncated", "truncated": true, ...}`) rather than hard-cut mid-JSON. This is a backstop; the per-list `cap_list` defaults do the primary bounding. See `unraid_mcp/core/response_limit.py`.
 
 **SSL/TLS:**
 - `UNRAID_VERIFY_SSL`: SSL verification (default: true; set `false` for self-signed certs)
@@ -173,7 +173,7 @@ The server loads environment variables from multiple locations in order:
 1. **LoggingMiddleware** — logs every `tools/call` and `resources/read` with duration
 2. **ErrorHandlingMiddleware** — converts unhandled exceptions to proper MCP errors
 3. **SlidingWindowRateLimitingMiddleware** — 540 req/min sliding window
-4. **StructuredResponseLimitingMiddleware** (`core/response_limit.py`) — replaces responses over the cap (default 128 KB, override via `UNRAID_MCP_MAX_RESPONSE_BYTES`) with a complete, parseable JSON truncation marker instead of a lossy mid-JSON byte cut
+4. **StructuredResponseLimitingMiddleware** (`core/response_limit.py`) — replaces responses over the cap (default 40 KB ≈ 10K tokens, override via `UNRAID_MCP_MAX_RESPONSE_BYTES`) with a complete, parseable JSON truncation marker instead of a lossy mid-JSON byte cut
 
 Note: `ResponseCachingMiddleware` was removed — the consolidated `unraid` tool mixes reads and mutations under one name, making per-subaction cache exclusion impossible.
 

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -116,9 +116,10 @@ UNRAID_MCP_TRANSPORT = os.getenv("UNRAID_MCP_TRANSPORT", "streamable-http").lowe
 
 # Maximum serialized tool-response size in bytes. Responses larger than this are
 # replaced with a structured, still-parseable truncation marker (see
-# core/response_limit.py) rather than hard-cut mid-JSON. Default 128 KB keeps a
-# single response well under the client context window.
-UNRAID_MCP_MAX_RESPONSE_BYTES = _parse_positive_int("UNRAID_MCP_MAX_RESPONSE_BYTES", 131072)
+# core/response_limit.py) rather than hard-cut mid-JSON. Default 40 KB (~10K
+# tokens) keeps a single response a small fraction of the client context window;
+# the per-list cap_list defaults do the primary bounding, this is the backstop.
+UNRAID_MCP_MAX_RESPONSE_BYTES = _parse_positive_int("UNRAID_MCP_MAX_RESPONSE_BYTES", 40000)
 
 # HTTP Authentication
 # Bearer token for HTTP transport (streamable-http / sse).

--- a/unraid_mcp/core/response_limit.py
+++ b/unraid_mcp/core/response_limit.py
@@ -63,7 +63,7 @@ class StructuredResponseLimitingMiddleware(Middleware):
     def __init__(
         self,
         *,
-        max_size: int = 131072,
+        max_size: int = 40000,
         tools: list[str] | None = None,
     ) -> None:
         if max_size <= 0:

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -79,7 +79,7 @@ _middleware_refs.error_middleware = _error_middleware
 #    in front of this server (e.g. nginx limit_req) if tighter burst control is needed.
 _rate_limiter = SlidingWindowRateLimitingMiddleware(max_requests=540, window_minutes=1)
 
-# 4. Cap tool responses (default 128 KB, override via UNRAID_MCP_MAX_RESPONSE_BYTES)
+# 4. Cap tool responses (default 40 KB / ~10K tokens, override via UNRAID_MCP_MAX_RESPONSE_BYTES)
 #    to protect the client context window. Unlike fastmcp's stock limiter — which
 #    hard-cuts the UTF-8 byte string mid-JSON and appends a plain-text suffix,
 #    yielding invalid JSON — oversized responses are replaced wholesale with a


### PR DESCRIPTION
Follow-up to the output-audit middleware work (#51). 128 KB still let one response eat ~16% of a 200K context window; drops the default to **40 KB (~10K tokens)**.

- `config/settings.py` default `131072` → `40000`
- `core/response_limit.py` class fallback `131072` → `40000`
- comments + CLAUDE.md updated

Still overridable via `UNRAID_MCP_MAX_RESPONSE_BYTES`. This is only the backstop — per-list `cap_list` defaults (50 items) do the primary bounding. ruff/ty/response-limit tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the max serialized tool-response backstop from 128 KB to 40 KB (~10K tokens) to reduce single-response context usage. Updated the middleware default, `config/settings.py`, and docs.

- **Migration**
  - To keep the old cap, set `UNRAID_MCP_MAX_RESPONSE_BYTES=131072`.

<sup>Written for commit 9684a20c832eb4e59720c8d828c08ad6ca6e678c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced default maximum tool response size limit from 128 KB to 40 KB (~10K tokens). Oversized responses now truncate earlier with a structured JSON error marker for consistency.

* **Documentation**
  * Updated configuration documentation to reflect new response size defaults and clarify truncation behavior using complete, parseable JSON markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->