### PR TITLE
chore: gitignore config/mcporter.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ CLAUDE.md.local
 logs/
 backups/
 data/
+
+# mcporter local test server definitions (may contain personal endpoints/tokens)
+/config/mcporter.json


### PR DESCRIPTION
Local mcporter test server definitions (e.g. the `unraid-uvx` stdio entry used to test `uvx unraid-mcp`) shouldn't be tracked — the mcporter skill warns they may carry personal endpoints/tokens. Adds `/config/mcporter.json` to .gitignore.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `/config/mcporter.json` in `.gitignore` to prevent committing local mcporter test server definitions, which may include personal endpoints or tokens.

<sup>Written for commit 0c16a5c650255b79b0344a38d6787fd0afa3dc2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/61?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

