### PR TITLE
docs: save session log

### DIFF
--- a/docs/sessions/2026-06-19-elicitation-removal-release-and-uv-lock.md
+++ b/docs/sessions/2026-06-19-elicitation-removal-release-and-uv-lock.md
@@ -1,0 +1,138 @@
+---
+date: 2026-06-19 16:50:37 EST
+repo: https://github.com/jmagar/unraid-mcp
+branch: fix/release-please-uv-lock
+head: 5c27637
+working directory: /home/jmagar/workspace/unraid-mcp/.claude/worktrees/clever-mcnulty-415b5e
+worktree: /home/jmagar/workspace/unraid-mcp/.claude/worktrees/clever-mcnulty-415b5e
+pr: "#47 feat: replace credential elicitation with plugin userConfig + .env setup hook — https://github.com/jmagar/unraid-mcp/pull/47 (MERGED); #42 chore(main): release 1.6.0 (MERGED)"
+beads: No bead activity observed
+---
+
+# Elicitation removal, v1.6.0 release, and release-please uv.lock fix
+
+## User Request
+
+"Use writing plans skill to create a plan to remove the use of elicitation to configure the server" → leverage the Rust servers' env+userConfig pattern → `work-it` to a green PR → review the `unraid` skill → harden further → merge to main, then merge the release PR to publish to PyPI/Docker → fix the release-please/uv.lock gap.
+
+## Session Overview
+
+Replaced MCP-elicitation credential setup with the `rmcp-template` pattern (plugin `userConfig` → `setup plugin-hook` → `~/.unraid-mcp/.env`), realigned the bundled `unraid` skill to the dendrite env-sourcing convention, hardened the setup/skill surface, and shipped it as **PR #47**. Merged #47 and the **release-please PR #42** to cut and publish **v1.6.0** to PyPI and Docker (both verified live). Started a follow-up (`fix/release-please-uv-lock`) to keep `uv.lock` in sync on release PRs; the push is blocked on missing `workflow` OAuth scope.
+
+## Sequence of Events
+
+1. Wrote implementation plan (`superpowers:writing-plans`) to remove credential elicitation.
+2. Reviewed `rmcp-template`/`axon`/`lab` config patterns; found unraid-mcp already had `userConfig` + `.mcp.json` `${CLAUDE_PLUGIN_OPTION_*}` interpolation — only the persisting `setup plugin-hook` was missing. Chose the full rmcp-template port.
+3. `work-it`: implemented PR #47 via an agent (8 plan tasks, TDD), then review waves (lavra + pr-review-toolkit + 3× simplifier), CodeRabbit; fixed all findings; created PR #47.
+4. Skill review (`plugin-dev:skill-reviewer`) → fixed the `unraid` skill: dendrite `load-env.sh` alignment (parse, not `source`), stale `health/setup` docs, README rewrite, param fixes.
+5. `pr-review-toolkit:review-pr` over the full diff → fixed dashboard single-server bug, suppressed-error surfacing, fleet-abort, added `tests/test_load_env_sh.py`.
+6. Hardening pass (4 items): symlink rejection, `.env` value quoting, dashboard output path, manifest↔map sync test; removed dead `get_api_credentials()`.
+7. Merged #47 → main (`c6721c1`); release-please folded it into release PR #42; merged #42 (`ceda592`) → tagged **v1.6.0**; PyPI + Docker publish workflows succeeded (PyPI shows 1.6.0).
+8. Diagnosed the release-PR check failures as a release-please/uv.lock gap; created `fix/release-please-uv-lock` (workflow step + `uv lock` resync). Push blocked by missing `workflow` scope.
+
+## Key Findings
+
+- unraid-mcp's `.mcp.json` already maps `UNRAID_API_URL/KEY` to `${CLAUDE_PLUGIN_OPTION_*}`; `userConfig` was already declared — elicitation was redundant for the plugin path.
+- Dendrite plugins document that `CLAUDE_PLUGIN_OPTION_*` is injected only into plugin subprocesses (hooks/MCP), **not** the Bash tool — so the skill's old curl fallback using those vars was broken. The hook materializes the file; the skill must read it.
+- release-please bumps `pyproject.toml` + manifests but **not** `uv.lock` (which records the project's own version). Every release PR's `uv sync --locked` jobs fail (Test/Lint/Type/Security) — confirmed on #40 (1.5.0) and #42 (1.6.0). After #42 merged, `main` itself went red (pyproject 1.6.0 vs uv.lock 1.5.0).
+- `dashboard.sh` had a hardcoded personal output path and a discovery regex (`^UNRAID_(.+)_URL$`) that matched `UNRAID_API_URL` itself, breaking single-server installs.
+
+## Technical Decisions
+
+- **Repurpose, not delete, `core/setup.py`**: kept the atomic 0600 `_write_env`; added `apply_plugin_options()` + `run_plugin_hook()` (always exit 0 advisory).
+- **Parse `.env`, don't `source` it** in `skills/unraid/load-env.sh` — exports only whitelisted `UNRAID_*` (injection-safe; a hardening over dendrite's `source` baseline).
+- **Symlink rejection** on credential reads in both `settings.py` and `load-env.sh`, matching the rmcp-template/axon CWE-22 convention.
+- **release-please uv.lock fix**: a workflow step that runs `uv lock` on the release PR branch after the bump (no built-in uv.lock updater exists; generic-updater annotations don't survive `uv lock` regeneration).
+- Merged #42 despite its red checks because the failures are the known uv.lock gap (identical to #40, which shipped fine) and no branch protection requires them; publish triggers on the tag, not PR checks.
+
+## Files Changed
+
+This session's work spans merged PR #47 and the in-progress fix branch. Highlights:
+
+| status | path | purpose | evidence |
+|---|---|---|---|
+| modified | unraid_mcp/core/setup.py | remove elicitation; add apply_plugin_options/run_plugin_hook; quote `_write_env` values | #47 |
+| modified | unraid_mcp/main.py | `setup [plugin-hook]` dispatch (rejects unknown subcommand) | #47 |
+| modified | unraid_mcp/tools/unraid.py | non-interactive, file-aware `health/setup` | #47 |
+| modified | unraid_mcp/config/settings.py | drop apply_runtime_config + get_api_credentials; symlink rejection on .env load | #47 |
+| created | skills/unraid/load-env.sh | parse ~/.unraid-mcp/.env, export only UNRAID_*, reject symlinks | #47 |
+| modified | skills/unraid/scripts/{unraid-query,dashboard}.sh | source load-env.sh; surface errors; fix single-server discovery + output path | #47 |
+| modified | skills/unraid/{SKILL.md,README.md,references/*} | userConfig + .env flow; read-only setup; param fixes | #47 |
+| created | tests/test_load_env_sh.py | bash-subprocess tests for load-env.sh injection-safety + symlink | #47 |
+| modified | tests/test_plugin_setup.py, test_health.py, test_setup.py | plugin-hook, health/setup, symlink, manifest-sync, _dotenv_value tests | #47 |
+| created | .claude-plugin/plugin.json, hooks/hooks.json, bin/plugin-setup.sh | SessionStart/ConfigChange setup-hook wiring | #47 |
+| modified | docs/ (many) + README.md | scope elicitation docs to destructive actions; describe new flow | #47 |
+| modified | .github/workflows/release-please.yml | sync uv.lock on release PR branch after bump | 5c27637 (unpushed) |
+| modified | uv.lock | resync project version 1.5.0 → 1.6.0 | 5c27637 (unpushed) |
+
+## Beads Activity
+
+No bead activity observed (project uses `bd` but none was created/touched this session).
+
+## Repository Maintenance
+
+- **Plans**: the implementation plan lived under gitignored `docs/superpowers/plans/` — not a tracked artifact; nothing to move. No `docs/plans/` entries relevant.
+- **Beads**: none touched.
+- **Worktrees/branches** (inspected via injected `git worktree list` + branch list — **no deletions performed**, parallel work in flight):
+  - `claude/clever-mcnulty-415b5e` (0e91c6e) — merged via #47; safe to delete later, left intact (cleanup was blocked on the workflow-scope push).
+  - `fix/release-please-uv-lock` (5c27637) — THIS session's fix; **not pushed** (workflow scope). Keep.
+  - `fix/uv-lock-1.6.0` @ worktree `lockfix` (origin/fix/uv-lock-1.6.0 exists) — a **parallel** uv.lock fix created outside this session; left untouched (unknown ownership/overlap).
+  - `claude/nifty-haibt-da9825` — other session; untouched.
+- **Stale docs**: addressed within #47 (elicitation docs scoped to destructive actions). No further stale docs found.
+
+## Tools and Skills Used
+
+- **Skills**: `superpowers:writing-plans`, `superpowers:executing-plans` (via agent), `vibin:work-it`, `vibin:save-to-md`.
+- **Agents**: Explore ×3 (Rust config review), general-purpose (implementation), skill-reviewer, and pr-review-toolkit/lavra/code-simplifier review agents.
+- **CLIs**: `git`, `gh` (PR/merge/release/checks + GraphQL thread resolution), `uv` (pytest/ruff/ty/lock), `shellcheck`, `curl`. External reviewers: CodeRabbit (rate-limited late in session), Codex (usage-limited).
+- **Issues encountered**: transient `api.github.com` connection errors (retried, resolved); CodeRabbit throttling; `git push` of workflow file rejected for missing `workflow` OAuth scope (unresolved).
+
+## Commands Executed
+
+| command | result |
+|---|---|
+| `gh pr merge 47 --squash` | merged → c6721c1 |
+| `gh pr merge 42 --squash` | merged → ceda592; tagged v1.6.0 |
+| publish workflows (PyPI + Docker) | both completed/success |
+| `curl pypi.org/pypi/unraid-mcp/json` | version 1.6.0 (live) |
+| `uv lock` (fix branch) | unraid-mcp 1.5.0 → 1.6.0; `uv lock --check` passes |
+| `git push -u origin HEAD` (fix branch) | REJECTED — workflow scope missing |
+
+## Errors Encountered
+
+- **Workflow push rejected**: OAuth token lacks `workflow` scope → cannot push `.github/workflows/release-please.yml`. Unresolved; requires `gh auth refresh -h github.com -s workflow` (interactive, user action) or the user pushing the branch.
+- **NUL-byte env test** failed initially (`os.environ` rejects NUL) — fixed by testing `\0` against `_safe_env_value` directly (resolved in #47).
+
+## Behavior Changes (Before/After)
+
+| area | before | after |
+|---|---|---|
+| Credential setup | `health/setup` prompted via `ctx.elicit` (hung on non-interactive clients) | plugin userConfig form → setup hook writes `~/.unraid-mcp/.env`; `health/setup` is read-only status |
+| Skill HTTP fallback | used `$CLAUDE_PLUGIN_OPTION_*` in Bash (empty there) | sources `load-env.sh`, which parses `~/.unraid-mcp/.env` |
+| Release | 1.5.0 | 1.6.0 published to PyPI + GHCR |
+
+## Verification Evidence
+
+| command | expected | actual | status |
+|---|---|---|---|
+| `uv run pytest` (final #47) | all pass | 1070 passed | pass |
+| ruff / ty / shellcheck | clean | clean | pass |
+| PyPI version after release | 1.6.0 | 1.6.0 | pass |
+| PyPI + Docker publish runs | success | success | pass |
+| `uv lock --check` (fix branch) | pass | pass | pass |
+
+## Risks and Rollback
+
+- v1.6.0 is published (PyPI versions are immutable) — rollback would require a 1.6.1. Not needed; release verified healthy.
+- `main` is currently red on `uv sync --locked` (pyproject 1.6.0 vs uv.lock 1.5.0) until a uv.lock resync lands (this fix branch, or the parallel `fix/uv-lock-1.6.0`).
+
+## Open Questions
+
+- Workflow-scope push: grant `workflow` scope to the `gh` token, or have the user push `fix/release-please-uv-lock`?
+- A parallel branch `fix/uv-lock-1.6.0` (origin-pushed) and a `release 1.6.1` release PR already exist — need to reconcile whether this session's `fix/release-please-uv-lock` is still needed or is superseded by that branch.
+
+## Next Steps
+
+1. Resolve the workflow-scope block (`gh auth refresh -h github.com -s workflow`) and push `fix/release-please-uv-lock`, OR adopt the parallel `fix/uv-lock-1.6.0` — whichever the maintainer prefers — to bring `main`/`uv.lock` back in sync (fixes the now-red main).
+2. Open/merge the uv.lock fix so release-please PRs (incl. the pending 1.6.1) go green.
+3. Clean up merged branches/worktrees (`claude/clever-mcnulty-415b5e`, and the chosen-against uv.lock branch) once a fix lands.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a session log documenting the 2026-06-19 work: removal of credential elicitation, the 1.6.0 release, and the follow-up to fix `release-please`/`uv.lock` sync.
Docs-only; no code or behavior changes.

<sup>Written for commit b7e2c2a84443f1b28f0aa37370a02cbfe573dfd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

