### PR TITLE
fix: repair drifted Justfile recipes (check-contract + typecheck)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -22,9 +22,9 @@ lint:
 fmt:
     uv run ruff format .
 
-# Type-check (pyright / mypy)
+# Type-check (ty)
 typecheck:
-    uv run pyright unraid_mcp/ || uv run mypy unraid_mcp/
+    uv run ty check unraid_mcp/
 
 # Validate skills SKILL.md files exist and are non-empty
 validate-skills:
@@ -106,11 +106,11 @@ gen-token:
 
 # ── Quality Gates ─────────────────────────────────────────────────────────────
 
-# Run docker security checks
+# Run repo contract checks (version sync, env hygiene, marketplace structure)
 check-contract:
-    bash scripts/check-docker-security.sh
-    bash scripts/check-no-baked-env.sh
-    bash scripts/ensure-ignore-files.sh --check
+    bash scripts/check-version-sync.sh
+    bash scripts/block-env-commits.sh
+    bash scripts/validate-marketplace.sh
 
 # ── CLI Generation ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What
Two `Justfile` recipes had drifted from the actual repo state and broke local dev workflows.

### 1. `check-contract`
Referenced three scripts that no longer exist (`check-docker-security.sh`, `check-no-baked-env.sh`, `ensure-ignore-files.sh`), so `just check-contract` failed immediately. Rewired to the repo's actual contract scripts:
- `scripts/check-version-sync.sh`
- `scripts/block-env-commits.sh`
- `scripts/validate-marketplace.sh`

### 2. `typecheck`
Ran `uv run pyright unraid_mcp/ || uv run mypy unraid_mcp/` — but neither pyright nor mypy is a dev dependency; the project standardized on **ty** (`ty>=0.0.15`). Changed to `uv run ty check unraid_mcp/` to match `.github/workflows/ci.yml`. This also fixes the `lefthook.yml` pre-commit `just typecheck` gate, which was inconsistent with CI.

## Verification
- `just check-contract` → exit 0 (version sync OK, env guard OK, marketplace 17/17)
- `just typecheck` → exit 0 (`All checks passed!`)

Change is path-limited to `Justfile`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken `Justfile` recipes so local dev gates work and match CI. `just check-contract` and `just typecheck` now run successfully and align with pre-commit.

- **Bug Fixes**
  - check-contract: replaced deleted script calls with existing ones: `scripts/check-version-sync.sh`, `scripts/block-env-commits.sh`, `scripts/validate-marketplace.sh`.
  - typecheck: switched from `pyright`/`mypy` to `ty` to match CI and pre-commit: `uv run ty check unraid_mcp/`.

<sup>Written for commit 9c9d43a31150b9ae48800d4f74c8867ce752d440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/68?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

