### PR TITLE
fix(server): refuse unauthenticated HTTP endpoint on non-loopback bind (S-H3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,12 @@ UNRAID_MCP_BEARER_TOKEN=your_bearer_token
 # ------------
 UNRAID_MCP_DISABLE_HTTP_AUTH=false
 
+# Set true ONLY when an upstream proxy/gateway (e.g. SWAG + Authelia) enforces
+# auth. With UNRAID_MCP_DISABLE_HTTP_AUTH=true the server refuses to start on a
+# non-loopback bind host (e.g. 0.0.0.0) unless this is true — preventing an
+# unauthenticated MCP endpoint from being exposed on the network.
+UNRAID_MCP_TRUST_PROXY=false
+
 # Docker user / network
 # ---------------------
 # DOCKER_NETWORK is optional. If set, the container joins that external network.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -422,17 +422,55 @@ class TestStartupGuard:
             s.UNRAID_MCP_BEARER_TOKEN = orig_token
             s.UNRAID_MCP_DISABLE_HTTP_AUTH = orig_disabled
 
-    def test_startup_guard_skipped_when_auth_disabled(self):
-        """run_server should NOT exit when DISABLE_HTTP_AUTH=true."""
+    def test_startup_guard_refuses_disabled_auth_on_public_interface(self):
+        """run_server must sys.exit(1) when auth is disabled on a non-loopback
+        bind host without an explicitly trusted proxy (finding S-H3)."""
         import unraid_mcp.config.settings as s
 
         orig_transport = s.UNRAID_MCP_TRANSPORT
         orig_token = s.UNRAID_MCP_BEARER_TOKEN
         orig_disabled = s.UNRAID_MCP_DISABLE_HTTP_AUTH
+        orig_host = s.UNRAID_MCP_HOST
+        orig_trust = s.UNRAID_MCP_TRUST_PROXY
         try:
             s.UNRAID_MCP_TRANSPORT = "streamable-http"
             s.UNRAID_MCP_BEARER_TOKEN = None
             s.UNRAID_MCP_DISABLE_HTTP_AUTH = True
+            s.UNRAID_MCP_HOST = "0.0.0.0"  # noqa: S104 — non-loopback bind under test
+            s.UNRAID_MCP_TRUST_PROXY = False
+
+            with (
+                patch("unraid_mcp.server.ensure_token_exists"),
+                pytest.raises(SystemExit) as exc_info,
+            ):
+                from unraid_mcp.server import run_server
+
+                run_server()
+
+            assert exc_info.value.code == 1
+        finally:
+            s.UNRAID_MCP_TRANSPORT = orig_transport
+            s.UNRAID_MCP_BEARER_TOKEN = orig_token
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = orig_disabled
+            s.UNRAID_MCP_HOST = orig_host
+            s.UNRAID_MCP_TRUST_PROXY = orig_trust
+
+    def test_startup_guard_allows_disabled_auth_when_trust_proxy(self):
+        """run_server should NOT exit when auth is disabled on a public bind
+        host but an upstream proxy is trusted (the SWAG-fronted topology)."""
+        import unraid_mcp.config.settings as s
+
+        orig_transport = s.UNRAID_MCP_TRANSPORT
+        orig_token = s.UNRAID_MCP_BEARER_TOKEN
+        orig_disabled = s.UNRAID_MCP_DISABLE_HTTP_AUTH
+        orig_host = s.UNRAID_MCP_HOST
+        orig_trust = s.UNRAID_MCP_TRUST_PROXY
+        try:
+            s.UNRAID_MCP_TRANSPORT = "streamable-http"
+            s.UNRAID_MCP_BEARER_TOKEN = None
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = True
+            s.UNRAID_MCP_HOST = "0.0.0.0"  # noqa: S104 — non-loopback bind under test
+            s.UNRAID_MCP_TRUST_PROXY = True
 
             from unraid_mcp.server import mcp as _mcp
 
@@ -449,6 +487,43 @@ class TestStartupGuard:
             s.UNRAID_MCP_TRANSPORT = orig_transport
             s.UNRAID_MCP_BEARER_TOKEN = orig_token
             s.UNRAID_MCP_DISABLE_HTTP_AUTH = orig_disabled
+            s.UNRAID_MCP_HOST = orig_host
+            s.UNRAID_MCP_TRUST_PROXY = orig_trust
+
+    def test_startup_guard_allows_disabled_auth_on_loopback(self):
+        """run_server should NOT exit when auth is disabled but the bind host is
+        loopback — the endpoint is not reachable from the network."""
+        import unraid_mcp.config.settings as s
+
+        orig_transport = s.UNRAID_MCP_TRANSPORT
+        orig_token = s.UNRAID_MCP_BEARER_TOKEN
+        orig_disabled = s.UNRAID_MCP_DISABLE_HTTP_AUTH
+        orig_host = s.UNRAID_MCP_HOST
+        orig_trust = s.UNRAID_MCP_TRUST_PROXY
+        try:
+            s.UNRAID_MCP_TRANSPORT = "streamable-http"
+            s.UNRAID_MCP_BEARER_TOKEN = None
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = True
+            s.UNRAID_MCP_HOST = "127.0.0.1"
+            s.UNRAID_MCP_TRUST_PROXY = False
+
+            from unraid_mcp.server import mcp as _mcp
+
+            with (
+                patch("unraid_mcp.server.ensure_token_exists"),
+                patch("unraid_mcp.server.log_configuration_status"),
+                patch.object(_mcp, "run"),
+            ):
+                from unraid_mcp.server import run_server
+
+                # Should NOT raise SystemExit
+                run_server()
+        finally:
+            s.UNRAID_MCP_TRANSPORT = orig_transport
+            s.UNRAID_MCP_BEARER_TOKEN = orig_token
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = orig_disabled
+            s.UNRAID_MCP_HOST = orig_host
+            s.UNRAID_MCP_TRUST_PROXY = orig_trust
 
 
 # ---------------------------------------------------------------------------

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -140,6 +140,13 @@ UNRAID_MCP_BEARER_TOKEN: str | None = os.getenv("UNRAID_MCP_BEARER_TOKEN") or No
 _raw_disable_auth = os.getenv("UNRAID_MCP_DISABLE_HTTP_AUTH", "false").lower()
 UNRAID_MCP_DISABLE_HTTP_AUTH: bool = _raw_disable_auth in ("true", "1", "yes")
 
+# When HTTP auth is disabled, the server refuses to bind a non-loopback interface
+# unless an upstream proxy/gateway is explicitly trusted to enforce auth. Set this
+# true for the documented SWAG-fronted topology, where SWAG/Authelia front the
+# endpoint. Leaving it false fails closed on a public/LAN bind (finding S-H3).
+_raw_trust_proxy = os.getenv("UNRAID_MCP_TRUST_PROXY", "false").lower()
+UNRAID_MCP_TRUST_PROXY: bool = _raw_trust_proxy in ("true", "1", "yes")
+
 # SSL Configuration
 raw_verify_ssl = os.getenv("UNRAID_VERIFY_SSL", "true").lower()
 if raw_verify_ssl in ["false", "0", "no"]:

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -4,6 +4,7 @@ This is the main server implementation using the modular architecture with
 separate modules for configuration, core functionality, subscriptions, and tools.
 """
 
+import ipaddress
 import os
 import secrets
 import sys
@@ -35,6 +36,33 @@ from .core.auth import BearerAuthMiddleware, HealthMiddleware, WellKnownMiddlewa
 from .core.response_limit import StructuredResponseLimitingMiddleware
 from .subscriptions.resources import register_subscription_resources
 from .tools.unraid import register_unraid_tool
+
+
+_LOOPBACK_HOSTNAMES = frozenset({"localhost"})
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return True if *host* binds only a loopback interface.
+
+    Loopback binds (``127.0.0.0/8``, ``::1``, ``localhost``) keep an
+    unauthenticated endpoint off the network. Bind-all addresses
+    (``0.0.0.0``, ``::``), LAN IPs, and non-localhost hostnames are treated as
+    non-loopback (fail closed — unknown names could resolve anywhere). Used by
+    the startup guard for finding S-H3.
+    """
+    h = host.strip().lower().strip("[]")
+    if not h:
+        return False
+    if h in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        addr = ipaddress.ip_address(h)
+    except ValueError:
+        return False
+    if addr.is_loopback:
+        return True
+    mapped = getattr(addr, "ipv4_mapped", None)
+    return bool(mapped is not None and mapped.is_loopback)
 
 
 def _chmod_safe(path: object, mode: int, *, strict: bool = False) -> None:
@@ -197,6 +225,27 @@ def run_server() -> None:
             print(
                 "FATAL: HTTP transport requires a bearer token. "
                 "Set UNRAID_MCP_BEARER_TOKEN in ~/.unraid-mcp/.env or restart to auto-generate.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        # S-H3: disabling auth is only safe behind a trusted gateway or on
+        # loopback. Refuse to expose an unauthenticated MCP endpoint on a
+        # public/LAN interface — that would let anyone on the network drive the
+        # Unraid API. Operators fronting the server with SWAG/Authelia opt in
+        # via UNRAID_MCP_TRUST_PROXY=true.
+        if (
+            is_http
+            and _settings.UNRAID_MCP_DISABLE_HTTP_AUTH
+            and not _settings.UNRAID_MCP_TRUST_PROXY
+            and not _is_loopback_host(_settings.UNRAID_MCP_HOST)
+        ):
+            print(
+                "FATAL: UNRAID_MCP_DISABLE_HTTP_AUTH=true with a non-loopback bind host "
+                f"({_settings.UNRAID_MCP_HOST}) would expose an unauthenticated MCP endpoint "
+                "on the network. Refusing to start. Either bind to 127.0.0.1, re-enable "
+                "bearer-token auth, or set UNRAID_MCP_TRUST_PROXY=true if an upstream gateway "
+                "enforces authentication.",
                 file=sys.stderr,
             )
             sys.exit(1)


### PR DESCRIPTION
## Summary
Security fix **S-H3**: when `UNRAID_MCP_DISABLE_HTTP_AUTH=true` on an HTTP transport (`streamable-http`/`sse`), `run_server()` now refuses to start (`sys.exit(1)`) if the bind host is **non-loopback**, unless `UNRAID_MCP_TRUST_PROXY=true` is set. This stops an unauthenticated MCP endpoint from being exposed on a public/LAN interface.

The guard is **HTTP-only** — stdio transport (the production deployment) is completely unaffected.

## Changes
- `settings.py`: add `UNRAID_MCP_TRUST_PROXY` (bool, env-parsed, default false)
- `server.py`: add `_is_loopback_host()` (127.0.0.0/8, ::1, localhost, IPv4-mapped loopback; fail-closed on 0.0.0.0/::/LAN/unknown hostnames) + the S-H3 guard in `run_server()`
- `tests/test_auth.py`: replace the single startup-guard test with three — refusal on public interface, allow via trust-proxy, allow on loopback
- `.env.example`: document `UNRAID_MCP_TRUST_PROXY`

## Verification
- `uv run pytest tests/test_auth.py -q` → 48 passed
- Full suite → 1329 passed, 9 skipped
- ruff check + format + ty → clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuse to start the HTTP server when auth is disabled and the bind host is not loopback, unless a trusted proxy is explicitly enabled. This prevents exposing an unauthenticated MCP endpoint on public or LAN interfaces.

- **Bug Fixes**
  - Added startup guard in `run_server()` for HTTP transports; exits on non-loopback bind when `UNRAID_MCP_DISABLE_HTTP_AUTH=true`. Stdio transport is unaffected.
  - Introduced `UNRAID_MCP_TRUST_PROXY` (default false) to allow disabled-auth setups when an upstream gateway enforces auth. Documented in `.env.example`.
  - Added `_is_loopback_host()` with strict checks (`127.0.0.0/8`, `::1`, `localhost` only). Tests cover refusal, trust-proxy allow, and loopback allow.

<sup>Written for commit e87afe11f5e89ac8ea70a7f042348c913385c383. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/72?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

