### PR TITLE
docs: save session log (Justfile recipe drift fix)

### DIFF
--- a/docs/sessions/2026-06-21-justfile-recipe-drift-fix.md
+++ b/docs/sessions/2026-06-21-justfile-recipe-drift-fix.md
@@ -1,0 +1,170 @@
+---
+date: 2026-06-21 01:08:32 EST
+repo: https://github.com/jmagar/unraid-mcp
+branch: claude/silly-gates-82baaf
+head: 9c9d43a
+working directory: /home/jmagar/workspace/unraid-mcp/.claude/worktrees/silly-gates-82baaf
+worktree: /home/jmagar/workspace/unraid-mcp/.claude/worktrees/silly-gates-82baaf
+pr: 68 — fix: repair drifted Justfile recipes (check-contract + typecheck) — https://github.com/jmagar/unraid-mcp/pull/68
+beads: none
+---
+
+# Justfile recipe drift fix (check-contract + typecheck)
+
+## User Request
+Fix two ways the `Justfile` had drifted from the actual repo and broke local dev
+workflows: (1) `check-contract` referenced three non-existent scripts so it failed
+immediately, and (2) `typecheck` ran pyright/mypy (not in dev deps) instead of the
+standardized `ty`. Mid-session the user added "we should be using ruff and ty," then:
+"ok commit push and merge into main."
+
+## Session Overview
+Verified both drifts against the live repo, made two path-limited edits to `Justfile`,
+and confirmed each recipe runs green. Then committed the fix as a Conventional Commit
+(`fix:`), pushed the branch, opened PR #68, merged it into `main`, and deleted the
+merged remote branch. The merge landed on `origin/main`; only `gh`'s local post-merge
+checkout step failed (because `main` is checked out in the primary worktree).
+
+## Sequence of Events
+1. Read `Justfile`, listed `scripts/`, and confirmed the three referenced scripts
+   (`check-docker-security.sh`, `check-no-baked-env.sh`, `ensure-ignore-files.sh`) do
+   not exist; the actual scripts are `check-version-sync.sh`, `block-env-commits.sh`,
+   `validate-marketplace.sh` (corroborated by `scripts/CLAUDE.md`).
+2. Confirmed `ty>=0.0.15` and `ruff>=0.12.8` in `pyproject.toml` `[dependency-groups].dev`,
+   and that `lefthook.yml` pre-commit calls `just typecheck`.
+3. Edited `typecheck` → `uv run ty check unraid_mcp/`; rewrote `check-contract` to call
+   the three existing scripts.
+4. Ran `just check-contract` (exit 0) and `just typecheck` (exit 0); confirmed `git status`
+   showed only `Justfile` changed.
+5. Committed `9c9d43a`, pushed branch, created PR #68, merged into `main`
+   (merge commit `f0f7e23`), deleted the remote branch via the GitHub API.
+6. Ran the `save-to-md` maintenance pass and wrote this session log.
+
+## Key Findings
+- `scripts/` contains only `block-env-commits.sh`, `check-version-sync.sh`,
+  `generate_unraid_api_reference.py`, `validate-marketplace.sh`, `CLAUDE.md` — the three
+  recipe-referenced scripts were absent (deleted, not renamed).
+- `pyproject.toml:303-304` pins `ty>=0.0.15` and `ruff>=0.12.8`; no pyright/mypy anywhere.
+- `lefthook.yml:13-14` runs `just typecheck` at pre-commit, so the broken recipe made the
+  local type gate inconsistent with `.github/workflows/ci.yml` (`uv run ty check unraid_mcp/`).
+- `scripts/CLAUDE.md` documents the three existing scripts as the repo's contract/maintenance
+  checks, validating them as the correct `check-contract` targets.
+
+## Technical Decisions
+- Rewrote `check-contract` to use the existing contract scripts rather than restoring the
+  three deleted ones — the existing trio (version sync, env hygiene, marketplace structure)
+  are the repo's actual contract checks per `scripts/CLAUDE.md`.
+- Updated the `check-contract` comment from "Run docker security checks" to accurately
+  describe the new behavior.
+- Used a `fix:` Conventional Commit so release-please folds it into the next patch release;
+  made no manual version edits.
+- Merged via PR (repo convention; history shows PR merges) rather than a direct push to `main`.
+
+## Files Changed
+| status | path | previous path | purpose | evidence |
+|---|---|---|---|---|
+| modified | Justfile | — | Point `typecheck` at `ty`; repoint `check-contract` to existing scripts | `git show --stat HEAD` → `1 file changed, 6 insertions(+), 6 deletions(-)` |
+| created | docs/sessions/2026-06-21-justfile-recipe-drift-fix.md | — | This session log | save-to-md workflow |
+
+## Beads Activity
+No bead activity observed. Injected context reported `Beads recent issues: []` and
+`Beads recent interactions: none`. No new beads were warranted — the task was small,
+fully completed, and merged to `main` within the session.
+
+## Repository Maintenance
+- **Plans**: No `docs/plans/` directory exists (`ls docs/plans/` → absent), so there were
+  no completed plans to move; `docs/plans/complete/` was not created.
+- **Beads**: No tracker state changed; see Beads Activity. Evidence: injected bead context
+  was empty.
+- **Worktrees/branches**: `git worktree list` shows three worktrees. `main` worktree
+  (`/home/jmagar/workspace/unraid-mcp`) is behind `origin/main` by 2 after the merge —
+  left untouched (cannot safely modify another worktree's checkout); user should run
+  `git -C /home/jmagar/workspace/unraid-mcp pull --ff-only`. The
+  `claude/reverent-volhard-9af0e2` worktree/branch is unrelated and of unclear ownership —
+  left alone. This worktree (`silly-gates-82baaf`) is the one in use and its branch is
+  merged; not removed because it is the active workspace. The remote branch
+  `origin/claude/silly-gates-82baaf` was deleted after the PR merge, then recreated by the
+  session-log push (see Next Steps).
+- **Stale docs**: No docs contradicted by this change. `scripts/CLAUDE.md` already matches
+  the new `check-contract` targets; CLAUDE.md's "Code Quality" section already documents
+  `ty`. No doc edits needed.
+- **Transparency**: All actions above are evidence-backed; no cleanup was skipped silently.
+
+## Tools and Skills Used
+- **Shell (Bash)**: git inspection/commit/push, `just` recipe runs, `ls`/`grep`, `gh` for
+  PR create/merge and branch deletion. One failure (see Errors), otherwise clean.
+- **File tools (Read/Edit/Write)**: read `Justfile`/scripts/`pyproject.toml`, applied two
+  edits to `Justfile`, wrote this log. No issues.
+- **gh CLI**: `gh pr create`, `gh pr merge`, `gh api -X DELETE`, `gh pr view`. The
+  `gh pr merge --delete-branch` post-merge local step failed (worktree conflict); remote
+  actions succeeded.
+- **Skill**: `vibin:save-to-md` for this session log.
+- No MCP servers, subagents, or browser tools were used.
+
+## Commands Executed
+| command | result |
+|---|---|
+| `just check-contract` | exit 0 — version sync OK (v2.0.1), env guard OK, marketplace 17/17 |
+| `just typecheck` | exit 0 — `uv run ty check unraid_mcp/` → "All checks passed!" |
+| `git commit -m "fix: repair drifted Justfile recipes ..."` | `9c9d43a` — 1 file changed |
+| `git push -u origin claude/silly-gates-82baaf` | new branch pushed |
+| `gh pr create --base main ...` | created PR #68 |
+| `gh pr merge 68 --merge --delete-branch` | remote merge OK; local checkout step errored |
+| `gh api -X DELETE repos/jmagar/unraid-mcp/git/refs/heads/claude/silly-gates-82baaf` | remote branch deleted |
+
+## Errors Encountered
+- `gh pr merge 68 --merge --delete-branch` printed `fatal: 'main' is already used by
+  worktree at '/home/jmagar/workspace/unraid-mcp'`. Root cause: `gh`'s post-merge cleanup
+  tries to check out `main` locally, but `main` is checked out in the primary worktree.
+  The remote merge itself succeeded (`origin/main` advanced to `f0f7e23`). Resolved by
+  verifying via `gh pr view`/`git log` and deleting the now-orphaned remote branch with
+  `gh api`.
+
+## Behavior Changes (Before/After)
+| area | before | after |
+|---|---|---|
+| `just check-contract` | failed immediately (missing scripts) | runs 3 existing contract scripts, exit 0 |
+| `just typecheck` | ran pyright/mypy (absent) → fail/fallthrough | `uv run ty check unraid_mcp/`, matches CI |
+| lefthook pre-commit type gate | inconsistent with CI | consistent with CI (`ty`) |
+
+## Verification Evidence
+| command | expected | actual | status |
+|---|---|---|---|
+| `just check-contract` | exit 0, all checks pass | exit 0; 17/17 marketplace, version sync OK | pass |
+| `just typecheck` | exit 0, ty passes | exit 0; "All checks passed!" | pass |
+| `git status --porcelain` (pre-commit) | only `Justfile` | ` M Justfile` | pass |
+| `git log --oneline -3 origin/main` | shows merge of #68 | `f0f7e23 Merge pull request #68` + `9c9d43a` | pass |
+
+## Risks and Rollback
+- Low risk: change is limited to two `Justfile` recipes; both verified green.
+- Rollback: revert `9c9d43a` (or its merge `f0f7e23`) on `main` via a new `revert` commit/PR.
+
+## Decisions Not Taken
+- Did not restore the three deleted scripts (`check-docker-security.sh`,
+  `check-no-baked-env.sh`, `ensure-ignore-files.sh`) — out of scope and the repo's real
+  contract checks already exist. Flagged as optional separate work if docker-security /
+  ignore-file gates are wanted back.
+- Did not direct-push to `main` — used a PR to match repo convention and release-please.
+
+## References
+- PR: https://github.com/jmagar/unraid-mcp/pull/68
+- `scripts/CLAUDE.md` (contract-script inventory)
+- `.github/workflows/ci.yml` (`uv run ty check unraid_mcp/`)
+- `lefthook.yml` (pre-commit `just typecheck`)
+
+## Open Questions
+- None outstanding for the fix itself.
+
+## Next Steps
+- The primary worktree's local `main` is behind by 2; run
+  `git -C /home/jmagar/workspace/unraid-mcp pull --ff-only`.
+- This session-log commit lands on `claude/silly-gates-82baaf` and the push **recreates**
+  `origin/claude/silly-gates-82baaf` (the feature branch was deleted post-merge). The code
+  fix is already on `main`; to also land this log on `main`, open a small docs PR from the
+  recreated branch, or cherry-pick the doc commit. Otherwise delete the branch again after
+  review.
+- This worktree (`silly-gates-82baaf`) can be removed with
+  `git worktree remove /home/jmagar/workspace/unraid-mcp/.claude/worktrees/silly-gates-82baaf`
+  once the log is dispositioned.
+- Optional follow-up: decide whether docker-security / ignore-file contract checks should be
+  reintroduced as their own scripts.


### PR DESCRIPTION
Adds the session log for the `check-contract` + `typecheck` Justfile fix merged in #68.

Single file: `docs/sessions/2026-06-21-justfile-recipe-drift-fix.md`. Docs only — no code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a session log documenting the `Justfile` recipe drift fix for `check-contract` and `typecheck`, with verification steps and rationale.
Docs only — adds `docs/sessions/2026-06-21-justfile-recipe-drift-fix.md` for traceability; no code changes.

<sup>Written for commit f47740ce43e3e94969947e12f8b983d2d82d215c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/70?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

