### PR TITLE
fix(ci): sync uv.lock self-version to 1.6.0 (unbreak main)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1622,7 +1622,7 @@ wheels = [
 
 [[package]]
 name = "unraid-mcp"
-version = "1.5.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
`main` CI is red: `uv sync --locked` fails because the 1.6.0 release (#42) bumped `pyproject.toml` to 1.6.0 but `uv.lock`'s editable self-package stayed at 1.5.0 (release-please doesn't run `uv lock`).

`uv lock` → single-line change (`unraid-mcp` 1.5.0 → 1.6.0); `uv sync --locked --group dev` now passes.

**Follow-up (separate, needs `workflow` scope):** add a `uv lock` step to release-please.yml so this can't recur.