### PR TITLE
fix(docker): pin uv builder to python3.12-bookworm-slim tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 # ── Stage 1: Build ──────────────────────────────────────────────────────────────
-FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 AS builder
-# tag: python3.12-bookworm-slim  (digest pinned for reproducibility; Dependabot bumps it)
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58 AS builder
+# Tag in the ref pins Dependabot to the python3.12-bookworm-slim variant (has a shell
+# for `RUN uv sync`). Without the tag, Dependabot tracks :latest — a FROM-scratch,
+# binary-only image with no /bin/sh — and the build breaks. Digest pinned for reproducibility.
 
 WORKDIR /app
 


### PR DESCRIPTION
## Problem
Dependabot's #76 bumped the `astral-sh/uv` builder image to digest `d0a0a75…`, which **breaks the Docker build**: `RUN /bin/sh -c "uv sync …"` fails with `stat /bin/sh: no such file or directory`.

## Root cause
The `FROM` line pinned the image **by digest with no tag** in the reference (`ghcr.io/astral-sh/uv@sha256:…`; the tag was only a comment). With no tag in the ref, Dependabot resolves digest updates against **`:latest`** — which for `astral-sh/uv` is a `FROM scratch`, binary-only image (just the `uv` executable, no OS, no shell). Verified against the registry: the proposed `d0a0a75…` is the `:latest` multi-arch index, while the old `e5b6…` digest is the current `python3.12-bookworm-slim` digest.

## Fix
Put the tag **in** the reference: `ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b6…`. Same (working) digest, so build behavior is unchanged, but Dependabot will now bump the digest of the correct shell-bearing variant going forward.

Supersedes #76 (closed).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken Docker builds by pinning the `ghcr.io/astral-sh/uv` builder to `:python3.12-bookworm-slim@sha256:e5b65587…` directly in the `FROM` line. Keeps digest pinning and ensures a shell is available for `RUN uv sync`.

- **Bug Fixes**
  - Prevents Dependabot from tracking `:latest` (a `FROM scratch` image with no `/bin/sh`), so the build and `uv` commands run correctly.

<sup>Written for commit 5802b690427a3b136729e4ae4b51947b48563de9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/86?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

