### PR TITLE
ci: sync uv.lock on release PRs so their checks stay green

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,6 +11,12 @@ name: release-please
 # `pull-requests: write`. The default GITHUB_TOKEN deliberately does NOT trigger
 # downstream workflows, so tags/releases it creates would never reach publish-pypi
 # or docker-publish. Store the token as the RELEASE_PLEASE_TOKEN secret.
+#
+# release-please bumps the version in pyproject.toml + the plugin manifests but NOT
+# in uv.lock (which records the project's own version). Left unsynced, the release
+# PR's `uv sync --locked` jobs (Test, Lint, Type Check, Security Audit) fail. The
+# "Sync uv.lock" step below regenerates uv.lock on the release PR branch so those
+# checks pass.
 
 on:
   push:
@@ -25,7 +31,32 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # When a release PR was opened/updated, sync uv.lock to the bumped version on
+      # that branch. Runs only for release PRs (not when a release is tagged).
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        with:
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081  # v5
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+      - name: Sync uv.lock with the version bump
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: |
+          set -euo pipefail
+          uv lock
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already in sync; nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with release version bump"
+          git push


### PR DESCRIPTION
## Summary
release-please bumps the version in `pyproject.toml` + the plugin manifests but **not** in `uv.lock` (which records the project's own version). So every release PR's `uv sync --locked` jobs (Test, Lint, Type Check, Security Audit) fail — seen on #40, #42, and the pending #57 (release 1.6.1).

## Change
After the release-please action opens/updates a release PR, regenerate `uv.lock` on that branch and push it, so the PR's locked checks pass. Runs only for release PRs (`prs_created == 'true'`), not when a release is tagged.

The one-time 1.6.0 resync already landed in #58; this is the durable fix so future release PRs (starting with #57) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `uv.lock` on release PR branches so CI checks stay green. The `release-please` workflow now regenerates and pushes `uv.lock` when it opens or updates a release PR.

- **Bug Fixes**
  - Runs only when `prs_created == 'true'` (not on tags).
  - Checks out the release PR branch, runs `uv lock`, commits and pushes if `uv.lock` changed.
  - Unblocks `uv sync --locked` jobs (Test, Lint, Type Check, Security Audit).

<sup>Written for commit 9ea2a10b2bbce7132cb7855ebbc5b4cc1a06399a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

