### PR TITLE
Comprehensive code-review remediation (44 fixes + hardening)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,19 @@ jobs:
         run: uv run ty check unraid_mcp/
 
   test:
-    name: Test
+    name: Test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
         with:
           version: "0.9.25"
+          python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
       - name: Install dependencies

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,25 +75,32 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
+      # On a pull_request the image is NOT pushed; instead it is loaded into the local
+      # docker daemon (load:true) so the blocking Trivy scan below can read it. load
+      # requires a single platform, so PR builds are amd64-only (CVEs live in the base
+      # layers and are arch-independent for this gate); SBOM/provenance attestations
+      # are registry-only and unsupported by the local docker exporter, so they are
+      # disabled on the PR path. Tag/branch/tag-push builds stay multi-arch + pushed.
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          sbom: true
-          provenance: mode=max
+          sbom: ${{ github.event_name != 'pull_request' }}
+          provenance: ${{ github.event_name == 'pull_request' && 'false' || 'mode=max' }}
 
-      # Pre-merge (pull_request) gate: the build above runs with push:false, so the
-      # image only exists locally and nothing has shipped yet. Scan it here with a
-      # non-zero exit-code so CRITICAL/HIGH CVEs *block the merge* before they can
-      # ever reach the registry. ignore-unfixed avoids failing on CVEs with no
-      # available patch (those are tracked via the advisory SARIF upload below).
+      # Pre-merge (pull_request) gate: the build above ran with load:true, so the image
+      # is in the local docker daemon. Scan it with a non-zero exit-code so CRITICAL/HIGH
+      # CVEs *block the merge* before they can ever reach the registry. ignore-unfixed
+      # avoids failing on CVEs with no available patch (those are tracked via the
+      # advisory SARIF upload below).
       - name: Scan image for vulnerabilities (blocking, pre-merge)
         if: github.event_name == 'pull_request'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -89,7 +89,27 @@ jobs:
           sbom: true
           provenance: mode=max
 
-      - name: Scan image for vulnerabilities
+      # Pre-merge (pull_request) gate: the build above runs with push:false, so the
+      # image only exists locally and nothing has shipped yet. Scan it here with a
+      # non-zero exit-code so CRITICAL/HIGH CVEs *block the merge* before they can
+      # ever reach the registry. ignore-unfixed avoids failing on CVEs with no
+      # available patch (those are tracked via the advisory SARIF upload below).
+      - name: Scan image for vulnerabilities (blocking, pre-merge)
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+
+      # Post-push (tag/branch) scan is intentionally ADVISORY (non-blocking): the image
+      # was already pushed above (push:true), so this can only report — not gate — and it
+      # only uploads SARIF to GitHub Security. This push-then-scan ordering is deliberate:
+      # it keeps releases fast (publish immediately, surface CVEs afterwards). The blocking
+      # gate that actually stops vulnerable images lives in the pull_request step above.
+      - name: Scan image for vulnerabilities (advisory, post-push)
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,8 +99,14 @@ jobs:
       # Pre-merge (pull_request) gate: the build above ran with load:true, so the image
       # is in the local docker daemon. Scan it with a non-zero exit-code so CRITICAL/HIGH
       # CVEs *block the merge* before they can ever reach the registry. ignore-unfixed
-      # avoids failing on CVEs with no available patch (those are tracked via the
-      # advisory SARIF upload below).
+      # avoids failing on CVEs with no available patch.
+      #
+      # Scope = library only (the application's Python dependencies — what a PR actually
+      # controls). Base-OS/kernel CVEs in the digest-pinned base are intentionally NOT a
+      # merge blocker here: a container ships no kernel, the base is bumped via Dependabot
+      # digest updates, and the full os+library picture is surfaced by the advisory SARIF
+      # scan below. Blocking on uncontrollable base CVEs would fail every PR until the next
+      # base bump.
       - name: Scan image for vulnerabilities (blocking, pre-merge)
         if: github.event_name == 'pull_request'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -109,6 +115,7 @@ jobs:
           format: 'table'
           exit-code: '1'
           severity: 'CRITICAL,HIGH'
+          vuln-type: 'library'
           ignore-unfixed: true
 
       # Post-push (tag/branch) scan is intentionally ADVISORY (non-blocking): the image

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,13 @@ name: release-please
 # downstream workflows, so tags/releases it creates would never reach publish-pypi
 # or docker-publish. Store the token as the RELEASE_PLEASE_TOKEN secret.
 #
+# WARNING — silent failure mode: a classic PAT EXPIRES SILENTLY. When it lapses,
+# this job simply stops opening/updating release PRs — no error, no alert — and
+# releases quietly halt until someone notices. Prefer a GitHub App installation
+# token (no expiry, scoped to exactly these permissions, and auditable per install)
+# over a classic PAT. If you must use a PAT, set a calendar reminder tied to its
+# expiry date so it gets rotated before it lapses.
+#
 # release-please bumps the version in pyproject.toml + the plugin manifests but NOT
 # in uv.lock (which records the project's own version). Left unsynced, the release
 # PR's `uv sync --locked` jobs (Test, Lint, Type Check, Security Audit) fail. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,10 @@ count only), both in `unraid_mcp/core/utils.py`.
 The server loads environment variables from multiple locations in order:
 1. `~/.unraid-mcp/.env` (primary — canonical credentials dir, all runtimes)
 2. `~/.unraid-mcp/.env.local` (local overrides, only used if primary is absent)
-3. `../.env.local` (project root local overrides)
-4. `../.env` (project root fallback)
-5. `unraid_mcp/.env` (last resort)
+3. `/app/.env.local` (Docker compat mount)
+4. `<project root>/.env.local` (project root local overrides)
+5. `<project root>/.env` (project root fallback)
+6. `unraid_mcp/.env` (last resort)
 
 ### Error Handling Strategy
 - GraphQL errors are converted to ToolError with descriptive messages
@@ -250,11 +251,14 @@ uv run pytest -x                     # Fail fast on first error
 
 ### Scripts
 ```bash
-# HTTP smoke-test against a live server (non-destructive actions, all domains)
-./tests/mcporter/test-actions.sh [MCP_URL]  # default: http://localhost:6970/mcp
-
-# stdio smoke-test, no running server needed (good for CI)
-./tests/mcporter/test-tools.sh [--parallel] [--timeout-ms N] [--verbose]
+# Canonical live integration test — exercises the full HTTP stack and optionally
+# docker/stdio modes. Direct JSON-RPC for HTTP (no mcporter dependency).
+./tests/test_live.sh                                  # --mode all (default)
+./tests/test_live.sh --mode http                      # http|docker|stdio|all
+./tests/test_live.sh --url http://localhost:6970/mcp --token <tok>
+./tests/test_live.sh --skip-auth                      # OAuth gateway deployments
+./tests/test_live.sh --skip-tools                     # no live Unraid API needed
+./tests/test_live.sh --verbose
 
 # Destructive action smoke-test (confirms guard blocks without confirm=True)
 ./tests/mcporter/test-destructive.sh [MCP_URL]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,15 +50,13 @@ ENV UNRAID_MCP_TRANSPORT=streamable-http \
 
 EXPOSE 6970
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget && rm -rf /var/lib/apt/lists/*
-
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 USER mcp
 
+# Shell-form CMD: /bin/sh expands ${UNRAID_MCP_PORT:-6970} before python runs.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD wget --quiet --tries=1 --spider \
-        "http://localhost:${UNRAID_MCP_PORT:-6970}/health" || exit 1
+    CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:${UNRAID_MCP_PORT:-6970}/health', timeout=5).status==200 else 1)" || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Justfile
+++ b/Justfile
@@ -78,16 +78,16 @@ test-live:
 
 # Run HTTP end-to-end smoke-test against the local server (auto-reads token from ~/.unraid-mcp/.env)
 test-http:
-    bash tests/mcporter/test-http.sh
+    bash tests/test_live.sh --mode http
 
 # Run HTTP e2e test with auth disabled (for gateway-protected deployments)
 test-http-no-auth:
-    bash tests/mcporter/test-http.sh --skip-auth
+    bash tests/test_live.sh --mode http --skip-auth
 
 # Run HTTP e2e test against a remote URL
 # Usage: just test-http-remote https://unraid.tootie.tv/mcp
 test-http-remote url:
-    bash tests/mcporter/test-http.sh --url {{url}} --skip-auth
+    bash tests/test_live.sh --mode http --url {{url}} --skip-auth
 
 # ── Setup ─────────────────────────────────────────────────────────────────────
 

--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ unraid(action="subscriptions", subaction="test_query", subscription_query="subsc
 
 All destructive actions require `confirm=True`. Omitting it or passing `confirm=False` raises a `ToolError` before any network request is made.
 
+> 26 destructive subactions total; `plugin` `install` / `install_language` share a row below.
+
 | Action | Subaction | Notes |
 | --- | --- | --- |
 | `array` | `stop_array` | Unmounts shares; stop containers and VMs first |
@@ -705,7 +707,7 @@ unraid(
 | `just test` | Run full test suite |
 | `just lint` | Run ruff linter |
 | `just fmt` | Run ruff formatter |
-| `just typecheck` | Run pyright or mypy |
+| `just typecheck` | Run the `ty` type checker (`uv run ty check unraid_mcp/`, matches CI) |
 | `just test-live` | Run live integration tests (requires a running Unraid server) |
 | `just up` | Start via Docker Compose |
 | `just down` | Stop Docker Compose containers |

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,8 @@ services:
       # proxy's docker network over publishing the port at all.
       - "127.0.0.1:${UNRAID_MCP_PORT:-6970}:${UNRAID_MCP_PORT:-6970}"
     env_file:
-      - ~/.claude-homelab/.env
+      - path: ~/.claude-homelab/.env
+        required: false
     volumes:
       - ./logs:/app/logs
       - ./backups:/app/backups
@@ -34,7 +35,7 @@ services:
           if [ "${UNRAID_MCP_TRANSPORT:-streamable-http}" = "stdio" ]; then
             exit 0
           fi
-          wget -qO- "http://localhost:${UNRAID_MCP_PORT:-6970}/health" > /dev/null
+          python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:${UNRAID_MCP_PORT:-6970}/health', timeout=5).status==200 else 1)"
       interval: 30s
       timeout: 5s
       start_period: 30s

--- a/docs/GUARDRAILS.md
+++ b/docs/GUARDRAILS.md
@@ -25,7 +25,9 @@ The server loads from the first `.env` file found:
 
 The `redact_sensitive()` function in `core/client.py` recursively replaces values for keys matching:
 - Exact: `key`, `pin`
-- Substring: `password`, `secret`, `token`, `apikey`, `authorization`, `credential`, `passphrase`, `jwt`, `cookie`, `session`
+- Substring: `password`, `secret`, `clientsecret`, `token`, `apikey`, `authorization`, `credential`, `passphrase`, `jwt`, `cookie`, `session`, `activationcode`, `privatekey`
+
+Beyond key-name matching, the function also redacts by **value shape** (`_is_sensitive_value`): any string value that looks like a JWT (`eyJ...` three-segment token), an `sk-`-prefixed API key, or a high-entropy opaque token (>=20 chars, token-charset only, mixing letters and digits) is masked even under an innocuous key name.
 
 All debug logging passes through this function.
 
@@ -105,7 +107,7 @@ When the MCP client does not support elicitation:
 
 ### Log path validation
 
-Log file paths are restricted to allowed prefixes (`/var/log/`, `/boot/logs/`, `/mnt/`) to prevent path traversal.
+Log file paths are restricted to allowed prefixes (`/var/log/`, `/boot/logs/`) to prevent path traversal.
 
 ### GraphQL injection prevention
 

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -79,21 +79,24 @@ Complete listing of all plugin components.
 | --- | --- | --- |
 | `skills/unraid/SKILL.md` | unraid | Client-facing skill with all domains, subactions, and workflows |
 
-## bin/ scripts
+## scripts/
 
 | Path | Language | Description |
 | --- | --- | --- |
-| `bin/sync-uv.sh` | Bash | SessionStart hook: sync uv virtual environment |
-| `bin/block-env-commits.sh` | Bash | Pre-commit hook: block accidental .env file commits |
-| `bin/check-version-sync.sh` | Bash | Verify version consistency across pyproject.toml and manifests |
-| `bin/validate-marketplace.sh` | Bash | Validate Claude Code marketplace and plugin manifest structure |
-| `bin/generate_unraid_api_reference.py` | Python | Generate canonical GraphQL API docs from live Unraid introspection |
+| `scripts/block-env-commits.sh` | Bash | Pre-commit hook: block accidental .env file commits |
+| `scripts/check-version-sync.sh` | Bash | Verify version consistency across pyproject.toml and manifests |
+| `scripts/validate-marketplace.sh` | Bash | Validate Claude Code marketplace and plugin manifest structure |
+| `scripts/generate_unraid_api_reference.py` | Python | Generate canonical GraphQL API docs from live Unraid introspection |
+| `plugins/unraid/scripts/plugin-setup.sh` | Bash | Plugin SessionStart/ConfigChange hook: persist userConfig credentials to `~/.unraid-mcp/.env` via `uvx unraid-mcp setup plugin-hook` |
 
 ## Hooks
 
+Configured in `plugins/unraid/hooks/hooks.json` (referenced by the Claude plugin manifest).
+
 | Hook | Trigger | Script |
 | --- | --- | --- |
-| Sync uv environment | SessionStart | `bin/sync-uv.sh` |
+| Credential setup | SessionStart | `plugins/unraid/scripts/plugin-setup.sh` |
+| Credential setup | ConfigChange (`user_settings`) | `plugins/unraid/scripts/plugin-setup.sh` |
 
 ## CI/CD workflows
 
@@ -108,7 +111,7 @@ Complete listing of all plugin components.
 
 | Directory | Focus | Count |
 | --- | --- | --- |
-| `tests/` (root) | Unit tests per domain | 28 test files |
+| `tests/` (root) | Unit tests per domain | 40 test files |
 | `tests/safety/` | Destructive action guards | guard verification |
 | `tests/schema/` | GraphQL query validation | 119 tests |
 | `tests/http_layer/` | httpx request/response | HTTP client tests |

--- a/docs/ROLLBACK.md
+++ b/docs/ROLLBACK.md
@@ -1,0 +1,120 @@
+# Rollback / Yank Runbook -- unraid-mcp
+
+What to do when a bad release ships. Merging the release-please PR fires a chain:
+
+1. **PyPI publish** -- `publish-pypi.yml` on the GitHub Release (`release: published`).
+2. **Docker publish** -- `docker-publish.yml` on the `v*` tag push.
+3. **MCP Registry publish** -- `mcp-publisher publish` runs inside `publish-pypi.yml`
+   after the PyPI step, using the version stamped into `server.json` from the tag.
+
+The published tool surface includes **destructive Unraid actions** (`array stop_array`,
+`array remove_disk`, `docker remove_container`, `vm force_stop`, `key delete`, ...). A bad
+release has real blast radius, so treat rollback as an incident, not housekeeping.
+
+> **First rule of releases:** versions are immutable. You cannot un-publish and re-use a
+> version number on any of the three channels. Recovery is always **yank/re-pin the bad
+> version + ship a forward-fix patch**, never "re-upload the same version with the fix."
+
+---
+
+## 1. PyPI -- yank + forward-fix
+
+PyPI does **not** allow re-uploading files for a version, even after you delete or yank it.
+You cannot "fix `X.Y.Z` in place." Recovery is two independent actions:
+
+**Yank the bad version** (hides it from new resolves; existing pins that request it exactly
+still install it, so in-flight deployments don't break):
+
+```bash
+# Via twine (preferred, scriptable)
+uv run twine yank unraid-mcp X.Y.Z --reason "broken release: <short reason>"
+
+# Or via the web UI: pypi.org/manage/project/unraid-mcp/release/X.Y.Z/ -> "Yank"
+```
+
+**Ship a forward-fix patch.** release-please makes this fast -- land a `fix:` commit on
+`main`, merge the release PR it opens, and the chain republishes a clean `X.Y.(Z+1)`:
+
+```bash
+git commit -m "fix: <what was broken in X.Y.Z>"
+# push -> merge the release-please PR -> publish-pypi.yml ships X.Y.(Z+1)
+```
+
+Tell consumers to upgrade (`uvx unraid-mcp-server@X.Y.(Z+1)`, `uv add unraid-mcp@>=X.Y.(Z+1)`).
+Yanking alone does not move anyone forward; the patch is what fixes them.
+
+---
+
+## 2. Docker -- re-pin to a prior immutable tag/digest
+
+The GHCR image is at `ghcr.io/<owner>/unraid-mcp`. You cannot delete a tag and expect
+consumers to recover -- you tell them to **re-pin to a known-good prior image by digest**.
+
+`docker/metadata-action` tags every build addressably, so a prior good build is always
+reachable even if the moving tags (`latest`, `X`, `X.Y`) now point at the bad release:
+
+- `type=semver` -> `X.Y.Z`, `X.Y`, `X` (immutable version tags)
+- `type=sha` -> `sha-<commit>` (immutable per-commit tag)
+- every build is also addressable by `@sha256:<digest>`
+
+**Recovery -- pin consumers to the prior digest:**
+
+```bash
+# Find the last-good version's digest (use the prior X.Y.Z tag)
+docker buildx imagetools inspect ghcr.io/<owner>/unraid-mcp:<prior-version>
+# -> copy the Digest: sha256:... line
+
+# Pin deployments to that immutable digest (compose / run)
+image: ghcr.io/<owner>/unraid-mcp@sha256:<prior-digest>
+```
+
+Pinning by `@sha256:...` (not a moving tag) guarantees the rolled-back deploy can't drift
+back onto the bad image. Then ship the forward-fix patch (section 1) so `latest`/`X.Y` move
+to a clean build, and consumers can return to tag-based pins.
+
+To list available tags/digests when you don't know the prior version:
+
+```bash
+gh api /users/<owner>/packages/container/unraid-mcp/versions \
+  --jq '.[] | {tags: .metadata.container.tags, created: .created_at}'
+```
+
+---
+
+## 3. MCP Registry -- republish the prior version
+
+The registry entry is driven by `server.json`, whose version is stamped from the git tag at
+publish time. Recovery is the same forward pattern: **republish the last-good version**, then
+let the forward-fix patch publish a clean newer one.
+
+```bash
+# Re-stamp server.json to the known-good prior version and republish
+jq --arg v "<prior-version>" '
+  .version = $v |
+  .packages = [.packages[] | if .registryType == "pypi" then .version = $v else . end]
+' server.json > server.tmp && mv server.tmp server.json
+
+./mcp-publisher login dns --domain tootie.tv --private-key "$MCP_PRIVATE_KEY"
+./mcp-publisher publish
+```
+
+In normal operation `server.json` is a `0.0.0` placeholder in-repo and is set from the tag by
+`publish-pypi.yml` -- only stamp it by hand for an out-of-band rollback republish. The forward-
+fix patch will publish the clean `X.Y.(Z+1)` through the normal chain.
+
+---
+
+## Prevention
+
+These guards exist to catch a bad release before (or just after) it ships -- keep them green:
+
+- **Version-sync guard.** Both `publish-pypi.yml` and `docker-publish.yml` assert the git tag
+  matches `pyproject.toml` before publishing, so a tag<->source drift fails the build instead
+  of shipping a mismatched version. `ci.yml`'s version-sync job checks the manifests on PRs.
+- **Trivy scan (advisory).** `docker-publish.yml` runs Trivy on the built image and uploads
+  SARIF to GitHub Security. It is **advisory** -- it surfaces CRITICAL/HIGH CVEs but does not
+  block the publish. Review the Security tab after a release; a flagged image is a candidate
+  for a forward-fix rebuild.
+- **Don't hand-edit versions.** Let release-please own the bump (see `docs/PUBLISHING.md` and
+  `docs/CHECKLIST.md`). Forward-fixing via a `fix:` commit is the supported fast path back to a
+  clean release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,13 +71,21 @@ classifiers = [
 # ============================================================================
 dependencies = [
     "python-dotenv>=1.1.1",
-    "fastmcp>=3.0.0",
+    # Upper-bounds on the two churn-prone deps: fastmcp and websockets have both
+    # shipped breaking changes across majors, and the WS layer is version-sensitive.
+    # Caps prevent `uv lock` from silently jumping a major (uv.lock pins the exact
+    # resolved version within the range).
+    "fastmcp>=3.0.0,<4.0.0",
     "httpx>=0.28.1",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.35.0",
-    "websockets>=15.0.1",
+    "websockets>=15.0.1,<17.0.0",
     "rich>=14.1.0",
     "pydantic-settings>=2.0",
+    # Runtime dependency for AST-based validation of the raw GraphQL subscription
+    # string accepted by `subscriptions/test_query` — the allowlist is enforced on
+    # the parsed operation (every top-level field), not a regex. (Was dev-only.)
+    "graphql-core>=3.2.0",
 ]
 
 # ============================================================================
@@ -261,7 +269,11 @@ filterwarnings = [
 [tool.coverage.run]
 source = ["unraid_mcp"]
 branch = true
-parallel = true
+# `parallel` is intentionally OFF: CI runs a single pytest process, so per-process
+# `.coverage.<suffix>` files (which need an explicit `coverage combine`) would only
+# add a silent-empty-report failure mode. Re-enable ONLY alongside a `coverage
+# combine` step if the suite is ever split (e.g. pytest-xdist `-n auto`).
+parallel = false
 data_file = ".cache/.coverage"
 omit = [
     "*/tests/*",
@@ -312,6 +324,5 @@ dev = [
     "ruff>=0.12.8",
     "build>=1.2.2",
     "twine>=6.0.1",
-    "graphql-core>=3.2.0",
     "hypothesis>=6.151.9",
 ]

--- a/tests/integration/test_subscriptions.py
+++ b/tests/integration/test_subscriptions.py
@@ -589,11 +589,15 @@ class TestReconnection:
 
         sleep_mock = AsyncMock()
 
+        # Pin the jitter (PERF-H2) to its upper bound so the recorded sleep equals
+        # the underlying backoff — this test asserts the backoff *escalation*, which
+        # full-jitter randomization would otherwise mask.
         with (
             patch(_WS_CONNECT, side_effect=ConnectionRefusedError("refused")),
             patch(_API_URL, "https://test.local"),
             patch(_API_KEY, "key"),
             patch(_SSL_CTX, return_value=None),
+            patch("unraid_mcp.subscriptions.manager.random.uniform", new=lambda lo, hi: hi),
             patch(_SLEEP, sleep_mock),
         ):
             await mgr._subscription_loop("test_sub", SAMPLE_QUERY, {})

--- a/tests/mcporter/README.md
+++ b/tests/mcporter/README.md
@@ -4,127 +4,91 @@ Live integration smoke-tests for the unraid-mcp server.
 
 ---
 
-## `test-http.sh` — HTTP live test, requires a running server
+## Canonical runner — `tests/test_live.sh`
 
-Full end-to-end smoke-test over the HTTP transport. No mcporter required — uses `curl` and `jq`.
+Non-destructive integration smoke-tests now live in a single canonical runner,
+[`tests/test_live.sh`](../test_live.sh) (the old `test-http.sh` and `test-tools.sh`
+scripts were consolidated into it). It exercises the full stack over HTTP, Docker, or
+stdio. No mcporter required — uses `curl` and `jq`.
 
 ```bash
-# Local server, auth disabled (gateway handles auth)
-./tests/mcporter/test-http.sh --skip-auth
+# All modes (http + docker + stdio) — the default
+./tests/test_live.sh
 
-# Local server with bearer token
-./tests/mcporter/test-http.sh --token <your-token>
+# HTTP only, against a running local server (token auto-read from ~/.unraid-mcp/.env)
+./tests/test_live.sh --mode http
 
-# Remote server via gateway
-./tests/mcporter/test-http.sh --url https://unraid.tootie.tv/mcp --skip-auth
+# HTTP, auth disabled (gateway handles auth)
+./tests/test_live.sh --mode http --skip-auth
 
-# With explicit token
-./tests/mcporter/test-http.sh --url http://localhost:6970/mcp --token <tok>
+# HTTP, explicit token
+./tests/test_live.sh --mode http --url http://localhost:6970/mcp --token <tok>
 
-# Verbose (print raw response bodies)
-./tests/mcporter/test-http.sh --skip-auth --verbose
+# HTTP against a remote server via gateway
+./tests/test_live.sh --mode http --url https://unraid.tootie.tv/mcp --skip-auth
+
+# Docker mode (builds the image, starts a container, tests, tears down)
+./tests/test_live.sh --mode docker
+
+# stdio mode (launches the server over stdio; no running server needed — good for CI)
+./tests/test_live.sh --mode stdio
+
+# Skip the live-API tool calls (no Unraid API needed); verbose response bodies
+./tests/test_live.sh --mode http --skip-tools --verbose
 ```
 
-Token is auto-read from `~/.unraid-mcp/.env` if not supplied via `--token`.
+The `just` wrappers map to these: `just test-http` → `--mode http`,
+`just test-http-no-auth` → `--mode http --skip-auth`,
+`just test-http-remote <url>` → `--mode http --url <url> --skip-auth`.
 
-### What it tests
+### Options
+
+| Flag | Effect |
+|---|---|
+| `--mode http\|docker\|stdio\|all` | Which transport(s) to exercise (default: `all`) |
+| `--url URL` | MCP endpoint for `http` mode (default: `http://localhost:6970/mcp`) |
+| `--token TOK` | Bearer token (auto-read from `~/.unraid-mcp/.env` if omitted) |
+| `--skip-auth` | Skip Phase 2 auth tests (for OAuth gateway deployments) |
+| `--skip-tools` | Skip Phase 4 tool smoke-tests (no live Unraid API needed) |
+| `--verbose` | Print raw response bodies |
+
+### What it tests (http / docker modes)
 
 | Phase | Tests |
 |---|---|
 | **1 · Middleware** | `/health`, `/.well-known/oauth-protected-resource`, `/.well-known/oauth-protected-resource/mcp` (all without auth) |
-| **2 · Auth** | No-token → 401, bad-token → 401 `invalid_token`, good-token → passes (skipped with `--skip-auth`) |
-| **3 · MCP protocol** | `initialize`, `tools/list` (tool count + named tools), `ping` |
-| **4 · Tool smoke-tests** | 14 non-destructive subactions across all domains |
+| **2 · Auth** | No-token → 401, bad-token → 401 `invalid_token`, good-token → passes (skipped with `--skip-auth` or when no token is configured) |
+| **3 · MCP protocol** | `initialize`, `tools/list` (tool count + `unraid` tool present), `ping` |
+| **4 · Tool smoke-tests** | Non-destructive subactions across all domains (skipped with `--skip-tools`) |
 | **4b · Guard bypass** | `confirm=True` bypasses destructive guard on `notification/delete` and `vm/force_stop` |
 
-Prerequisites: `curl`, `jq`.
+`stdio` mode performs the protocol handshake (`initialize`, `tools/list`) and confirms the
+`unraid` tool is present, without needing a running server.
+
+Prerequisites: `curl`, `jq` (plus `docker` for `--mode docker`, `uv` for `--mode stdio`).
 
 ---
 
-## `test-tools.sh` — stdio, no running server needed
+## Destructive Actions — `test-destructive.sh`
+
+`tests/test_live.sh` never executes destructive actions (Phase 4b only verifies that the
+`confirm=True` guard *can* be bypassed). Destructive coverage lives in
+[`test-destructive.sh`](./test-destructive.sh), which exercises the destructive actions
+using create→destroy and no-op patterns over stdio (it spawns `uv run unraid-mcp-server`
+per call — no running server needed).
 
 ```bash
-./tests/mcporter/test-tools.sh                        # sequential, 25s timeout
-./tests/mcporter/test-tools.sh --parallel             # parallel suites
-./tests/mcporter/test-tools.sh --timeout-ms 10000     # tighter timeout
-./tests/mcporter/test-tools.sh --verbose              # print raw responses
+# Dry-run — lists what would execute, runs nothing destructive (default)
+./tests/mcporter/test-destructive.sh
+
+# Actually execute the destructive tests
+./tests/mcporter/test-destructive.sh --confirm
 ```
 
-Launches `uv run unraid-mcp-server` in stdio mode for each tool call. Requires `mcporter`, `uv`, and `python3` in `PATH`. Good for CI pipelines — no persistent server process needed.
-
----
-
-## What `test-tools.sh` Tests
-
-### Phase 1 — Param-free reads
-
-All actions requiring no arguments beyond `action` itself.
-
-| Tool | Actions tested |
-|------|----------------|
-| `unraid_info` | `overview`, `array`, `network`, `registration`, `connect`, `variables`, `metrics`, `services`, `display`, `config`, `online`, `owner`, `settings`, `server`, `servers`, `flash`, `ups_devices`, `ups_device`, `ups_config` |
-| `unraid_array` | `parity_status` |
-| `unraid_storage` | `disks`, `shares`, `unassigned`, `log_files` |
-| `unraid_docker` | `list`, `networks`, `port_conflicts`, `check_updates`, `sync_templates`, `refresh_digests` |
-| `unraid_vm` | `list` |
-| `unraid_notifications` | `overview`, `list`, `warnings`, `recalculate` |
-| `unraid_rclone` | `list_remotes`, `config_form` |
-| `unraid_users` | `me` |
-| `unraid_keys` | `list` |
-| `unraid_health` | `check`, `test_connection`, `diagnose` |
-| `unraid_settings` | *(all 9 actions skipped — mutations only)* |
-
-### Phase 2 — ID-discovered reads
-
-IDs are extracted from Phase 1 responses and used for actions requiring a specific resource. Each is skipped if Phase 1 returned no matching resources.
-
-| Action | Source of ID |
-|--------|--------------|
-| `docker: details` | first container from `docker: list` |
-| `docker: logs` | first container from `docker: list` |
-| `docker: network_details` | first network from `docker: networks` |
-| `storage: disk_details` | first disk from `storage: disks` |
-| `storage: logs` | first path from `storage: log_files` |
-| `vm: details` | first VM from `vm: list` |
-| `keys: get` | first key from `keys: list` |
-
-### Skipped actions (and why)
-
-| Label | Meaning |
-|-------|---------|
-| `destructive (confirm=True required)` | Permanently modifies or deletes data |
-| `mutation — state-changing` | Modifies live system state (container/VM lifecycle, settings) |
-| `mutation — creates …` | Creates a new resource |
-
-**Full skip list:**
-- `unraid_info`: `update_server`, `update_ssh`
-- `unraid_array`: `parity_start`, `parity_pause`, `parity_resume`, `parity_cancel`
-- `unraid_storage`: `flash_backup`
-- `unraid_docker`: `start`, `stop`, `restart`, `pause`, `unpause`, `update`, `remove`, `update_all`, `create_folder`, `set_folder_children`, `delete_entries`, `move_to_folder`, `move_to_position`, `rename_folder`, `create_folder_with_items`, `update_view_prefs`, `reset_template_mappings`
-- `unraid_vm`: `start`, `stop`, `pause`, `resume`, `reboot`, `force_stop`, `reset`
-- `unraid_notifications`: `create`, `create_unique`, `archive`, `unread`, `archive_all`, `archive_many`, `unarchive_many`, `unarchive_all`, `delete`, `delete_archived`
-- `unraid_rclone`: `create_remote`, `delete_remote`
-- `unraid_keys`: `create`, `update`, `delete`
-- `unraid_settings`: all 9 actions
-
-### Output format
-
-```
-  <action label>                                              PASS
-  <action label>                                              FAIL
-      <first 3 lines of error detail>
-  <action label>                                              SKIP (reason)
-
-Results: 42 passed  0 failed  37 skipped  (79 total)
-```
-
-Exit code `0` when all executed tests pass, `1` if any fail.
-
----
-
-## Destructive Actions
-
-Neither script executes destructive actions. They are explicitly `skip_test`-ed with reason `"destructive (confirm=True required)"`.
+`--confirm` is **required** to execute; without it the script only dry-runs. Actions with
+global blast radius (no safe isolation) are `skip_test`-ed regardless. The two tests it
+actually runs under `--confirm` are `notifications: delete` and `keys: delete`, each via a
+create→delete cycle. Requires `mcporter`, `uv`, and `python3` in `PATH`.
 
 All destructive actions require `confirm=True` at the call site. There is no environment variable gate — `confirm` is the sole guard.
 
@@ -146,13 +110,13 @@ For exact per-action mcporter commands, see [`docs/DESTRUCTIVE_ACTIONS.md`](../.
 ## Prerequisites
 
 ```bash
-# mcporter CLI
+# mcporter CLI (for test-destructive.sh)
 npm install -g mcporter
 
-# uv (for test-tools.sh stdio mode)
+# uv (for stdio/docker modes and test-destructive.sh)
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# python3 — used for inline JSON extraction
+# python3 — used for inline JSON extraction in test-destructive.sh
 python3 --version  # 3.12+
 ```
 
@@ -160,4 +124,4 @@ python3 --version  # 3.12+
 
 ## Cleanup
 
-`test-tools.sh` spawns stdio server subprocesses per call — they exit when mcporter finishes each invocation — and may write a timestamped log file under `${TMPDIR:-/tmp}`. It does not leave background processes.
+`test-destructive.sh` spawns stdio server subprocesses per call — they exit when mcporter finishes each invocation. `tests/test_live.sh --mode docker` builds an image and runs a container that it always tears down at the end. Neither leaves background processes.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -891,7 +891,9 @@ class TestRateLimiterWiring:
         mock_client.post.return_value = mock_response
 
         with (
-            patch("unraid_mcp.core.client._rate_limiter.acquire", new_callable=AsyncMock) as acquire,
+            patch(
+                "unraid_mcp.core.client._rate_limiter.acquire", new_callable=AsyncMock
+            ) as acquire,
             patch("unraid_mcp.core.client.get_http_client", return_value=mock_client),
         ):
             result = await make_graphql_request("{ info { os } }")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -858,3 +858,43 @@ class TestRateLimitRetry:
             pytest.raises(ToolError, match="10 seconds"),
         ):
             await make_graphql_request("{ info }")
+
+
+# ---------------------------------------------------------------------------
+# make_graphql_request — rate limiter wiring
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiterWiring:
+    """Pin that make_graphql_request actually goes through the singleton limiter."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_config(self):
+        with (
+            patch("unraid_mcp.config.settings.UNRAID_API_URL", "https://unraid.local/graphql"),
+            patch("unraid_mcp.config.settings.UNRAID_API_KEY", "test-key"),
+        ):
+            yield
+
+    async def test_acquire_awaited_once_on_success(self) -> None:
+        """A normal successful request must acquire exactly one rate-limiter token.
+
+        Guards against the acquire() call being dropped: without this assertion,
+        removing `await _rate_limiter.acquire()` from make_graphql_request would
+        pass the whole suite silently.
+        """
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"data": {"info": {"os": "Unraid"}}}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with (
+            patch("unraid_mcp.core.client._rate_limiter.acquire", new_callable=AsyncMock) as acquire,
+            patch("unraid_mcp.core.client.get_http_client", return_value=mock_client),
+        ):
+            result = await make_graphql_request("{ info { os } }")
+
+        assert result == {"info": {"os": "Unraid"}}
+        acquire.assert_awaited_once()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -620,6 +620,55 @@ class TestGraphQLErrorHandling:
         assert result["idempotent_success"] is True
         assert result["operation"] == "stop"
 
+    async def test_idempotent_start_via_304_signal_not_prose(self) -> None:
+        """The numeric 'HTTP code 304' signal is treated as idempotent success.
+
+        Pins the locale-stable numeric path: an 'already started'-style no-op that
+        carries ONLY the 304 signal (no English idempotent prose like 'already
+        started') is synthesized into idempotent-success without relying on prose.
+        """
+        # Deliberately carries no _START_IDEMPOTENT_PHRASES substring — only 304.
+        error_msg = "Error response from daemon: HTTP code 304"
+        assert not any(p in error_msg.lower() for p in _START_IDEMPOTENT_PHRASES)
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"errors": [{"message": error_msg}]}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("unraid_mcp.core.client.get_http_client", return_value=mock_client):
+            result = await make_graphql_request(
+                'mutation { docker { start(id: "x") } }',
+                operation_context={"operation": "start"},
+            )
+        assert result["idempotent_success"] is True
+        assert result["operation"] == "start"
+        assert result["message"] == error_msg
+
+    async def test_idempotent_stop_via_304_signal_not_prose(self) -> None:
+        """The 304 signal is idempotent for 'stop' too, without prose matching."""
+        # Deliberately carries no _STOP_IDEMPOTENT_PHRASES substring — only 304.
+        error_msg = "Error response from daemon: HTTP code 304"
+        assert not any(p in error_msg.lower() for p in _STOP_IDEMPOTENT_PHRASES)
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {"errors": [{"message": error_msg}]}
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+
+        with patch("unraid_mcp.core.client.get_http_client", return_value=mock_client):
+            result = await make_graphql_request(
+                'mutation { docker { stop(id: "x") } }',
+                operation_context={"operation": "stop"},
+            )
+        assert result["idempotent_success"] is True
+        assert result["operation"] == "stop"
+        assert result["message"] == error_msg
+
     async def test_non_idempotent_error_with_context_raises(self) -> None:
         """An error that doesn't match idempotent patterns still raises even with context."""
         mock_response = MagicMock()

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,138 @@
+"""Concurrency tests for the autostart double-checked lock and the rate limiter.
+
+Two independent concurrency-safety properties are covered:
+
+1. ``ensure_subscriptions_started`` uses double-checked locking so the
+   underlying ``autostart_subscriptions`` fan-out runs at most once even when
+   many coroutines race into it concurrently.
+2. ``_RateLimiter`` (token bucket) must never over-issue under contention:
+   the bucket may go to zero but never negative, and acquiring more tokens
+   than the bucket capacity must take at least the refill-bounded time.
+"""
+
+import asyncio
+import contextlib
+import time
+from unittest.mock import AsyncMock, patch
+
+from unraid_mcp.core.client import _RateLimiter
+from unraid_mcp.subscriptions import resources as res
+
+
+# ---------------------------------------------------------------------------
+# Autostart double-checked lock
+# ---------------------------------------------------------------------------
+
+
+class TestAutostartDoubleCheckedLock:
+    """ensure_subscriptions_started must fan out exactly once under a stampede."""
+
+    async def test_autostart_runs_once_under_concurrency(self) -> None:
+        original_flag = res._subscriptions_started
+        try:
+            with patch.object(
+                res, "autostart_subscriptions", new_callable=AsyncMock
+            ) as mock_autostart:
+                # Reset the latch so the slow-path actually runs.
+                res._subscriptions_started = False
+
+                await asyncio.gather(
+                    *[res.ensure_subscriptions_started() for _ in range(20)]
+                )
+
+                # Despite 20 racing callers, the fan-out fired exactly once.
+                mock_autostart.assert_awaited_once()
+                # And the flag is latched so future callers fast-path out.
+                assert res._subscriptions_started is True
+        finally:
+            res._subscriptions_started = original_flag
+
+    async def test_fast_path_skips_autostart_when_already_started(self) -> None:
+        """When the flag is already latched, no autostart is attempted at all."""
+        original_flag = res._subscriptions_started
+        try:
+            with patch.object(
+                res, "autostart_subscriptions", new_callable=AsyncMock
+            ) as mock_autostart:
+                res._subscriptions_started = True
+
+                await asyncio.gather(
+                    *[res.ensure_subscriptions_started() for _ in range(10)]
+                )
+
+                mock_autostart.assert_not_awaited()
+        finally:
+            res._subscriptions_started = original_flag
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter under contention
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiterUnderContention:
+    """The token bucket must never over-issue tokens under concurrent acquire()."""
+
+    async def test_bucket_never_goes_negative(self) -> None:
+        """Gathering more acquires than capacity must keep tokens >= 0 throughout."""
+        # Small, fast bucket: 5 tokens, fast refill so the test stays quick.
+        limiter = _RateLimiter(max_tokens=5, refill_rate=50.0)
+
+        observed_min = float("inf")
+        original_refill = limiter._refill
+
+        def _spy_refill() -> None:
+            nonlocal observed_min
+            original_refill()
+            observed_min = min(observed_min, limiter.tokens)
+
+        with patch.object(limiter, "_refill", side_effect=_spy_refill):
+            # 25 acquires against a 5-token bucket forces heavy contention.
+            await asyncio.gather(*[limiter.acquire() for _ in range(25)])
+
+        # The bucket may hit zero but must never be over-issued (negative).
+        assert limiter.tokens >= 0.0
+        assert observed_min >= 0.0
+
+    async def test_does_not_over_issue_within_initial_capacity(self) -> None:
+        """With refill effectively frozen, only `max_tokens` acquires complete."""
+        max_tokens = 4
+        limiter = _RateLimiter(max_tokens=max_tokens, refill_rate=1.0)
+
+        # Freeze time so no tokens refill during the window: every acquire beyond
+        # the initial capacity would have to wait on refill (which never advances).
+        frozen = time.monotonic()
+        with patch("unraid_mcp.core.client.time.monotonic", return_value=frozen):
+            # Exactly max_tokens acquires should complete instantly without waiting.
+            await asyncio.wait_for(
+                asyncio.gather(*[limiter.acquire() for _ in range(max_tokens)]),
+                timeout=2.0,
+            )
+            # The bucket is now drained — never negative.
+            assert limiter.tokens >= 0.0
+            assert limiter.tokens < 1.0
+
+            # One more acquire must block (no refill while time is frozen).
+            with_extra = asyncio.ensure_future(limiter.acquire())
+            await asyncio.sleep(0)  # let it run up to the wait
+            assert not with_extra.done()
+            with_extra.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await with_extra
+
+    async def test_refill_bounded_total_time(self) -> None:
+        """Acquiring beyond capacity must take at least the refill-bounded time."""
+        # 2 tokens, slow-ish refill. Acquiring 4 needs 2 refilled tokens, each
+        # taking 1/refill_rate seconds -> a measurable, deterministic lower bound.
+        refill_rate = 20.0  # tokens/sec -> 0.05s per refilled token
+        limiter = _RateLimiter(max_tokens=2, refill_rate=refill_rate)
+
+        start = time.monotonic()
+        await asyncio.gather(*[limiter.acquire() for _ in range(4)])
+        elapsed = time.monotonic() - start
+
+        # 2 tokens are immediate; the other 2 must wait on refill. Lower bound is
+        # ~2 / refill_rate = 0.1s. Use a conservative fraction to avoid flake.
+        min_expected = (2 / refill_rate) * 0.8
+        assert elapsed >= min_expected
+        assert limiter.tokens >= 0.0

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -36,9 +36,7 @@ class TestAutostartDoubleCheckedLock:
                 # Reset the latch so the slow-path actually runs.
                 res._subscriptions_started = False
 
-                await asyncio.gather(
-                    *[res.ensure_subscriptions_started() for _ in range(20)]
-                )
+                await asyncio.gather(*[res.ensure_subscriptions_started() for _ in range(20)])
 
                 # Despite 20 racing callers, the fan-out fired exactly once.
                 mock_autostart.assert_awaited_once()
@@ -56,9 +54,7 @@ class TestAutostartDoubleCheckedLock:
             ) as mock_autostart:
                 res._subscriptions_started = True
 
-                await asyncio.gather(
-                    *[res.ensure_subscriptions_started() for _ in range(10)]
-                )
+                await asyncio.gather(*[res.ensure_subscriptions_started() for _ in range(10)])
 
                 mock_autostart.assert_not_awaited()
         finally:

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -13,10 +13,12 @@ Two independent concurrency-safety properties are covered:
 import asyncio
 import contextlib
 import time
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from unraid_mcp.core.client import _RateLimiter
 from unraid_mcp.subscriptions import resources as res
+from unraid_mcp.subscriptions.manager import SubscriptionManager
 
 
 # ---------------------------------------------------------------------------
@@ -62,6 +64,103 @@ class TestAutostartDoubleCheckedLock:
 
 
 # ---------------------------------------------------------------------------
+# SubscriptionManager._data_lock (resource_data read-vs-write) under contention
+# ---------------------------------------------------------------------------
+
+
+class TestResourceDataLockUnderContention:
+    """_data_lock must serialize resource_data writes against reads so a reader
+    never observes a torn/half-written payload.
+
+    Each writer stores a payload whose fields satisfy an internal invariant
+    (``doubled == n * 2`` and ``marker == f"v{n}"``). A reader that ever sees a
+    dict violating that invariant would prove a partial write escaped the lock.
+    """
+
+    @staticmethod
+    def _is_consistent(payload: dict[str, Any]) -> bool:
+        n = payload["n"]
+        return payload["doubled"] == n * 2 and payload["marker"] == f"v{n}"
+
+    async def test_no_torn_value_escapes_get_resource_data(self) -> None:
+        manager = SubscriptionManager()
+        name = "metrics"  # single name -> maximal contention on one slot
+        n_writers = 60
+        n_readers = 60
+        reads_per_reader = 40
+
+        observed: list[dict[str, Any] | None] = []
+
+        async def _writer(n: int) -> None:
+            # Yield first so writers actually interleave with readers under gather.
+            await asyncio.sleep(0)
+            await manager._store_subscription_data(
+                name, {"n": n, "doubled": n * 2, "marker": f"v{n}"}
+            )
+
+        async def _reader() -> None:
+            for _ in range(reads_per_reader):
+                value = await manager.get_resource_data(name)
+                observed.append(value)
+                await asyncio.sleep(0)
+
+        writers = [_writer(i) for i in range(n_writers)]
+        readers = [_reader() for _ in range(n_readers)]
+
+        # No exception and no deadlock: a bounded timeout guards against a hang.
+        await asyncio.wait_for(asyncio.gather(*writers, *readers), timeout=5.0)
+
+        # Every read is either None (pre-first-write) or a *complete, consistent*
+        # prior value — never a half-applied dict.
+        seen_value = False
+        for value in observed:
+            if value is None:
+                continue
+            seen_value = True
+            assert set(value) == {"n", "doubled", "marker"}, value
+            assert self._is_consistent(value), value
+
+        # Sanity: readers actually observed written data at least once (the test
+        # would be vacuous if every read returned None).
+        assert seen_value
+
+        # Final stored value must be one of the writers' complete payloads.
+        final = await manager.get_resource_data(name)
+        assert final is not None
+        assert self._is_consistent(final)
+
+    async def test_timestamp_accessor_also_returns_whole_values(self) -> None:
+        """get_resource_data_with_timestamp shares _data_lock — same guarantee."""
+        manager = SubscriptionManager()
+        name = "cpu"
+
+        async def _writer(n: int) -> None:
+            await asyncio.sleep(0)
+            await manager._store_subscription_data(
+                name, {"n": n, "doubled": n * 2, "marker": f"v{n}"}
+            )
+
+        results: list[tuple[dict[str, Any], str] | None] = []
+
+        async def _reader() -> None:
+            for _ in range(30):
+                results.append(await manager.get_resource_data_with_timestamp(name))
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(
+            asyncio.gather(*[_writer(i) for i in range(40)], *[_reader() for _ in range(40)]),
+            timeout=5.0,
+        )
+
+        for result in results:
+            if result is None:
+                continue
+            data, ts = result
+            assert self._is_consistent(data), data
+            assert isinstance(ts, str) and ts  # complete ISO timestamp
+
+
+# ---------------------------------------------------------------------------
 # Rate limiter under contention
 # ---------------------------------------------------------------------------
 
@@ -89,6 +188,65 @@ class TestRateLimiterUnderContention:
         # The bucket may hit zero but must never be over-issued (negative).
         assert limiter.tokens >= 0.0
         assert observed_min >= 0.0
+
+    async def test_never_over_issues_within_a_frozen_window(self) -> None:
+        """Under heavy contention with refill frozen, the limiter must issue at
+        most ``max_tokens`` acquires and tokens must never go negative AFTER a
+        decrement.
+
+        Unlike ``test_bucket_never_goes_negative`` (which samples ``tokens``
+        *before* the ``tokens -= 1`` decrement and so asserts a near-tautology),
+        this gathers far more concurrent ``acquire()`` calls than capacity and
+        observes the post-decrement token count to prove no extra token is ever
+        physically issued within the window.
+        """
+        max_tokens = 5
+        limiter = _RateLimiter(max_tokens=max_tokens, refill_rate=1.0)
+
+        completed = 0
+        post_decrement_min = float("inf")
+        observed_negative = False
+        original_acquire = limiter.acquire
+
+        async def _instrumented_acquire() -> None:
+            nonlocal completed, post_decrement_min, observed_negative
+            await original_acquire()
+            # We are here only because a token was actually decremented.
+            completed += 1
+            post_decrement_min = min(post_decrement_min, limiter.tokens)
+            if limiter.tokens < 0.0:
+                observed_negative = True
+
+        # Freeze time so no refill happens: only the initial ``max_tokens`` may
+        # be issued; every further acquire must block on the (never-advancing)
+        # refill.
+        frozen = time.monotonic()
+        n_callers = max_tokens * 6  # heavy over-subscription
+        with (
+            patch("unraid_mcp.core.client.time.monotonic", return_value=frozen),
+            patch.object(limiter, "acquire", side_effect=_instrumented_acquire),
+        ):
+            tasks = [asyncio.ensure_future(limiter.acquire()) for _ in range(n_callers)]
+            # Let every task run up to either completion or its refill-wait.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+            # Exactly the bucket capacity may have been issued — never more.
+            assert completed == max_tokens
+            assert not observed_negative
+            assert post_decrement_min >= 0.0
+            # The bucket is drained but non-negative.
+            assert 0.0 <= limiter.tokens < 1.0
+
+            # The remaining callers are still blocked on refill (no over-issue).
+            done = [t for t in tasks if t.done()]
+            assert len(done) == max_tokens
+
+            for t in tasks:
+                t.cancel()
+            for t in tasks:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await t
 
     async def test_does_not_over_issue_within_initial_capacity(self) -> None:
         """With refill effectively frozen, only `max_tokens` acquires complete."""

--- a/tests/test_dispatcher_contract.py
+++ b/tests/test_dispatcher_contract.py
@@ -18,7 +18,6 @@ import importlib
 import inspect
 
 import pytest
-
 from conftest import make_tool_fn
 
 from unraid_mcp.core.exceptions import ToolError

--- a/tests/test_dispatcher_contract.py
+++ b/tests/test_dispatcher_contract.py
@@ -47,8 +47,10 @@ def test_unraid_input_fields_match_tool_signature() -> None:
 # Domains whose handler ends with an explicit "Unhandled <domain> subaction ...
 # — this is a bug" guard, plus the module + subactions-set attribute to monkeypatch
 # so an in-set-but-unhandled subaction reaches that guard. (vm/user have no guard:
-# they are structurally exhaustive. live/health use special dispatch and are
-# covered by their own suites.)
+# they are structurally exhaustive.) live and health ALSO have this guard but use
+# special dispatch (live validates against SNAPSHOT_ACTIONS | COLLECT_ACTIONS; health
+# against _HEALTH_SUBACTIONS) that the generic sweep can't drive, so they get the two
+# dedicated tests below — they are NOT exercised by this parametrized sweep.
 _GUARDED_DOMAINS = {
     "system": ("unraid_mcp.tools._system", "_SYSTEM_SUBACTIONS"),
     "array": ("unraid_mcp.tools._array", "_ARRAY_SUBACTIONS"),
@@ -85,3 +87,47 @@ async def test_domain_fallthrough_guard_fires(
     tool_fn = _make_tool()
     with pytest.raises(ToolError, match=rf"Unhandled {domain} subaction"):
         await tool_fn(action=domain, subaction=fake, confirm=True)
+
+
+async def test_live_fallthrough_guard_fires(
+    monkeypatch: pytest.MonkeyPatch, mock_graphql_request
+) -> None:
+    """live validates against SNAPSHOT_ACTIONS | COLLECT_ACTIONS, then dispatches by
+    explicit subaction branches. A fake key in COLLECT_ACTIONS passes validation but
+    matches none of the real branches (log_tail / notification_feed /
+    plugin_install_updates), so it falls through to the clean fall-through guard with
+    NO WebSocket/network call. (Injecting into SNAPSHOT_ACTIONS instead would hit the
+    `subaction in SNAPSHOT_ACTIONS` branch and attempt a real subscription.)"""
+    from unraid_mcp.subscriptions import queries
+
+    fake = "__unhandled_live_probe__"
+    monkeypatch.setattr(queries, "COLLECT_ACTIONS", queries.COLLECT_ACTIONS | {fake: ""})
+
+    mock_graphql_request.return_value = {}
+    tool_fn = _make_tool()
+    with pytest.raises(ToolError, match=r"Unhandled live subaction"):
+        await tool_fn(action="live", subaction=fake)
+
+
+async def test_health_fallthrough_guard_fires(
+    monkeypatch: pytest.MonkeyPatch, mock_graphql_request
+) -> None:
+    """health validates against _HEALTH_SUBACTIONS, then dispatches by explicit
+    subaction branches. A fake added to the set passes validation but is none of
+    setup / test_connection / check / diagnose, so it falls through to the clean
+    fall-through guard with NO network call."""
+    import unraid_mcp.tools._health as _health
+    import unraid_mcp.tools.unraid as _unraid
+
+    fake = "__unhandled_health_probe__"
+    augmented = _health._HEALTH_SUBACTIONS | {fake}
+    # `unraid.py` does `from ._health import _HEALTH_SUBACTIONS`, binding the name in
+    # its own namespace — patch the source module AND the read site so validation sees
+    # the fake regardless of which reference the handler resolves.
+    monkeypatch.setattr(_health, "_HEALTH_SUBACTIONS", augmented)
+    monkeypatch.setattr(_unraid, "_HEALTH_SUBACTIONS", augmented)
+
+    mock_graphql_request.return_value = {}
+    tool_fn = _make_tool()
+    with pytest.raises(ToolError, match=r"Unhandled health subaction"):
+        await tool_fn(action="health", subaction=fake)

--- a/tests/test_dispatcher_contract.py
+++ b/tests/test_dispatcher_contract.py
@@ -1,0 +1,88 @@
+"""Contract tests for the consolidated `unraid` dispatcher.
+
+Two invariants the review flagged:
+
+* #4 — the flat tool signature and the `UnraidInput` model are now coupled by a
+  `locals()`-based pack, so their field sets MUST stay identical (extra="forbid"
+  would otherwise reject a dispatch at runtime).
+* #5 / TEST-H2 — the "mutation subaction not in the query dict -> KeyError"
+  gotcha. Every domain handler ends with an explicit fall-through guard; this
+  sweep proves each domain's guard actually fires for an in-set-but-unhandled
+  subaction instead of leaking a raw KeyError (which `tool_error_handler` would
+  mask as a generic "likely a bug"). Only `docker` was previously covered.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+from conftest import make_tool_fn
+
+from unraid_mcp.core.exceptions import ToolError
+from unraid_mcp.tools.unraid import UnraidInput
+
+
+def _make_tool():
+    return make_tool_fn("unraid_mcp.tools.unraid", "register_unraid_tool", "unraid")
+
+
+def test_unraid_input_fields_match_tool_signature() -> None:
+    """#4: UnraidInput fields == the tool signature params (minus ctx).
+
+    The packing block builds the model straight from locals(); if a parameter is
+    added to one side and not the other this assertion fails at CI time instead of
+    a confusing runtime ValidationError on a single subaction.
+    """
+    tool_fn = _make_tool()
+    sig_params = set(inspect.signature(tool_fn).parameters) - {"ctx"}
+    model_fields = set(UnraidInput.model_fields)
+    assert sig_params == model_fields, (
+        f"signature/model drift — only in signature: {sig_params - model_fields}; "
+        f"only in model: {model_fields - sig_params}"
+    )
+
+
+# Domains whose handler ends with an explicit "Unhandled <domain> subaction ...
+# — this is a bug" guard, plus the module + subactions-set attribute to monkeypatch
+# so an in-set-but-unhandled subaction reaches that guard. (vm/user have no guard:
+# they are structurally exhaustive. live/health use special dispatch and are
+# covered by their own suites.)
+_GUARDED_DOMAINS = {
+    "system": ("unraid_mcp.tools._system", "_SYSTEM_SUBACTIONS"),
+    "array": ("unraid_mcp.tools._array", "_ARRAY_SUBACTIONS"),
+    "disk": ("unraid_mcp.tools._disk", "_DISK_SUBACTIONS"),
+    "docker": ("unraid_mcp.tools._docker", "_DOCKER_SUBACTIONS"),
+    "notification": ("unraid_mcp.tools._notification", "_NOTIFICATION_SUBACTIONS"),
+    "key": ("unraid_mcp.tools._key", "_KEY_SUBACTIONS"),
+    "plugin": ("unraid_mcp.tools._plugin", "_PLUGIN_SUBACTIONS"),
+    "rclone": ("unraid_mcp.tools._rclone", "_RCLONE_SUBACTIONS"),
+    "setting": ("unraid_mcp.tools._setting", "_SETTING_SUBACTIONS"),
+    "connect": ("unraid_mcp.tools._connect", "_CONNECT_SUBACTIONS"),
+    "onboarding": ("unraid_mcp.tools._onboarding", "_ONBOARDING_SUBACTIONS"),
+    "customization": ("unraid_mcp.tools._customization", "_CUSTOMIZATION_SUBACTIONS"),
+    "oidc": ("unraid_mcp.tools._oidc", "_OIDC_SUBACTIONS"),
+}
+
+
+@pytest.mark.parametrize("domain", sorted(_GUARDED_DOMAINS))
+async def test_domain_fallthrough_guard_fires(
+    domain: str, monkeypatch: pytest.MonkeyPatch, mock_graphql_request
+) -> None:
+    """#5: an in-set-but-unhandled subaction must raise the domain's clean
+    fall-through guard, never a raw KeyError from a query-dict lookup."""
+    module_name, attr = _GUARDED_DOMAINS[domain]
+    module = importlib.import_module(module_name)
+    fake = "__unhandled_probe__"
+    current = getattr(module, attr)
+    monkeypatch.setattr(module, attr, current | {fake})
+
+    # Return value is irrelevant — the fake subaction falls through before any
+    # GraphQL request is made. confirm=True keeps a (hypothetically destructive)
+    # fake from being gated.
+    mock_graphql_request.return_value = {}
+    tool_fn = _make_tool()
+    with pytest.raises(ToolError, match=rf"Unhandled {domain} subaction"):
+        await tool_fn(action=domain, subaction=fake, confirm=True)

--- a/tests/test_elicitation.py
+++ b/tests/test_elicitation.py
@@ -124,3 +124,38 @@ class TestGateDestructiveActionElicitationIntegration:
             await gate_destructive_action(
                 ctx, "stop_array", self._DESTRUCTIVE, confirm=False, description=self._DESC
             )
+
+    async def test_dict_description_present_key_used_in_message(self) -> None:
+        """A dict description keyed by the gated subaction feeds that text to elicit."""
+        marker = "ZAPP_BRANNIGAN_DELETES_THE_ARRAY_UNIQUE_MARKER"
+        elicit_result = SimpleNamespace(action="accept", data=SimpleNamespace(confirmed=True))
+        elicit = AsyncMock(return_value=elicit_result)
+        ctx = _make_ctx(elicit)
+
+        await gate_destructive_action(
+            ctx,
+            "stop_array",
+            self._DESTRUCTIVE,
+            confirm=False,
+            description={"stop_array": marker},
+        )
+
+        elicit.assert_awaited_once()
+        message = elicit.await_args.kwargs["message"]
+        assert marker in message
+
+    async def test_dict_description_missing_key_raises_before_elicit(self) -> None:
+        """A dict missing the gated subaction's key raises ToolError, never eliciting."""
+        elicit = AsyncMock()
+        ctx = _make_ctx(elicit)
+
+        with pytest.raises(ToolError, match="Missing destructive-action description"):
+            await gate_destructive_action(
+                ctx,
+                "stop_array",
+                self._DESTRUCTIVE,
+                confirm=False,
+                description={"some_other_action": "Not for stop_array."},
+            )
+
+        elicit.assert_not_awaited()

--- a/tests/test_elicitation.py
+++ b/tests/test_elicitation.py
@@ -1,0 +1,132 @@
+"""Unit tests for the destructive-action elicitation body in core/guards.py.
+
+The safety suite (tests/safety/) exercises ``gate_destructive_action`` via
+``ctx=None`` or by mocking ``elicit_destructive_confirmation`` away, so the
+elicitation *body* — the ``ctx.elicit(...)`` call, the NotImplementedError
+fallback when the client doesn't support elicitation, and the
+``result.action != 'accept'`` / ``result.data.confirmed`` parsing — is
+otherwise untested. These tests drive that body directly with a fake ctx.
+"""
+
+from types import SimpleNamespace
+from typing import ClassVar
+from unittest.mock import AsyncMock
+
+import pytest
+
+from unraid_mcp.core.exceptions import ToolError
+from unraid_mcp.core.guards import (
+    elicit_destructive_confirmation,
+    gate_destructive_action,
+)
+
+
+def _make_ctx(elicit: AsyncMock) -> SimpleNamespace:
+    """Build a minimal fake MCP context whose .elicit is the given AsyncMock."""
+    return SimpleNamespace(elicit=elicit)
+
+
+# ---------------------------------------------------------------------------
+# elicit_destructive_confirmation — the elicitation body
+# ---------------------------------------------------------------------------
+
+
+class TestElicitDestructiveConfirmation:
+    """Drive the ctx.elicit(...) path directly with a fake/mock ctx."""
+
+    async def test_not_implemented_returns_false(self) -> None:
+        """Client without elicitation support -> NotImplementedError -> False."""
+        elicit = AsyncMock(side_effect=NotImplementedError)
+        ctx = _make_ctx(elicit)
+
+        result = await elicit_destructive_confirmation(ctx, "stop_array", "Stops the array.")
+
+        assert result is False
+        elicit.assert_awaited_once()
+
+    async def test_accept_with_confirmed_true_returns_true(self) -> None:
+        """An accept result carrying confirmed=True -> True."""
+        elicit_result = SimpleNamespace(
+            action="accept", data=SimpleNamespace(confirmed=True)
+        )
+        elicit = AsyncMock(return_value=elicit_result)
+        ctx = _make_ctx(elicit)
+
+        result = await elicit_destructive_confirmation(ctx, "stop_array", "Stops the array.")
+
+        assert result is True
+        elicit.assert_awaited_once()
+
+    async def test_accept_with_confirmed_false_returns_false(self) -> None:
+        """An accept result with the box unchecked (confirmed=False) -> False."""
+        elicit_result = SimpleNamespace(
+            action="accept", data=SimpleNamespace(confirmed=False)
+        )
+        elicit = AsyncMock(return_value=elicit_result)
+        ctx = _make_ctx(elicit)
+
+        result = await elicit_destructive_confirmation(ctx, "stop_array", "Stops the array.")
+
+        assert result is False
+
+    @pytest.mark.parametrize("non_accept_action", ["decline", "cancel", "reject"])
+    async def test_non_accept_result_returns_false(self, non_accept_action: str) -> None:
+        """A decline/cancel/other non-accept result -> False, before data is read."""
+        # data is deliberately absent: a non-accept result must short-circuit
+        # before result.data.confirmed is ever accessed.
+        elicit_result = SimpleNamespace(action=non_accept_action, data=None)
+        elicit = AsyncMock(return_value=elicit_result)
+        ctx = _make_ctx(elicit)
+
+        result = await elicit_destructive_confirmation(ctx, "stop_array", "Stops the array.")
+
+        assert result is False
+        elicit.assert_awaited_once()
+
+    async def test_none_ctx_returns_false_without_elicit(self) -> None:
+        """No MCP context available -> False immediately, no elicitation attempted."""
+        result = await elicit_destructive_confirmation(None, "stop_array", "Stops the array.")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# gate_destructive_action — body integration via the same fake ctx
+# ---------------------------------------------------------------------------
+
+
+class TestGateDestructiveActionElicitationIntegration:
+    """Exercise gate_destructive_action driving the real elicitation body."""
+
+    _DESTRUCTIVE: ClassVar[set[str]] = {"stop_array"}
+    _DESC = "Stops the array."
+
+    async def test_accept_confirmed_passes_gate(self) -> None:
+        """An accepted+confirmed elicitation lets the gate return without raising."""
+        elicit_result = SimpleNamespace(
+            action="accept", data=SimpleNamespace(confirmed=True)
+        )
+        ctx = _make_ctx(AsyncMock(return_value=elicit_result))
+
+        # No exception means the gate passed.
+        await gate_destructive_action(
+            ctx, "stop_array", self._DESTRUCTIVE, confirm=False, description=self._DESC
+        )
+
+    async def test_decline_raises_tool_error(self) -> None:
+        """A declined elicitation raises ToolError mentioning confirm=True bypass."""
+        elicit_result = SimpleNamespace(action="decline", data=None)
+        ctx = _make_ctx(AsyncMock(return_value=elicit_result))
+
+        with pytest.raises(ToolError, match="confirm=True"):
+            await gate_destructive_action(
+                ctx, "stop_array", self._DESTRUCTIVE, confirm=False, description=self._DESC
+            )
+
+    async def test_unsupported_client_raises_tool_error(self) -> None:
+        """When the client can't elicit (NotImplementedError) the gate raises ToolError."""
+        ctx = _make_ctx(AsyncMock(side_effect=NotImplementedError))
+
+        with pytest.raises(ToolError, match="confirm=True"):
+            await gate_destructive_action(
+                ctx, "stop_array", self._DESTRUCTIVE, confirm=False, description=self._DESC
+            )

--- a/tests/test_elicitation.py
+++ b/tests/test_elicitation.py
@@ -46,9 +46,7 @@ class TestElicitDestructiveConfirmation:
 
     async def test_accept_with_confirmed_true_returns_true(self) -> None:
         """An accept result carrying confirmed=True -> True."""
-        elicit_result = SimpleNamespace(
-            action="accept", data=SimpleNamespace(confirmed=True)
-        )
+        elicit_result = SimpleNamespace(action="accept", data=SimpleNamespace(confirmed=True))
         elicit = AsyncMock(return_value=elicit_result)
         ctx = _make_ctx(elicit)
 
@@ -59,9 +57,7 @@ class TestElicitDestructiveConfirmation:
 
     async def test_accept_with_confirmed_false_returns_false(self) -> None:
         """An accept result with the box unchecked (confirmed=False) -> False."""
-        elicit_result = SimpleNamespace(
-            action="accept", data=SimpleNamespace(confirmed=False)
-        )
+        elicit_result = SimpleNamespace(action="accept", data=SimpleNamespace(confirmed=False))
         elicit = AsyncMock(return_value=elicit_result)
         ctx = _make_ctx(elicit)
 
@@ -102,9 +98,7 @@ class TestGateDestructiveActionElicitationIntegration:
 
     async def test_accept_confirmed_passes_gate(self) -> None:
         """An accepted+confirmed elicitation lets the gate return without raising."""
-        elicit_result = SimpleNamespace(
-            action="accept", data=SimpleNamespace(confirmed=True)
-        )
+        elicit_result = SimpleNamespace(action="accept", data=SimpleNamespace(confirmed=True))
         ctx = _make_ctx(AsyncMock(return_value=elicit_result))
 
         # No exception means the gate passed.

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -188,7 +188,7 @@ class TestHealthActions:
             patch("unraid_mcp.subscriptions.manager.subscription_manager", mock_manager),
             patch("unraid_mcp.subscriptions.resources.ensure_subscriptions_started", AsyncMock()),
             patch(
-                "unraid_mcp.subscriptions.utils._analyze_subscription_status",
+                "unraid_mcp.subscriptions.utils.analyze_subscription_status",
                 return_value=(0, []),
             ),
             patch("unraid_mcp.server._error_middleware", mock_error),
@@ -209,7 +209,7 @@ class TestHealthActions:
             patch("unraid_mcp.subscriptions.manager.subscription_manager", mock_manager),
             patch("unraid_mcp.subscriptions.resources.ensure_subscriptions_started", AsyncMock()),
             patch(
-                "unraid_mcp.subscriptions.utils._analyze_subscription_status",
+                "unraid_mcp.subscriptions.utils.analyze_subscription_status",
                 return_value=(0, []),
             ),
             pytest.raises(ToolError, match="Failed to execute health/diagnose"),

--- a/tests/test_help_and_subscriptions.py
+++ b/tests/test_help_and_subscriptions.py
@@ -184,20 +184,30 @@ class TestTestSubscriptionQueryHandler:
         with pytest.raises(ToolError, match="not a mutation or query"):
             await test_subscription_query("mutation { startArray { id } }")
 
-    async def test_allowlisted_field_accepted_end_to_end(self) -> None:
-        """An allowlisted field passes validation and runs the WebSocket probe."""
-        from unraid_mcp.subscriptions.diagnostics import test_subscription_query
-
+    @staticmethod
+    def _mock_ws() -> MagicMock:
         ack = json.dumps({"type": "connection_ack"})
         data_resp = json.dumps(
             {"id": "test", "type": "next", "payload": {"data": {"cpu": {"used": 12}}}}
         )
-
         ws = MagicMock()
         ws.subprotocol = "graphql-transport-ws"
         ws.send = AsyncMock()
         # First recv() -> ack, second recv() -> data response.
         ws.recv = AsyncMock(side_effect=[ack, data_resp])
+        return ws
+
+    async def test_allowlisted_field_accepted_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An allowlisted field passes validation and runs the WebSocket probe.
+
+        With the raw-probe flag enabled, the upstream frame is echoed back.
+        """
+        from unraid_mcp.subscriptions.diagnostics import test_subscription_query
+
+        monkeypatch.setenv("UNRAID_MCP_ENABLE_RAW_SUBSCRIPTION_PROBE", "true")
+        ws = self._mock_ws()
 
         with (
             patch(
@@ -216,5 +226,37 @@ class TestTestSubscriptionQueryHandler:
             result = await test_subscription_query("subscription { cpu { used idle system } }")
 
         assert result["success"] is True
+        assert result["validated_field"] == "cpu"
         assert result["query_tested"] == "subscription { cpu { used idle system } }"
+        # Flag enabled -> raw upstream frame is included.
         assert result["response"]["payload"]["data"]["cpu"]["used"] == 12
+
+    async def test_raw_frame_withheld_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """SEC-M1: by default the probe must NOT echo the raw upstream frame."""
+        from unraid_mcp.subscriptions.diagnostics import test_subscription_query
+
+        monkeypatch.delenv("UNRAID_MCP_ENABLE_RAW_SUBSCRIPTION_PROBE", raising=False)
+        ws = self._mock_ws()
+
+        with (
+            patch(
+                "unraid_mcp.subscriptions.diagnostics.build_ws_url",
+                return_value="ws://localhost:2999/graphql",
+            ),
+            patch(
+                "unraid_mcp.subscriptions.diagnostics.build_ws_ssl_context",
+                return_value=None,
+            ),
+            patch("unraid_mcp.subscriptions.protocol.websockets.connect") as mock_connect,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(return_value=ws)
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            result = await test_subscription_query("subscription { cpu { used idle system } }")
+
+        assert result["success"] is True
+        assert result["first_frame_received"] is True
+        assert result["validated_field"] == "cpu"
+        # No raw frame leaked — response is a withheld-placeholder string, not the dict.
+        assert isinstance(result["response"], str)
+        assert "withheld" in result["response"].lower()

--- a/tests/test_logging_rotation.py
+++ b/tests/test_logging_rotation.py
@@ -78,6 +78,36 @@ def test_no_overwrite_below_cap(tmp_path: Path) -> None:
     handler.close()
 
 
+def test_byte_counter_tracks_disk_size_across_overwrite(tmp_path: Path) -> None:
+    """The in-process byte counter must not drift from the real file size, even
+    across an overwrite.
+
+    Writing past the cap forces at least one overwrite; a handful more records are
+    written after. The counter (_bytes_written) must stay within a couple of bytes
+    of the physical file size. Under the pre-fix one-record undercount (the in-flight
+    record written to the fresh file was never re-accounted), this drifts and fails.
+    """
+    log_path = tmp_path / "test.log"
+    # Small cap so a few records cross it and force an overwrite.
+    handler = _make_handler(log_path, max_bytes=200)
+
+    # Enough records to force at least one overwrite...
+    for _ in range(50):
+        handler.emit(_record("A" * 100))
+    # ...then a handful more after the overwrite.
+    for i in range(5):
+        handler.emit(_record(f"tail {i}"))
+    handler.flush()
+
+    disk_size = log_path.stat().st_size
+    drift = abs(handler._bytes_written - disk_size)
+    assert drift <= 2, (
+        f"byte counter drifted from disk size: counter={handler._bytes_written}, "
+        f"disk={disk_size}, drift={drift}"
+    )
+    handler.close()
+
+
 def test_seeds_byte_counter_from_existing_file(tmp_path: Path) -> None:
     """An already-large existing file triggers an overwrite on the first emit."""
     log_path = tmp_path / "test.log"

--- a/tests/test_logging_rotation.py
+++ b/tests/test_logging_rotation.py
@@ -8,6 +8,8 @@ overwritten (not grown unbounded), and a reset marker is emitted.
 import logging
 from pathlib import Path
 
+import pytest
+
 from unraid_mcp.config.logging import OverwriteFileHandler
 
 
@@ -123,4 +125,33 @@ def test_seeds_byte_counter_from_existing_file(tmp_path: Path) -> None:
     assert "Z" * 500 not in contents
     assert "LOG FILE RESET" in contents
     assert "first line after restart" in contents
+    handler.close()
+
+
+def test_failed_rotation_writes_no_marker_and_keeps_old_stream(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If reopen fails on overwrite, do NOT emit a reset marker and do NOT swap the
+    stream (the marker only belongs on a successfully-opened fresh file)."""
+    handler = _make_handler(tmp_path / "test.log", max_bytes=200)
+    old_stream = handler.stream
+
+    # Spy on every record the handler actually writes (super().emit) so we can assert
+    # the reset marker is never emitted on a failed rotation.
+    written: list[str] = []
+    monkeypatch.setattr(
+        logging.FileHandler, "emit", lambda self, rec: written.append(rec.getMessage())
+    )
+
+    def _boom() -> object:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(handler, "_open", _boom)  # both reopen attempts fail
+
+    handler._bytes_written = handler.max_bytes  # force a rotation attempt
+    rotated = handler._rotate_if_needed()
+
+    assert rotated is False  # reopen failed → no rotation
+    assert handler.stream is old_stream  # stream not swapped
+    assert not any("LOG FILE RESET" in m for m in written)  # marker NOT emitted
     handler.close()

--- a/tests/test_logging_rotation.py
+++ b/tests/test_logging_rotation.py
@@ -1,0 +1,96 @@
+"""Tests for OverwriteFileHandler's overwrite/reset contract.
+
+These exercise the OBSERVABLE behavior through the public handler API (logging a
+record), not private internals: writing enough data crosses the cap, the file is
+overwritten (not grown unbounded), and a reset marker is emitted.
+"""
+
+import logging
+from pathlib import Path
+
+from unraid_mcp.config.logging import OverwriteFileHandler
+
+
+def _make_handler(path: Path, max_bytes: int) -> OverwriteFileHandler:
+    handler = OverwriteFileHandler(path, max_bytes=max_bytes, encoding="utf-8")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    # Force a size check on every emit so tests don't need 100+ records.
+    handler._check_interval = 1
+    return handler
+
+
+def _record(msg: str) -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg=msg,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_file_overwritten_when_cap_crossed(tmp_path: Path) -> None:
+    """Writing past the cap overwrites the file instead of growing it unbounded."""
+    log_path = tmp_path / "test.log"
+    # Small cap so a handful of records crosses it.
+    handler = _make_handler(log_path, max_bytes=200)
+
+    # Each record is ~100 bytes; write well past the cap.
+    for _ in range(50):
+        handler.emit(_record("X" * 100))
+    handler.flush()
+
+    size = log_path.stat().st_size
+    # The file must have been overwritten — bounded near the cap, not 50 * ~100 bytes.
+    assert size < 50 * 100, f"file grew unbounded: {size} bytes"
+    handler.close()
+
+
+def test_reset_marker_emitted_on_overwrite(tmp_path: Path) -> None:
+    """A reset marker line appears in the file after an overwrite occurs."""
+    log_path = tmp_path / "test.log"
+    handler = _make_handler(log_path, max_bytes=200)
+
+    for _ in range(50):
+        handler.emit(_record("Y" * 100))
+    handler.flush()
+
+    contents = log_path.read_text(encoding="utf-8")
+    assert "LOG FILE RESET" in contents, "reset marker was never written"
+    handler.close()
+
+
+def test_no_overwrite_below_cap(tmp_path: Path) -> None:
+    """Staying under the cap leaves the file intact with no reset marker."""
+    log_path = tmp_path / "test.log"
+    handler = _make_handler(log_path, max_bytes=10 * 1024 * 1024)
+
+    for i in range(20):
+        handler.emit(_record(f"line {i}"))
+    handler.flush()
+
+    contents = log_path.read_text(encoding="utf-8")
+    assert "LOG FILE RESET" not in contents
+    assert "line 0" in contents
+    assert "line 19" in contents
+    handler.close()
+
+
+def test_seeds_byte_counter_from_existing_file(tmp_path: Path) -> None:
+    """An already-large existing file triggers an overwrite on the first emit."""
+    log_path = tmp_path / "test.log"
+    # Pre-fill the file past the cap before the handler is created.
+    log_path.write_text("Z" * 500, encoding="utf-8")
+
+    handler = _make_handler(log_path, max_bytes=200)
+    handler.emit(_record("first line after restart"))
+    handler.flush()
+
+    contents = log_path.read_text(encoding="utf-8")
+    # The pre-existing oversized content must have been discarded.
+    assert "Z" * 500 not in contents
+    assert "LOG FILE RESET" in contents
+    assert "first line after restart" in contents
+    handler.close()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,6 +1,6 @@
 """Unit tests for the shared client-side list-capping helper."""
 
-from unraid_mcp.core.pagination import DEFAULT_LIST_LIMIT, cap_list
+from unraid_mcp.core.pagination import DEFAULT_LIST_LIMIT, _item_bytes, cap_list
 
 
 def test_default_list_limit_matches_documented_tool_default():
@@ -66,3 +66,98 @@ def test_custom_default():
     capped, meta = cap_list(items, limit=None, default=5)
     assert len(capped) == 5
     assert meta["truncated"] is True
+
+
+def test_byte_budget_truncates_below_numeric_limit():
+    """Large items trip the byte ceiling before the count cap is reached."""
+    # Each item serializes to ~100 bytes; a 250-byte budget keeps ~2-3 items.
+    items = [{"data": "x" * 90} for _ in range(50)]
+    per_item = _item_bytes(items[0])
+    capped, meta = cap_list(items, limit=50, byte_budget=250)
+    # Trimmed below the numeric limit of 50.
+    assert len(capped) < 50
+    assert len(capped) >= 1
+    assert meta["returned"] == len(capped)
+    assert meta["total"] == 50
+    assert meta["truncated"] is True
+    # Byte-cap hint differs from the count-cap wording.
+    assert "bytes to fit the response budget" in meta["hint"]
+    assert "narrow the query" in meta["hint"]
+    assert f"~{250} bytes" in meta["hint"]
+    # Sanity: the kept items roughly track the budget given per-item size.
+    assert len(capped) <= 250 // per_item + 1
+
+
+def test_byte_budget_single_oversized_item_still_returned():
+    """A lone item larger than the entire budget is kept (kept > 0 guard)."""
+    items = [{"data": "y" * 5000}]
+    capped, meta = cap_list(items, limit=20, byte_budget=10)
+    assert len(capped) == 1
+    assert capped != []
+    assert meta["returned"] == 1
+    assert meta["total"] == 1
+    # Single oversized item alone does not exceed the count cap, and the byte
+    # guard never trims below one item, so it is not flagged truncated here.
+    assert meta["truncated"] is False
+
+
+def test_byte_budget_oversized_first_then_more_keeps_at_least_one():
+    """When more items follow a huge first item, at least the first is kept."""
+    items = [{"data": "z" * 5000}, {"data": "z" * 5000}, {"data": "z" * 5000}]
+    capped, meta = cap_list(items, limit=20, byte_budget=10)
+    assert len(capped) == 1
+    assert capped != []
+    assert meta["returned"] == 1
+    assert meta["total"] == 3
+    assert meta["truncated"] is True
+    assert "bytes to fit the response budget" in meta["hint"]
+
+
+def test_count_cap_takes_precedence_when_budget_generous():
+    """A generous byte_budget yields exactly the count-capped slice + count hint."""
+    items = list(range(100))
+    capped, meta = cap_list(items, limit=5, byte_budget=10_000_000)
+    assert capped == list(range(5))
+    assert meta["returned"] == 5
+    assert meta["total"] == 100
+    assert meta["truncated"] is True
+    # Count-cap hint wording, not the byte-cap wording.
+    assert "pass a larger limit=" in meta["hint"]
+    assert "bytes to fit the response budget" not in meta["hint"]
+
+
+def test_byte_budget_zero_disables_ceiling():
+    """byte_budget=0 leaves the count-capped slice unchanged."""
+    items = [{"data": "x" * 200} for _ in range(10)]
+    capped, meta = cap_list(items, limit=5, byte_budget=0)
+    assert len(capped) == 5
+    assert meta == {
+        "returned": 5,
+        "total": 10,
+        "truncated": True,
+        "hint": (
+            "showing 5 of 10 items; pass a larger limit= "
+            "to see more (limit=0 for all)"
+        ),
+    }
+
+
+def test_byte_budget_none_disables_ceiling():
+    """byte_budget=None (the default) preserves count-only behavior."""
+    items = [{"data": "x" * 200} for _ in range(3)]
+    capped, meta = cap_list(items, limit=10, byte_budget=None)
+    assert capped == items
+    assert meta == {"returned": 3, "total": 3, "truncated": False}
+
+
+def test_item_bytes_non_serializable_falls_back_to_str():
+    """_item_bytes never raises on an item json.dumps cannot encode.
+
+    A circular reference makes ``json.dumps`` raise ``ValueError`` even with
+    ``default=str``, exercising the ``str()`` fallback branch.
+    """
+    circular: list = []
+    circular.append(circular)
+    size = _item_bytes(circular)
+    assert size == len(str(circular).encode())
+    assert size > 0

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -135,10 +135,7 @@ def test_byte_budget_zero_disables_ceiling():
         "returned": 5,
         "total": 10,
         "truncated": True,
-        "hint": (
-            "showing 5 of 10 items; pass a larger limit= "
-            "to see more (limit=0 for all)"
-        ),
+        "hint": ("showing 5 of 10 items; pass a larger limit= to see more (limit=0 for all)"),
     }
 
 

--- a/tests/test_reconnect_backoff.py
+++ b/tests/test_reconnect_backoff.py
@@ -1,0 +1,66 @@
+"""Unit tests for the reconnect-backoff decision (PERF-H2).
+
+Pins the invariant that a backend flapping just past the stable threshold can
+neither pin the reconnect cadence at the floor nor dodge the give-up ceiling.
+The logic was extracted from the 268-line `_subscription_loop` into the pure
+`_compute_reconnect_delay` helper precisely so it could be tested here.
+"""
+
+import pytest
+
+from unraid_mcp.subscriptions.manager import (
+    _HEALTHY_CONNECTION_SECONDS,
+    _INITIAL_RETRY_DELAY,
+    _MAX_RETRY_DELAY,
+    _STABLE_CONNECTION_SECONDS,
+    SubscriptionManager,
+)
+
+
+_compute = SubscriptionManager._compute_reconnect_delay
+
+
+class TestComputeReconnectDelay:
+    def test_healthy_connection_resets_backoff_and_attempts(self) -> None:
+        delay, reset = _compute(_HEALTHY_CONNECTION_SECONDS + 1, 80.0)
+        assert delay == _INITIAL_RETRY_DELAY
+        assert reset is True
+
+    def test_briefly_stable_escalates_backoff_but_resets_attempts(self) -> None:
+        # A 31s flap must NOT pin backoff at the floor — it escalates — but keeps
+        # the attempt counter reset so we don't abandon a reachable backend.
+        delay, reset = _compute(_STABLE_CONNECTION_SECONDS + 1, 10.0)
+        assert delay == pytest.approx(15.0)  # 10 * 1.5
+        assert reset is True
+
+    def test_briefly_stable_does_not_reset_to_floor(self) -> None:
+        # The PERF-H2 bug: a 31s connection used to reset backoff to 5 every time,
+        # pinning the reconnect cadence and dodging the give-up ceiling.
+        delay, _ = _compute(_STABLE_CONNECTION_SECONDS + 1, _INITIAL_RETRY_DELAY)
+        assert delay > _INITIAL_RETRY_DELAY
+
+    def test_never_stable_escalates_and_climbs_toward_giveup(self) -> None:
+        delay, reset = _compute(2.0, 20.0)
+        assert delay == pytest.approx(30.0)  # 20 * 1.5
+        assert reset is False  # attempt counter is NOT reset -> climbs to give-up
+
+    def test_no_connection_established_escalates(self) -> None:
+        delay, reset = _compute(0.0, _INITIAL_RETRY_DELAY)
+        assert delay == pytest.approx(7.5)
+        assert reset is False
+
+    def test_backoff_capped(self) -> None:
+        delay, _ = _compute(0.0, _MAX_RETRY_DELAY)
+        assert delay == _MAX_RETRY_DELAY
+
+    def test_repeated_flap_backoff_grows_monotonically(self) -> None:
+        # A backend that flaps at ~31s repeatedly: backoff must keep growing even
+        # though the attempt counter is reset each cycle.
+        delay = _INITIAL_RETRY_DELAY
+        delays = []
+        for _ in range(6):
+            delay, reset = _compute(_STABLE_CONNECTION_SECONDS + 1, delay)
+            assert reset is True
+            delays.append(delay)
+        assert delays == sorted(delays)
+        assert delays[-1] > delays[0]

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -188,15 +188,46 @@ class TestEnsureSubscriptionsStarted:
             res._subscriptions_started = False
             res._last_startup_error = None
 
-    async def test_failed_autostart_latches_and_records_error(self, _reset_startup_state) -> None:
+    async def test_failed_autostart_without_spawned_loops_retries(
+        self, _reset_startup_state
+    ) -> None:
+        """No loops spawned (config/programming error) -> do NOT latch, retry every call."""
         res = _reset_startup_state
         mock = AsyncMock(side_effect=RuntimeError("ws backend down"))
-        with patch.object(res, "autostart_subscriptions", mock):
+        # No subscription loops were actually spawned.
+        with (
+            patch.object(res, "autostart_subscriptions", mock),
+            patch.object(res.subscription_manager, "active_subscriptions", {}),
+        ):
             await res.ensure_subscriptions_started()
             await res.ensure_subscriptions_started()
             await res.ensure_subscriptions_started()
-        # Latched after the first attempt — no per-call autostart stampede (PERF-H1).
+        # Flag left unset -> autostart retried on every call (no permanent brick).
+        assert mock.call_count == 3
+        assert res._subscriptions_started is False
+        # Error still recorded and observable instead of swallowed (C1).
+        err = res.get_last_startup_error()
+        assert err is not None and "ws backend down" in err
+
+    async def test_failed_autostart_with_spawned_loops_latches(
+        self, _reset_startup_state
+    ) -> None:
+        """At least one loop spawned (self-healing) -> latch, no per-call stampede (PERF-H1)."""
+        res = _reset_startup_state
+        mock = AsyncMock(side_effect=RuntimeError("ws backend down"))
+        # A subscription loop was spawned before the failure -> active_subscriptions non-empty.
+        with (
+            patch.object(res, "autostart_subscriptions", mock),
+            patch.object(
+                res.subscription_manager, "active_subscriptions", {"systemMetricsCpu": object()}
+            ),
+        ):
+            await res.ensure_subscriptions_started()
+            await res.ensure_subscriptions_started()
+            await res.ensure_subscriptions_started()
+        # Latched after the first attempt — spawned loops self-heal via reconnect.
         assert mock.call_count == 1
+        assert res._subscriptions_started is True
         # Error recorded and observable instead of swallowed (C1).
         err = res.get_last_startup_error()
         assert err is not None and "ws backend down" in err

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -170,3 +170,55 @@ class TestAutoStartDisabledFallback:
             resource = _get_resource(mcp, f"unraid://live/{action}")
             result = await resource.fn()
         assert json.loads(result)["status"] == "connecting"
+
+
+class TestEnsureSubscriptionsStarted:
+    """C1 / PERF-H1: a failed autostart must latch (no stampede) and surface the
+    error, instead of being silently swallowed and re-attempted on every call."""
+
+    @pytest.fixture
+    def _reset_startup_state(self):
+        import unraid_mcp.subscriptions.resources as res
+
+        res._subscriptions_started = False
+        res._last_startup_error = None
+        try:
+            yield res
+        finally:
+            res._subscriptions_started = False
+            res._last_startup_error = None
+
+    async def test_failed_autostart_latches_and_records_error(self, _reset_startup_state) -> None:
+        res = _reset_startup_state
+        mock = AsyncMock(side_effect=RuntimeError("ws backend down"))
+        with patch.object(res, "autostart_subscriptions", mock):
+            await res.ensure_subscriptions_started()
+            await res.ensure_subscriptions_started()
+            await res.ensure_subscriptions_started()
+        # Latched after the first attempt — no per-call autostart stampede (PERF-H1).
+        assert mock.call_count == 1
+        # Error recorded and observable instead of swallowed (C1).
+        err = res.get_last_startup_error()
+        assert err is not None and "ws backend down" in err
+
+    async def test_successful_autostart_clears_error(self, _reset_startup_state) -> None:
+        res = _reset_startup_state
+        mock = AsyncMock()
+        with patch.object(res, "autostart_subscriptions", mock):
+            await res.ensure_subscriptions_started()
+            await res.ensure_subscriptions_started()
+        assert mock.call_count == 1
+        assert res.get_last_startup_error() is None
+
+    async def test_cancellation_does_not_latch(self, _reset_startup_state) -> None:
+        import asyncio
+
+        res = _reset_startup_state
+        mock = AsyncMock(side_effect=asyncio.CancelledError())
+        with (
+            patch.object(res, "autostart_subscriptions", mock),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await res.ensure_subscriptions_started()
+        # Shutdown path: flag NOT latched so a later call can retry.
+        assert res._subscriptions_started is False

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -209,9 +209,7 @@ class TestEnsureSubscriptionsStarted:
         err = res.get_last_startup_error()
         assert err is not None and "ws backend down" in err
 
-    async def test_failed_autostart_with_spawned_loops_latches(
-        self, _reset_startup_state
-    ) -> None:
+    async def test_failed_autostart_with_spawned_loops_latches(self, _reset_startup_state) -> None:
         """At least one loop spawned (self-healing) -> latch, no per-call stampede (PERF-H1)."""
         res = _reset_startup_state
         mock = AsyncMock(side_effect=RuntimeError("ws backend down"))

--- a/tests/test_response_limit.py
+++ b/tests/test_response_limit.py
@@ -139,6 +139,38 @@ def test_measure_multi_content_falls_back_to_full_serialization():
     assert mw._measure(result) == len(pydantic_core.to_json(result, fallback=str))
 
 
+def test_measure_multi_text_over_cap_short_circuits():
+    """Multi text-block running sum over the cap returns the byte lower bound (> cap)
+    without a full pydantic serialization (the early-bail path)."""
+    mw = StructuredResponseLimitingMiddleware(max_size=10)
+    result = ToolResult(
+        content=[
+            TextContent(type="text", text="x" * 8),
+            TextContent(type="text", text="y" * 8),  # running 16 > 10 → early return
+        ]
+    )
+
+    measured = mw._measure(result)
+    assert measured == 16  # text-byte lower bound, NOT full serialization
+    assert measured > mw.max_size
+
+
+def test_measure_non_text_block_forces_full_serialization():
+    """A non-TextContent block breaks the cheap estimate and forces full measurement."""
+    import pydantic_core
+    from mcp.types import ImageContent
+
+    mw = StructuredResponseLimitingMiddleware(max_size=131072)
+    result = ToolResult(
+        content=[
+            TextContent(type="text", text="a"),
+            ImageContent(type="image", data="QUJD", mimeType="image/png"),
+        ]
+    )
+
+    assert mw._measure(result) == len(pydantic_core.to_json(result, fallback=str))
+
+
 async def test_single_text_content_cap_decision_matches_text_bytes():
     """The cap decision for a single TextContent keys off the text byte length."""
     cap = 100

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -49,6 +49,12 @@ class TestFormatBytes:
     def test_none(self) -> None:
         assert format_bytes(None) == "N/A"
 
+    def test_non_finite_floats_return_na(self) -> None:
+        # int(inf) raises OverflowError, int(nan) raises ValueError — _coerce_int
+        # maps both to None → "N/A" rather than letting them escape.
+        assert format_bytes(float("inf")) == "N/A"
+        assert format_bytes(float("nan")) == "N/A"
+
     def test_bytes(self) -> None:
         assert format_bytes(512) == "512.00 B"
 

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -1,7 +1,10 @@
 """Tests for _validate_subscription_query in diagnostics.py.
 
 Security-critical: this function is the only guard against arbitrary GraphQL
-operations (mutations, queries) being sent over the WebSocket subscription channel.
+operations (mutations, queries) or non-allowlisted subscription fields being sent
+over the authenticated WebSocket subscription channel. Validation runs on the
+parsed GraphQL AST (graphql-core), which closes the multi-field / alias /
+argument smuggling bypasses a first-field-only regex allowlist permits (SEC-H1).
 """
 
 import pytest
@@ -14,124 +17,127 @@ from unraid_mcp.subscriptions.diagnostics import (
 
 
 class TestValidateSubscriptionQueryAllowed:
-    """All whitelisted subscription names must be accepted."""
+    """All whitelisted subscription field names must be accepted."""
 
     @pytest.mark.parametrize("sub_name", sorted(_ALLOWED_SUBSCRIPTION_FIELDS))
     def test_all_allowed_names_accepted(self, sub_name: str) -> None:
         query = f"subscription {{ {sub_name} {{ data }} }}"
-        result = _validate_subscription_query(query)
-        assert result == sub_name
+        assert _validate_subscription_query(query) == sub_name
 
     def test_returns_extracted_subscription_name(self) -> None:
-        query = "subscription { cpu { usage } }"
-        assert _validate_subscription_query(query) == "cpu"
+        assert _validate_subscription_query("subscription { cpu { usage } }") == "cpu"
 
     def test_leading_whitespace_accepted(self) -> None:
-        query = "  subscription { memory { free } }"
-        assert _validate_subscription_query(query) == "memory"
+        assert _validate_subscription_query("  subscription { memory { free } }") == "memory"
 
     def test_multiline_query_accepted(self) -> None:
         query = "subscription {\n  cpu {\n    used\n  }\n}"
         assert _validate_subscription_query(query) == "cpu"
 
-    def test_case_insensitive_subscription_keyword(self) -> None:
-        """'SUBSCRIPTION' should be accepted (regex uses IGNORECASE)."""
-        query = "SUBSCRIPTION { cpu { usage } }"
-        assert _validate_subscription_query(query) == "cpu"
+    def test_subfield_named_like_keyword_accepted(self) -> None:
+        """A *subfield* literally named like 'mutation'/'query' is fine — only the
+        operation type matters. (The old bare-word regex false-rejected these.)"""
+        assert _validate_subscription_query("subscription { cpu { mutationField } }") == "cpu"
+        assert _validate_subscription_query("subscription { cpu { queryResult } }") == "cpu"
 
 
-class TestValidateSubscriptionQueryForbiddenKeywords:
-    """Queries containing 'mutation' or 'query' as standalone keywords must be rejected."""
+class TestValidateSubscriptionQueryWrongOperation:
+    """Non-subscription operations must be rejected."""
 
-    def test_mutation_keyword_rejected(self) -> None:
-        query = 'mutation { docker { start(id: "abc") } }'
-        with pytest.raises(ToolError, match="must be a subscription"):
-            _validate_subscription_query(query)
+    def test_mutation_operation_rejected(self) -> None:
+        with pytest.raises(ToolError, match="not a mutation or query"):
+            _validate_subscription_query('mutation { docker { start(id: "abc") } }')
 
-    def test_query_keyword_rejected(self) -> None:
-        query = "query { info { os { platform } } }"
-        with pytest.raises(ToolError, match="must be a subscription"):
-            _validate_subscription_query(query)
+    def test_query_operation_rejected(self) -> None:
+        with pytest.raises(ToolError, match="not a mutation or query"):
+            _validate_subscription_query("query { info { os { platform } } }")
 
-    def test_mutation_embedded_in_subscription_rejected(self) -> None:
-        """'mutation' anywhere in the string triggers rejection."""
-        query = "subscription { cpuSubscription { mutation data } }"
-        with pytest.raises(ToolError, match="must be a subscription"):
-            _validate_subscription_query(query)
-
-    def test_query_embedded_in_subscription_rejected(self) -> None:
-        query = "subscription { cpuSubscription { query data } }"
-        with pytest.raises(ToolError, match="must be a subscription"):
-            _validate_subscription_query(query)
-
-    def test_mutation_case_insensitive_rejection(self) -> None:
-        query = 'MUTATION { docker { start(id: "abc") } }'
-        with pytest.raises(ToolError, match="must be a subscription"):
-            _validate_subscription_query(query)
-
-    def test_mutation_field_identifier_not_rejected(self) -> None:
-        """'mutationField' as an identifier must NOT be rejected — only standalone 'mutation'."""
-        # This tests the \b word boundary in _FORBIDDEN_KEYWORDS
-        query = "subscription { cpu { mutationField } }"
-        # Should not raise — "mutationField" is an identifier, not the keyword
-        result = _validate_subscription_query(query)
-        assert result == "cpu"
-
-    def test_query_field_identifier_not_rejected(self) -> None:
-        """'queryResult' as an identifier must NOT be rejected."""
-        query = "subscription { cpu { queryResult } }"
-        result = _validate_subscription_query(query)
-        assert result == "cpu"
+    def test_uppercase_operation_keyword_rejected(self) -> None:
+        """GraphQL is case-sensitive: 'SUBSCRIPTION' is not a valid operation
+        keyword, so the document fails to parse (the old IGNORECASE regex wrongly
+        accepted it and would have forwarded an invalid query upstream)."""
+        with pytest.raises(ToolError, match="not a valid GraphQL document"):
+            _validate_subscription_query("SUBSCRIPTION { cpu { usage } }")
 
 
 class TestValidateSubscriptionQueryInvalidFormat:
-    """Queries that don't match the expected subscription format must be rejected."""
+    """Syntactically invalid documents must be rejected as such."""
 
-    def test_empty_string_rejected(self) -> None:
-        with pytest.raises(ToolError, match="must start with 'subscription'"):
-            _validate_subscription_query("")
-
-    def test_plain_identifier_rejected(self) -> None:
-        with pytest.raises(ToolError, match="must start with 'subscription'"):
-            _validate_subscription_query("cpuSubscription { usage }")
-
-    def test_missing_operation_body_rejected(self) -> None:
-        with pytest.raises(ToolError, match="must start with 'subscription'"):
-            _validate_subscription_query("subscription")
-
-    def test_subscription_without_field_rejected(self) -> None:
-        """subscription { } with no field name doesn't match the pattern."""
-        with pytest.raises(ToolError, match="must start with 'subscription'"):
-            _validate_subscription_query("subscription {  }")
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "cpuSubscription { usage }",
+            "subscription",
+            "subscription {  }",
+        ],
+    )
+    def test_invalid_graphql_rejected(self, bad: str) -> None:
+        with pytest.raises(ToolError, match="not a valid GraphQL document"):
+            _validate_subscription_query(bad)
 
 
 class TestValidateSubscriptionQueryUnknownName:
-    """Subscription names not in the whitelist must be rejected even if format is valid."""
+    """Valid subscriptions selecting a non-allowlisted field must be rejected."""
 
     def test_unknown_subscription_name_rejected(self) -> None:
-        query = "subscription { unknownSubscription { data } }"
         with pytest.raises(ToolError, match="not allowed"):
-            _validate_subscription_query(query)
+            _validate_subscription_query("subscription { unknownSubscription { data } }")
 
     def test_error_message_includes_allowed_list(self) -> None:
-        """Error message must list the allowed subscription field names for usability."""
-        query = "subscription { badSub { data } }"
         with pytest.raises(ToolError, match="Allowed fields"):
-            _validate_subscription_query(query)
+            _validate_subscription_query("subscription { badSub { data } }")
 
     def test_arbitrary_field_name_rejected(self) -> None:
-        query = "subscription { users { id email } }"
         with pytest.raises(ToolError, match="not allowed"):
-            _validate_subscription_query(query)
+            _validate_subscription_query("subscription { users { id email } }")
 
     def test_logfile_rejected_security(self) -> None:
         """logFile allows arbitrary file reads via path argument — must be blocked."""
-        query = 'subscription { logFile(path: "/etc/shadow") { content } }'
         with pytest.raises(ToolError, match="not allowed"):
-            _validate_subscription_query(query)
+            _validate_subscription_query(
+                'subscription { logFile(path: "/etc/shadow") { content } }'
+            )
 
     def test_close_but_not_whitelisted_rejected(self) -> None:
         """'cpuSubscription' (old operation-style name) is not in the field allow-list."""
-        query = "subscription { cpuSubscription { usage } }"
         with pytest.raises(ToolError, match="not allowed"):
+            _validate_subscription_query("subscription { cpuSubscription { usage } }")
+
+
+class TestValidateSubscriptionQueryBypassRegression:
+    """SEC-H1: a regex allowlist that checks only the first selected field is
+    bypassable. The AST validator must reject every smuggling vector below.
+
+    These tests would PASS validation (i.e. fail to reject) under the old
+    first-field-only regex — they pin the fix.
+    """
+
+    def test_second_disallowed_field_rejected(self) -> None:
+        """The PoC: an allowed first field plus a disallowed second field. The old
+        regex returned 'cpu' and forwarded the whole query to the authed WS."""
+        with pytest.raises(ToolError, match="exactly one top-level field"):
+            _validate_subscription_query("subscription { cpu { used } secretAdminField { token } }")
+
+    def test_two_allowlisted_fields_still_rejected(self) -> None:
+        """Even two *allowed* fields are rejected — the probe tests exactly one."""
+        with pytest.raises(ToolError, match="exactly one top-level field"):
+            _validate_subscription_query("subscription { cpu { used } memory { free } }")
+
+    def test_alias_smuggling_rejected(self) -> None:
+        """An allowed-looking alias over a disallowed *real* field must be rejected —
+        the real field name is what is validated."""
+        with pytest.raises(ToolError, match="not allowed"):
+            _validate_subscription_query("subscription { cpu: secretAdminField { token } }")
+
+    def test_alias_over_allowed_field_accepted(self) -> None:
+        """An alias over an allowed real field is fine (real name is allowlisted)."""
+        assert _validate_subscription_query("subscription { myCpu: cpu { used } }") == "cpu"
+
+    def test_top_level_fragment_spread_rejected(self) -> None:
+        """A top-level fragment spread could smuggle a disallowed field — reject it."""
+        query = (
+            "subscription { ...evil } fragment evil on Subscription { secretAdminField { token } }"
+        )
+        with pytest.raises(ToolError):
             _validate_subscription_query(query)

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -141,3 +141,24 @@ class TestValidateSubscriptionQueryBypassRegression:
         )
         with pytest.raises(ToolError):
             _validate_subscription_query(query)
+
+
+class TestValidateSubscriptionQuerySizeAndFragments:
+    """PR-review hardening: input size cap (DoS) and orphan-fragment rejection."""
+
+    def test_oversized_query_rejected_before_parse(self) -> None:
+        # Over the char cap → rejected WITHOUT invoking the linear-time GraphQL
+        # parser, preventing an event-loop stall on a multi-MB input (CWE-400).
+        huge = "subscription { cpu { " + "x " * 5000 + "} }"
+        with pytest.raises(ToolError, match="exceeds the maximum length"):
+            _validate_subscription_query(huge)
+
+    def test_orphan_fragment_definition_rejected(self) -> None:
+        # An extra (orphan) fragment definition rides along to the upstream WS
+        # unused — the document must contain exactly one (subscription) definition.
+        query = (
+            "subscription { cpu { used } } "
+            "fragment Evil on Subscription { notificationsWarningsAndAlerts { message } }"
+        )
+        with pytest.raises(ToolError, match="exactly one subscription operation"):
+            _validate_subscription_query(query)

--- a/unraid_mcp/config/logging.py
+++ b/unraid_mcp/config/logging.py
@@ -97,18 +97,20 @@ class OverwriteFileHandler(logging.FileHandler):
             # Reset the byte counter now that we are writing to a fresh file.
             self._bytes_written = 0
 
-        if self.stream is not None:
-            reset_record = logging.LogRecord(
-                name="UnraidMCPServer.Logging",
-                level=logging.INFO,
-                pathname="",
-                lineno=0,
-                msg="=== LOG FILE RESET (10MB limit reached) ===",
-                args=(),
-                exc_info=None,
-            )
-            super().emit(reset_record)
-            self._account_for(reset_record)
+            # Write the reset marker ONLY on a successful overwrite — otherwise we'd
+            # stamp "LOG FILE RESET" onto the old, un-reset file (reopen failed).
+            if self.stream is not None:
+                reset_record = logging.LogRecord(
+                    name="UnraidMCPServer.Logging",
+                    level=logging.INFO,
+                    pathname="",
+                    lineno=0,
+                    msg="=== LOG FILE RESET (10MB limit reached) ===",
+                    args=(),
+                    exc_info=None,
+                )
+                super().emit(reset_record)
+                self._account_for(reset_record)
 
         return rotated
 

--- a/unraid_mcp/config/logging.py
+++ b/unraid_mcp/config/logging.py
@@ -53,17 +53,22 @@ class OverwriteFileHandler(logging.FileHandler):
         except OSError:
             self._bytes_written = 0
 
-    def _rotate_if_needed(self) -> None:
+    def _rotate_if_needed(self) -> bool:
         """Overwrite the log file if the accumulated byte count crossed the cap.
 
         Opens a fresh stream (deleting the old file first), atomically swaps it in,
         resets the in-process byte counter, and writes a reset marker. On repeated
         open failure, logging silently continues on the existing stream.
+
+        Returns ``True`` if the file was actually overwritten (the byte counter was
+        reset), so the caller can re-account the in-flight record against the fresh
+        file — the record is written to the *new* file but was counted against the
+        old one before the reset.
         """
         if self._bytes_written < self.max_bytes:
-            return
+            return False
         if not (self.stream and hasattr(self.stream, "name")):
-            return
+            return False
 
         base_path = Path(self.baseFilename)
         # Open new file FIRST, then swap — self.stream is never None.
@@ -83,7 +88,8 @@ class OverwriteFileHandler(logging.FileHandler):
                 )
                 new_stream = None
 
-        if new_stream is not None:
+        rotated = new_stream is not None
+        if rotated:
             old_stream = self.stream
             self.stream = new_stream  # atomic swap
             if old_stream is not None:
@@ -104,6 +110,8 @@ class OverwriteFileHandler(logging.FileHandler):
             super().emit(reset_record)
             self._account_for(reset_record)
 
+        return rotated
+
     def _account_for(self, record: logging.LogRecord) -> None:
         """Add the byte size of a formatted record to the in-process counter."""
         try:
@@ -119,11 +127,18 @@ class OverwriteFileHandler(logging.FileHandler):
         """Emit a record, checking accumulated size periodically and overwriting if needed."""
         self._emit_count += 1
         self._account_for(record)
+        rotated = False
         if self._emit_count == 1 or self._emit_count % self._check_interval == 0:
-            self._rotate_if_needed()
+            rotated = self._rotate_if_needed()
 
         # Emit the original record
         super().emit(record)
+
+        if rotated:
+            # This record was counted against the pre-rotation file but is physically
+            # written to the fresh file above. Re-account it so the new file's counter
+            # reflects what it actually holds (fixes a one-record undercount per cycle).
+            self._account_for(record)
 
 
 def _create_shared_file_handler() -> OverwriteFileHandler:

--- a/unraid_mcp/config/logging.py
+++ b/unraid_mcp/config/logging.py
@@ -41,62 +41,86 @@ class OverwriteFileHandler(logging.FileHandler):
         self.max_bytes = max_bytes
         self._emit_count = 0
         self._check_interval = 100
+        # In-process byte counter — accumulates the size of each formatted record so
+        # the periodic size check no longer needs a stat()/exists() syscall on the
+        # event-loop thread. Seeded below from the existing file size (append mode).
+        self._bytes_written = 0
         super().__init__(filename, mode, encoding, delay)
+        try:
+            base_path = Path(self.baseFilename)
+            if base_path.exists():
+                self._bytes_written = base_path.stat().st_size
+        except OSError:
+            self._bytes_written = 0
 
-    def emit(self, record: logging.LogRecord) -> None:
-        """Emit a record, checking file size periodically and overwriting if needed."""
-        self._emit_count += 1
-        if (
-            (self._emit_count == 1 or self._emit_count % self._check_interval == 0)
-            and self.stream
-            and hasattr(self.stream, "name")
-        ):
+    def _rotate_if_needed(self) -> None:
+        """Overwrite the log file if the accumulated byte count crossed the cap.
+
+        Opens a fresh stream (deleting the old file first), atomically swaps it in,
+        resets the in-process byte counter, and writes a reset marker. On repeated
+        open failure, logging silently continues on the existing stream.
+        """
+        if self._bytes_written < self.max_bytes:
+            return
+        if not (self.stream and hasattr(self.stream, "name")):
+            return
+
+        base_path = Path(self.baseFilename)
+        # Open new file FIRST, then swap — self.stream is never None.
+        try:
+            base_path.unlink(missing_ok=True)
+            new_stream = self._open()
+        except OSError:
             try:
-                base_path = Path(self.baseFilename)
-                file_size = base_path.stat().st_size if base_path.exists() else 0
-                if file_size >= self.max_bytes:
-                    # Open new file FIRST, then swap — self.stream is never None.
-                    try:
-                        base_path.unlink(missing_ok=True)
-                        new_stream = self._open()
-                    except OSError:
-                        try:
-                            new_stream = self._open()
-                        except OSError:
-                            import sys
-
-                            print(
-                                "WARNING: Failed to reopen log file after rotation. "
-                                "File logging continues on old stream.",
-                                file=sys.stderr,
-                            )
-                            new_stream = None
-
-                    if new_stream is not None:
-                        old_stream = self.stream
-                        self.stream = new_stream  # atomic swap
-                        if old_stream is not None:
-                            old_stream.close()
-
-                    if self.stream is not None:
-                        reset_record = logging.LogRecord(
-                            name="UnraidMCPServer.Logging",
-                            level=logging.INFO,
-                            pathname="",
-                            lineno=0,
-                            msg="=== LOG FILE RESET (10MB limit reached) ===",
-                            args=(),
-                            exc_info=None,
-                        )
-                        super().emit(reset_record)
-
-            except OSError as e:
+                new_stream = self._open()
+            except OSError:
                 import sys
 
                 print(
-                    f"WARNING: Log file size check failed: {e}. Continuing without rotation.",
+                    "WARNING: Failed to reopen log file after rotation. "
+                    "File logging continues on old stream.",
                     file=sys.stderr,
                 )
+                new_stream = None
+
+        if new_stream is not None:
+            old_stream = self.stream
+            self.stream = new_stream  # atomic swap
+            if old_stream is not None:
+                old_stream.close()
+            # Reset the byte counter now that we are writing to a fresh file.
+            self._bytes_written = 0
+
+        if self.stream is not None:
+            reset_record = logging.LogRecord(
+                name="UnraidMCPServer.Logging",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="=== LOG FILE RESET (10MB limit reached) ===",
+                args=(),
+                exc_info=None,
+            )
+            super().emit(reset_record)
+            self._account_for(reset_record)
+
+    def _account_for(self, record: logging.LogRecord) -> None:
+        """Add the byte size of a formatted record to the in-process counter."""
+        try:
+            enc = self.encoding or "utf-8"
+            self._bytes_written += len(self.format(record).encode(enc))
+            self._bytes_written += len(self.terminator.encode(enc))
+        except (LookupError, UnicodeError, TypeError, ValueError):
+            # Accounting must never break logging; a single missed measurement just
+            # delays the next size check slightly.
+            return
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Emit a record, checking accumulated size periodically and overwriting if needed."""
+        self._emit_count += 1
+        self._account_for(record)
+        if self._emit_count == 1 or self._emit_count % self._check_interval == 0:
+            self._rotate_if_needed()
 
         # Emit the original record
         super().emit(record)

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -129,7 +129,11 @@ class Settings(BaseSettings):
 
     # Server Configuration
     unraid_mcp_port: int = Field(default=6970, alias="UNRAID_MCP_PORT")
-    unraid_mcp_host: str = Field(default="0.0.0.0", alias="UNRAID_MCP_HOST")  # noqa: S104
+    # Default to loopback so a bare-metal HTTP run is not LAN-exposed unless the
+    # operator explicitly opts in (S-H3 / SEC-M3). The Docker image sets
+    # UNRAID_MCP_HOST=0.0.0.0 itself, since the container must bind all interfaces
+    # for the (loopback-published) port to be reachable from the host.
+    unraid_mcp_host: str = Field(default="127.0.0.1", alias="UNRAID_MCP_HOST")
     unraid_mcp_transport: str = Field(default="streamable-http", alias="UNRAID_MCP_TRANSPORT")
 
     # Maximum serialized tool-response size in bytes. Responses larger than this are

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -367,15 +367,23 @@ def is_configured() -> bool:
 
 
 def apply_bearer_token(token: str) -> None:
-    """Store the generated bearer token in the module global.
+    """Store the generated bearer token in both config surfaces.
 
     Called by ``ensure_token_exists()`` in server.py after writing the token
     to disk.  We do NOT set os.environ here — the caller is responsible for
     calling ``os.environ.pop("UNRAID_MCP_BEARER_TOKEN", None)`` immediately
     after, so the token is no longer accessible via os.environ.
+
+    The bearer token has two read surfaces — the ``UNRAID_MCP_BEARER_TOKEN``
+    module global and the live ``_settings.unraid_mcp_bearer_token`` instance
+    field — so we update BOTH here to keep them consistent; otherwise the
+    instance field goes stale while the global advances. This is a one-shot
+    startup-time write (no concurrent readers yet), and any reader must go
+    through one consistent surface rather than mixing the two.
     """
     global UNRAID_MCP_BEARER_TOKEN
     UNRAID_MCP_BEARER_TOKEN = token
+    _settings.unraid_mcp_bearer_token = token
 
 
 def get_config_summary() -> dict[str, Any]:

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -367,23 +367,22 @@ def is_configured() -> bool:
 
 
 def apply_bearer_token(token: str) -> None:
-    """Store the generated bearer token in both config surfaces.
+    """Store the generated bearer token in the authoritative config surface.
 
     Called by ``ensure_token_exists()`` in server.py after writing the token
     to disk.  We do NOT set os.environ here — the caller is responsible for
     calling ``os.environ.pop("UNRAID_MCP_BEARER_TOKEN", None)`` immediately
     after, so the token is no longer accessible via os.environ.
 
-    The bearer token has two read surfaces — the ``UNRAID_MCP_BEARER_TOKEN``
-    module global and the live ``_settings.unraid_mcp_bearer_token`` instance
-    field — so we update BOTH here to keep them consistent; otherwise the
-    instance field goes stale while the global advances. This is a one-shot
-    startup-time write (no concurrent readers yet), and any reader must go
-    through one consistent surface rather than mixing the two.
+    The single authoritative read surface for the bearer token is the
+    ``UNRAID_MCP_BEARER_TOKEN`` module global: every reader (the auth
+    middleware via ``server.py``, the startup gate, ``get_config_summary``)
+    goes through it. The ``Settings`` instance field is only read once at
+    import to seed this global, so this one-shot startup-time write updates the
+    global only.
     """
     global UNRAID_MCP_BEARER_TOKEN
     UNRAID_MCP_BEARER_TOKEN = token
-    _settings.unraid_mcp_bearer_token = token
 
 
 def get_config_summary() -> dict[str, Any]:

--- a/unraid_mcp/core/auth.py
+++ b/unraid_mcp/core/auth.py
@@ -116,9 +116,7 @@ class BearerAuthMiddleware:
     # Helpers
     # ------------------------------------------------------------------
 
-    def _check_auth(
-        self, headers: list[tuple[bytes, bytes]]
-    ) -> tuple[str, bytes, bytes] | None:
+    def _check_auth(self, headers: list[tuple[bytes, bytes]]) -> tuple[str, bytes, bytes] | None:
         """Validate the Authorization header for a request.
 
         Returns ``None`` when authentication succeeds. On failure, returns a

--- a/unraid_mcp/core/auth.py
+++ b/unraid_mcp/core/auth.py
@@ -96,56 +96,16 @@ class BearerAuthMiddleware:
             )
             return
 
-        # Extract Authorization header from raw ASGI headers list
-        auth_header: bytes | None = None
-        for key, val in scope.get("headers", []):
-            if key.lower() == b"authorization":
-                auth_header = val
-                break
-
-        if auth_header is None:
-            # No Authorization header at all — prompt client per RFC 6750
+        failure = self._check_auth(scope.get("headers", []))
+        if failure is not None:
+            reason, body, www_authenticate = failure
             self._record_failure(client_ip)
-            self._maybe_warn(client_ip, "missing authorization header")
+            self._maybe_warn(client_ip, reason)
             await self._send_response(
                 send,
                 status=401,
-                body=self._body_401_missing,
-                extra_headers=[(b"www-authenticate", b'Bearer realm="unraid-mcp"')],
-            )
-            return
-
-        # Headers are latin-1 per RFC 7230; decode before string operations
-        auth_str = auth_header.decode("latin-1")
-        if not auth_str.lower().startswith("bearer "):
-            # Wrong scheme — treat as missing (don't hint that bearer exists)
-            self._record_failure(client_ip)
-            self._maybe_warn(client_ip, "non-bearer auth scheme")
-            await self._send_response(
-                send,
-                status=401,
-                body=self._body_401_missing,
-                extra_headers=[(b"www-authenticate", b'Bearer realm="unraid-mcp"')],
-            )
-            return
-
-        # Extract token from original string (value is verbatim after scheme)
-        provided: bytes = auth_str[len("bearer ") :].strip().encode()
-
-        # Constant-time comparison prevents timing side-channel attacks
-        if not hmac.compare_digest(provided, self._token):
-            self._record_failure(client_ip)
-            self._maybe_warn(client_ip, "invalid token")
-            await self._send_response(
-                send,
-                status=401,
-                body=self._body_401_invalid,
-                extra_headers=[
-                    (
-                        b"www-authenticate",
-                        b'Bearer realm="unraid-mcp", error="invalid_token"',
-                    )
-                ],
+                body=body,
+                extra_headers=[(b"www-authenticate", www_authenticate)],
             )
             return
 
@@ -155,6 +115,55 @@ class BearerAuthMiddleware:
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
+
+    def _check_auth(
+        self, headers: list[tuple[bytes, bytes]]
+    ) -> tuple[str, bytes, bytes] | None:
+        """Validate the Authorization header for a request.
+
+        Returns ``None`` when authentication succeeds. On failure, returns a
+        ``(reason, body, www_authenticate)`` tuple the caller uses to emit the
+        appropriate 401 response: ``reason`` is the throttled-warning string,
+        ``body`` the JSON error body, and ``www_authenticate`` the
+        ``WWW-Authenticate`` header value (per RFC 6750).
+        """
+        # Extract Authorization header from raw ASGI headers list
+        auth_header: bytes | None = None
+        for key, val in headers:
+            if key.lower() == b"authorization":
+                auth_header = val
+                break
+
+        if auth_header is None:
+            # No Authorization header at all — prompt client per RFC 6750
+            return (
+                "missing authorization header",
+                self._body_401_missing,
+                b'Bearer realm="unraid-mcp"',
+            )
+
+        # Headers are latin-1 per RFC 7230; decode before string operations
+        auth_str = auth_header.decode("latin-1")
+        if not auth_str.lower().startswith("bearer "):
+            # Wrong scheme — treat as missing (don't hint that bearer exists)
+            return (
+                "non-bearer auth scheme",
+                self._body_401_missing,
+                b'Bearer realm="unraid-mcp"',
+            )
+
+        # Extract token from original string (value is verbatim after scheme)
+        provided: bytes = auth_str[len("bearer ") :].strip().encode()
+
+        # Constant-time comparison prevents timing side-channel attacks
+        if not hmac.compare_digest(provided, self._token):
+            return (
+                "invalid token",
+                self._body_401_invalid,
+                b'Bearer realm="unraid-mcp", error="invalid_token"',
+            )
+
+        return None
 
     def _get_client_ip(self, scope: Scope) -> str:
         """Extract and sanitize the client IP from the ASGI scope.

--- a/unraid_mcp/core/client.py
+++ b/unraid_mcp/core/client.py
@@ -275,6 +275,89 @@ async def close_http_client() -> None:
             logger.info("Closed shared HTTP client")
 
 
+async def _post_with_429_retry(
+    client: httpx.AsyncClient,
+    url: str,
+    post_kwargs: dict[str, Any],
+) -> httpx.Response:
+    """POST a GraphQL request, retrying with exponential backoff on HTTP 429.
+
+    Retries up to 3 times (backoff 1s, 2s, 4s) when the Unraid API responds 429.
+    Raises ToolError if no response is received or if 429 persists after retries.
+
+    Args:
+        client: Shared HTTP client with connection pooling
+        url: Unraid GraphQL endpoint URL
+        post_kwargs: Keyword args for ``client.post`` (json/headers/timeout)
+
+    Returns:
+        The first non-429 response (or the final 429 only via the persisted-429 error path)
+
+    Raises:
+        ToolError: If no response is received, or 429 persists after 3 retries
+    """
+    response: httpx.Response | None = None
+    for attempt in range(3):
+        response = await client.post(url, **post_kwargs)
+        if response.status_code == 429:
+            backoff = 2**attempt
+            logger.warning(
+                f"Rate limited (429) by Unraid API, retrying in {backoff}s (attempt {attempt + 1}/3)"
+            )
+            await asyncio.sleep(backoff)
+            continue
+        break
+
+    if response is None:  # pragma: no cover — guaranteed by loop
+        raise ToolError("No response received after retry attempts")
+
+    # Provide a clear message when all retries are exhausted on 429
+    if response.status_code == 429:
+        logger.error("Rate limit (429) persisted after 3 retries — request aborted")
+        raise ToolError("Unraid API is rate limiting requests. Wait ~10 seconds before retrying.")
+
+    return response
+
+
+def _synthesize_idempotent_success(
+    error_details: str,
+    response_data: dict[str, Any],
+    operation_context: dict[str, str] | None,
+) -> dict[str, Any] | None:
+    """Synthesize a success response for an idempotent GraphQL error, else None.
+
+    When the operation is already in its requested state (e.g. starting an
+    already-running container), the upstream returns an error that should be
+    treated as success. Returns a synthesized success dict in that case;
+    otherwise returns None so the caller raises the GraphQL error.
+
+    Args:
+        error_details: Joined GraphQL error message(s)
+        response_data: The full decoded GraphQL response (for ``original_errors``)
+        operation_context: Optional context carrying an 'operation' key
+
+    Returns:
+        A success dict when the error is idempotent for the operation, else None
+    """
+    if not (operation_context and operation_context.get("operation")):
+        return None
+
+    operation = operation_context["operation"]
+    if not is_idempotent_error(error_details, operation):
+        return None
+
+    logger.warning(
+        f"Idempotent operation '{operation}' - treating as success: {error_details}"
+    )
+    # Return a success response with the current state information
+    return {
+        "idempotent_success": True,
+        "operation": operation,
+        "message": error_details,
+        "original_errors": response_data["errors"],
+    }
+
+
 async def make_graphql_request(
     query: str,
     variables: dict[str, Any] | None = None,
@@ -325,32 +408,12 @@ async def make_graphql_request(
         # Get the shared HTTP client with connection pooling
         client = await get_http_client()
 
-        # Retry loop for 429 rate limit responses
+        # POST with retry/backoff for 429 rate limit responses
         post_kwargs: dict[str, Any] = {"json": payload, "headers": headers}
         if custom_timeout is not None:
             post_kwargs["timeout"] = custom_timeout
 
-        response: httpx.Response | None = None
-        for attempt in range(3):
-            response = await client.post(_settings.UNRAID_API_URL, **post_kwargs)
-            if response.status_code == 429:
-                backoff = 2**attempt
-                logger.warning(
-                    f"Rate limited (429) by Unraid API, retrying in {backoff}s (attempt {attempt + 1}/3)"
-                )
-                await asyncio.sleep(backoff)
-                continue
-            break
-
-        if response is None:  # pragma: no cover — guaranteed by loop
-            raise ToolError("No response received after retry attempts")
-
-        # Provide a clear message when all retries are exhausted on 429
-        if response.status_code == 429:
-            logger.error("Rate limit (429) persisted after 3 retries — request aborted")
-            raise ToolError(
-                "Unraid API is rate limiting requests. Wait ~10 seconds before retrying."
-            )
+        response = await _post_with_429_retry(client, _settings.UNRAID_API_URL, post_kwargs)
 
         response.raise_for_status()  # Raise an exception for HTTP error codes 4xx/5xx
 
@@ -361,19 +424,11 @@ async def make_graphql_request(
             )
 
             # Check if this is an idempotent error that should be treated as success
-            if operation_context and operation_context.get("operation"):
-                operation = operation_context["operation"]
-                if is_idempotent_error(error_details, operation):
-                    logger.warning(
-                        f"Idempotent operation '{operation}' - treating as success: {error_details}"
-                    )
-                    # Return a success response with the current state information
-                    return {
-                        "idempotent_success": True,
-                        "operation": operation,
-                        "message": error_details,
-                        "original_errors": response_data["errors"],
-                    }
+            idempotent_result = _synthesize_idempotent_success(
+                error_details, response_data, operation_context
+            )
+            if idempotent_result is not None:
+                return idempotent_result
 
             logger.error(f"GraphQL API returned errors: {response_data['errors']}")
             # Use ToolError for GraphQL errors to provide better feedback to LLM

--- a/unraid_mcp/core/client.py
+++ b/unraid_mcp/core/client.py
@@ -303,7 +303,8 @@ async def _post_with_429_retry(
         post_kwargs: Keyword args for ``client.post`` (json/headers/timeout)
 
     Returns:
-        The first non-429 response (or the final 429 only via the persisted-429 error path)
+        The first non-429 response. A 429 that persists past all retries raises
+        instead of returning (see Raises).
 
     Raises:
         ToolError: If no response is received, or 429 persists after 3 retries

--- a/unraid_mcp/core/client.py
+++ b/unraid_mcp/core/client.py
@@ -307,29 +307,21 @@ async def _post_with_429_retry(
         instead of returning (see Raises).
 
     Raises:
-        ToolError: If no response is received, or 429 persists after 3 retries
+        ToolError: If 429 persists after 3 retries
     """
-    response: httpx.Response | None = None
     for attempt in range(3):
         response = await client.post(url, **post_kwargs)
-        if response.status_code == 429:
-            backoff = 2**attempt
-            logger.warning(
-                f"Rate limited (429) by Unraid API, retrying in {backoff}s (attempt {attempt + 1}/3)"
-            )
-            await asyncio.sleep(backoff)
-            continue
-        break
+        if response.status_code != 429:
+            return response
+        backoff = 2**attempt
+        logger.warning(
+            f"Rate limited (429) by Unraid API, retrying in {backoff}s (attempt {attempt + 1}/3)"
+        )
+        await asyncio.sleep(backoff)
 
-    if response is None:  # pragma: no cover — guaranteed by loop
-        raise ToolError("No response received after retry attempts")
-
-    # Provide a clear message when all retries are exhausted on 429
-    if response.status_code == 429:
-        logger.error("Rate limit (429) persisted after 3 retries — request aborted")
-        raise ToolError("Unraid API is rate limiting requests. Wait ~10 seconds before retrying.")
-
-    return response
+    # All 3 attempts returned 429.
+    logger.error("Rate limit (429) persisted after 3 retries — request aborted")
+    raise ToolError("Unraid API is rate limiting requests. Wait ~10 seconds before retrying.")
 
 
 def _synthesize_idempotent_success(

--- a/unraid_mcp/core/client.py
+++ b/unraid_mcp/core/client.py
@@ -114,6 +114,14 @@ def redact_sensitive(obj: Any) -> Any:
 DEFAULT_TIMEOUT = httpx.Timeout(10.0, read=30.0, connect=5.0)
 DISK_TIMEOUT = httpx.Timeout(10.0, read=TIMEOUT_CONFIG["disk_operations"], connect=5.0)
 
+# Module-global singletons: the shared connection pool (_http_client) and the
+# upstream token bucket (_rate_limiter, defined below). This in-process state is
+# correct for the single-process (stdio) deployment but is a HORIZONTAL-SCALING
+# BARRIER: N replicas would each open their own pool and run an independent token
+# bucket, so the modeled "100 req/10s" upstream limit would be violated N-fold
+# (each replica thinks it owns the full budget). Scaling horizontally would require
+# a shared/distributed limiter (e.g. Redis-backed) rather than this per-process one.
+#
 # Global connection pool (module-level singleton)
 # Python 3.12+ asyncio.Lock() is safe at module level — no running event loop required
 _http_client: httpx.AsyncClient | None = None
@@ -155,6 +163,10 @@ class _RateLimiter:
             await asyncio.sleep(wait_time)
 
 
+# Module-global singleton (see the horizontal-scaling note near _http_client above):
+# one per-process token bucket. With N replicas each runs its own, so the upstream
+# "100 req/10s" cap is enforced per-process, not fleet-wide — a distributed limiter
+# would be required to bound the aggregate rate across replicas.
 _rate_limiter = _RateLimiter()
 
 
@@ -346,9 +358,7 @@ def _synthesize_idempotent_success(
     if not is_idempotent_error(error_details, operation):
         return None
 
-    logger.warning(
-        f"Idempotent operation '{operation}' - treating as success: {error_details}"
-    )
+    logger.warning(f"Idempotent operation '{operation}' - treating as success: {error_details}")
     # Return a success response with the current state information
     return {
         "idempotent_success": True,

--- a/unraid_mcp/core/guards.py
+++ b/unraid_mcp/core/guards.py
@@ -87,8 +87,13 @@ async def gate_destructive_action(
         destructive_actions: Set of action names considered destructive.
         confirm: When True, bypasses elicitation and proceeds immediately.
         description: Human-readable description of the action's impact.
-            Pass a str when one description covers all destructive actions.
-            Pass a dict[action_name, description] when descriptions differ.
+            Convention: prefer the dict[subaction, description] form, keyed by
+            subaction, so each destructive action carries its own message — this
+            is what the multi-destructive domains pass. A bare str is the
+            single-action shorthand: it applies to whichever destructive action
+            is gated (typically a domain with exactly one). When a dict is
+            passed, the gated subaction MUST have an entry; a missing key raises
+            ToolError (see below) rather than silently proceeding.
     """
     if action not in destructive_actions:
         return

--- a/unraid_mcp/core/pagination.py
+++ b/unraid_mcp/core/pagination.py
@@ -20,10 +20,14 @@ DEFAULT_LIST_LIMIT: int = 20
 
 
 def _item_bytes(item: Any) -> int:
-    """Serialized byte size of a single item for byte-budget accounting.
+    """Approximate serialized byte size of a single item for byte-budget accounting.
 
-    Uses the same compact JSON serialization the tool response uses, falling back
-    to ``str`` for anything non-JSON-serializable so a quirky item can never raise.
+    A separate, cheap JSON serialization used only to *measure* — the response
+    itself is serialized again by the response encoder, so this is a deliberate
+    extra pass whose cost is bounded by the byte budget. Falls back to ``str`` for
+    anything non-JSON-serializable so a quirky item can never raise. The estimate
+    need not match the encoder's exact wire size; callers leave headroom (see
+    ``_LIVE_EVENT_BYTE_BUDGET`` = half the response cap) to absorb the difference.
     """
     try:
         return len(json.dumps(item, default=str).encode())
@@ -50,10 +54,13 @@ def cap_list(
             (the default) preserves the count-only behavior — fully backward
             compatible. When set, items are added until the running serialized
             size would exceed the budget, then truncation stops early; this keeps
-            a single huge item (e.g. a multi-KB log event) from tripping the
-            response-size backstop and discarding the entire response. A value
-            ``<= 0`` disables the byte ceiling. The byte cap is applied *after*
-            the count cap, so it only ever returns fewer items, never more.
+            a handful of multi-KB items (e.g. log events) from collectively
+            tripping the response-size backstop and discarding the entire
+            response. At least one item is always returned, so a *single* item
+            larger than the whole budget is still returned in full (and may then
+            hit the backstop) — the budget bounds aggregate size, not max item
+            size. A value ``<= 0`` disables the byte ceiling. The byte cap is
+            applied *after* the count cap, so it only ever returns fewer items.
 
     Returns:
         A ``(capped_items, meta)`` tuple. ``meta`` always carries ``returned``,

--- a/unraid_mcp/core/pagination.py
+++ b/unraid_mcp/core/pagination.py
@@ -9,6 +9,7 @@ This is the shared primitive every list subaction should use so the truncation
 signal is consistent across the whole tool surface.
 """
 
+import json
 from typing import Any
 
 
@@ -18,8 +19,24 @@ from typing import Any
 DEFAULT_LIST_LIMIT: int = 20
 
 
+def _item_bytes(item: Any) -> int:
+    """Serialized byte size of a single item for byte-budget accounting.
+
+    Uses the same compact JSON serialization the tool response uses, falling back
+    to ``str`` for anything non-JSON-serializable so a quirky item can never raise.
+    """
+    try:
+        return len(json.dumps(item, default=str).encode())
+    except (TypeError, ValueError):
+        return len(str(item).encode())
+
+
 def cap_list(
-    items: list[Any], limit: int | None, *, default: int = DEFAULT_LIST_LIMIT
+    items: list[Any],
+    limit: int | None,
+    *,
+    default: int = DEFAULT_LIST_LIMIT,
+    byte_budget: int | None = None,
 ) -> tuple[list[Any], dict[str, Any]]:
     """Cap a list client-side and describe the result.
 
@@ -29,6 +46,14 @@ def cap_list(
             ``<= 0`` disables capping (returns everything) — use it as an
             explicit "give me all" escape hatch.
         default: Limit applied when ``limit`` is ``None``.
+        byte_budget: Optional running serialized-size ceiling (bytes). ``None``
+            (the default) preserves the count-only behavior — fully backward
+            compatible. When set, items are added until the running serialized
+            size would exceed the budget, then truncation stops early; this keeps
+            a single huge item (e.g. a multi-KB log event) from tripping the
+            response-size backstop and discarding the entire response. A value
+            ``<= 0`` disables the byte ceiling. The byte cap is applied *after*
+            the count cap, so it only ever returns fewer items, never more.
 
     Returns:
         A ``(capped_items, meta)`` tuple. ``meta`` always carries ``returned``,
@@ -41,7 +66,8 @@ def cap_list(
     effective = default if limit is None else limit
 
     if effective is not None and effective > 0 and total > effective:
-        return items[:effective], {
+        capped = items[:effective]
+        meta = {
             "returned": effective,
             "total": total,
             "truncated": True,
@@ -50,5 +76,32 @@ def cap_list(
                 "to see more (limit=0 for all)"
             ),
         }
+    else:
+        capped = items
+        meta = {"returned": total, "total": total, "truncated": False}
 
-    return items, {"returned": total, "total": total, "truncated": False}
+    # Optional secondary byte ceiling: trim the already count-capped slice so its
+    # running serialized size stays under the budget. Bounds total bytes, not just
+    # item count — large items can't nuke the whole response.
+    if byte_budget is not None and byte_budget > 0 and capped:
+        running = 0
+        kept = 0
+        for item in capped:
+            running += _item_bytes(item)
+            if kept > 0 and running > byte_budget:
+                break
+            kept += 1
+        if kept < len(capped):
+            byte_capped = capped[:kept]
+            return byte_capped, {
+                "returned": kept,
+                "total": total,
+                "truncated": True,
+                "hint": (
+                    f"showing {kept} of {total} items (stopped at ~{byte_budget} "
+                    "bytes to fit the response budget); narrow the query or fetch "
+                    "fewer/smaller items"
+                ),
+            }
+
+    return capped, meta

--- a/unraid_mcp/core/response_limit.py
+++ b/unraid_mcp/core/response_limit.py
@@ -71,8 +71,7 @@ class StructuredResponseLimitingMiddleware(Middleware):
         self.max_size = max_size
         self.tools = set(tools) if tools is not None else None
 
-    @staticmethod
-    def _measure(result: ToolResult) -> int:
+    def _measure(self, result: ToolResult) -> int:
         """Return the serialized byte size of a ToolResult.
 
         The ``unraid`` tool's payload is a JSON string in a single ``TextContent``
@@ -83,12 +82,37 @@ class StructuredResponseLimitingMiddleware(Middleware):
         escaping can add more than a wrapper's worth of bytes for quote/backslash-
         heavy content), so the fast path under-counts and is therefore conservative:
         it never truncates a response that full serialization would have kept under
-        the cap. Multi-content or other result shapes fall back to full
-        serialization.
+        the cap.
+
+        For multi-block results we avoid serializing an over-cap payload in full
+        just to reject it. The raw text bytes of all ``TextContent`` blocks are a
+        strict lower bound on the full ``to_json`` size (which adds the content
+        wrapper plus JSON escaping, both non-negative). So if that running sum alone
+        already exceeds ``max_size``, full serialization would too — we return the
+        partial sum early (still ``> max_size``, preserving the exact over-cap
+        decision) without serializing the rest. Only when the text bytes stay within
+        the cap — or the result carries genuinely opaque (non-text) blocks — do we
+        fall back to the full ``pydantic_core.to_json`` measurement.
         """
         content = result.content
         if len(content) == 1 and isinstance(content[0], TextContent):
             return len(content[0].text.encode())
+
+        # Sum text-block byte lengths as a lower bound, bailing out as soon as the
+        # running total exceeds the cap. Any non-text block makes the result opaque
+        # to this cheap estimate, so defer to full serialization for an exact size.
+        running = 0
+        for block in content:
+            if not isinstance(block, TextContent):
+                break
+            running += len(block.text.encode())
+            if running > self.max_size:
+                return running
+        else:
+            # All blocks were text and their total stayed within the cap; the
+            # wrapper/escaping could still push the full payload over, so measure it.
+            return len(pydantic_core.to_json(result, fallback=str))
+
         return len(pydantic_core.to_json(result, fallback=str))
 
     def _marker_result(self, original_bytes: int) -> ToolResult:

--- a/unraid_mcp/core/response_limit.py
+++ b/unraid_mcp/core/response_limit.py
@@ -99,20 +99,20 @@ class StructuredResponseLimitingMiddleware(Middleware):
             return len(content[0].text.encode())
 
         # Sum text-block byte lengths as a lower bound, bailing out as soon as the
-        # running total exceeds the cap. Any non-text block makes the result opaque
-        # to this cheap estimate, so defer to full serialization for an exact size.
+        # running total exceeds the cap.
         running = 0
         for block in content:
             if not isinstance(block, TextContent):
+                # A non-text block is opaque to the cheap estimate — fall through
+                # to the exact measurement below.
                 break
             running += len(block.text.encode())
             if running > self.max_size:
                 return running
-        else:
-            # All blocks were text and their total stayed within the cap; the
-            # wrapper/escaping could still push the full payload over, so measure it.
-            return len(pydantic_core.to_json(result, fallback=str))
 
+        # Either a non-text block was hit, or all blocks were text but stayed within
+        # the cap (wrapper/escaping could still push the full payload over) — in both
+        # cases a full serialization is the only exact measure.
         return len(pydantic_core.to_json(result, fallback=str))
 
     def _marker_result(self, original_bytes: int) -> ToolResult:

--- a/unraid_mcp/core/utils.py
+++ b/unraid_mcp/core/utils.py
@@ -228,7 +228,8 @@ def _coerce_int(value: Any) -> int | None:
         return None
     try:
         return int(value)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, OverflowError):
+        # OverflowError: int(inf) / int(very-large-float) — map to None like the rest.
         return None
 
 

--- a/unraid_mcp/core/utils.py
+++ b/unraid_mcp/core/utils.py
@@ -4,6 +4,8 @@ import re
 from typing import Any
 from urllib.parse import urlparse
 
+from .exceptions import ToolError
+
 
 _MISSING: object = object()
 
@@ -215,6 +217,21 @@ def mutation_success(result: Any, *, boolean: bool) -> bool:
     return bool(result) if boolean else result is not None
 
 
+def _coerce_int(value: Any) -> int | None:
+    """Coerce ``value`` to ``int`` for the size formatters, or None on failure.
+
+    Returns None for ``None`` input and for anything ``int()`` rejects, so callers
+    can map None → ``"N/A"`` uniformly. Shared by :func:`format_bytes` and
+    :func:`format_kb` to keep their coercion behavior identical.
+    """
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return None
+
+
 def format_bytes(bytes_value: int | None) -> str:
     """Format byte values into human-readable sizes.
 
@@ -224,12 +241,10 @@ def format_bytes(bytes_value: int | None) -> str:
     Returns:
         Human-readable string like "1.00 GB" or "N/A" if input is None/invalid.
     """
-    if bytes_value is None:
+    coerced = _coerce_int(bytes_value)
+    if coerced is None:
         return "N/A"
-    try:
-        value = float(int(bytes_value))
-    except (ValueError, TypeError):
-        return "N/A"
+    value = float(coerced)
     for unit in ["B", "KB", "MB", "GB", "TB", "PB"]:
         if value < 1024.0:
             return f"{value:.2f} {unit}"
@@ -268,11 +283,8 @@ def format_kb(k: Any) -> str:
     Returns:
         Human-readable string like "1.00 GB" or "N/A" if input is None/invalid.
     """
-    if k is None:
-        return "N/A"
-    try:
-        kb = int(k)
-    except (ValueError, TypeError):
+    kb = _coerce_int(k)
+    if kb is None:
         return "N/A"
     return format_bytes(kb * 1024)
 
@@ -285,8 +297,6 @@ def validate_subaction(subaction: str, valid_set: set[str], domain: str) -> None
         valid_set: Set of valid subaction names.
         domain: The domain name for error messages (e.g. "docker").
     """
-    from .exceptions import ToolError
-
     if subaction not in valid_set:
         raise ToolError(
             f"Invalid subaction '{subaction}' for {domain}. Must be one of: {sorted(valid_set)}"

--- a/unraid_mcp/subscriptions/diagnostics.py
+++ b/unraid_mcp/subscriptions/diagnostics.py
@@ -11,9 +11,17 @@ tool routes ``action="subscriptions"`` to (subactions ``diagnose`` and
 
 import asyncio
 import json
-import re
+import os
 from datetime import UTC, datetime
 from typing import Any
+
+from graphql import (
+    FieldNode,
+    GraphQLError,
+    OperationDefinitionNode,
+    OperationType,
+    parse,
+)
 
 from ..config import settings as _settings
 from ..config.logging import logger
@@ -21,7 +29,7 @@ from ..core.exceptions import ToolError
 from ..core.utils import safe_display_url
 from .manager import subscription_manager
 from .protocol import ProtocolError, graphql_ws_session
-from .resources import ensure_subscriptions_started
+from .resources import ensure_subscriptions_started, get_last_startup_error
 from .utils import (
     _analyze_subscription_status,
     build_ws_ssl_context,
@@ -29,10 +37,10 @@ from .utils import (
 )
 
 
-# Schema field names that appear inside the selection set of allowed subscriptions.
-# The regex _SUBSCRIPTION_NAME_PATTERN extracts the first identifier after the
-# opening "{", so we list the actual field names used in queries (e.g. "logFile"),
-# NOT the operation-level names (e.g. "logFileSubscription").
+# Schema field names that appear as the top-level selection of allowed subscriptions.
+# These are the actual field names used in queries (e.g. "cpu", "logFile"), NOT the
+# operation-level names (e.g. "logFileSubscription"). The validator below enforces
+# this allowlist against the *parsed* GraphQL AST — see _validate_subscription_query.
 _ALLOWED_SUBSCRIPTION_FIELDS = frozenset(
     {
         "containerStats",
@@ -50,36 +58,67 @@ _ALLOWED_SUBSCRIPTION_FIELDS = frozenset(
     }
 )
 
-# Pattern: must start with "subscription" keyword, then extract the first selected
-# field name (the word immediately after "{").
-_SUBSCRIPTION_NAME_PATTERN = re.compile(r"^\s*subscription\b[^{]*\{\s*(\w+)", re.IGNORECASE)
-# Reject any query that contains a bare "mutation" or "query" operation keyword.
-_FORBIDDEN_KEYWORDS = re.compile(r"\b(mutation|query)\b", re.IGNORECASE)
+# Env flag (debug only): when truthy, test_query echoes the upstream's raw first
+# frame back to the caller. Off by default so the probe never becomes an exfil
+# channel for whatever the upstream returns (SEC-M1).
+_RAW_PROBE_ENV = "UNRAID_MCP_ENABLE_RAW_SUBSCRIPTION_PROBE"
+
+
+def _raw_subscription_probe_enabled() -> bool:
+    """Whether test_query may echo the raw upstream frame (debug only)."""
+    return os.getenv(_RAW_PROBE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _validate_subscription_query(query: str) -> str:
     """Validate that a subscription query is safe to execute.
 
-    Only allows subscription operations targeting whitelisted schema field names.
-    Rejects any query containing mutation/query keywords.
+    This is the **only** place the server accepts a caller-authored GraphQL
+    document, so validation is done on the parsed AST rather than a regex
+    (a regex allowlist is bypassable via multi-field, alias, and argument
+    smuggling — SEC-H1). The document must:
+
+    * parse as valid GraphQL;
+    * contain exactly one operation, and that operation must be a ``subscription``
+      (not a query/mutation);
+    * select exactly one top-level field, whose **real** name (alias resolved)
+      is in :data:`_ALLOWED_SUBSCRIPTION_FIELDS`.
 
     Returns:
-        The extracted field name (e.g. "logFile").
+        The validated top-level field name (e.g. "cpu").
 
     Raises:
         ToolError: If the query fails validation.
     """
-    if _FORBIDDEN_KEYWORDS.search(query):
+    try:
+        document = parse(query)
+    except GraphQLError as exc:
+        raise ToolError("Query rejected: not a valid GraphQL document.") from exc
+
+    operations = [d for d in document.definitions if isinstance(d, OperationDefinitionNode)]
+    if len(operations) != 1:
+        raise ToolError("Query rejected: must contain exactly one subscription operation.")
+
+    operation = operations[0]
+    if operation.operation is not OperationType.SUBSCRIPTION:
         raise ToolError("Query rejected: must be a subscription, not a mutation or query.")
 
-    match = _SUBSCRIPTION_NAME_PATTERN.match(query)
-    if not match:
+    selections = operation.selection_set.selections
+    if len(selections) != 1:
+        # Reject multi-field selections outright — the probe tests a single field,
+        # and allowing more is exactly the multi-field smuggling vector (SEC-H1).
         raise ToolError(
-            "Query rejected: must start with 'subscription' and contain a valid "
-            "subscription field. Example: subscription { cpu { used idle system } }"
+            "Query rejected: a subscription test must select exactly one top-level field."
         )
 
-    field_name = match.group(1)
+    selection = selections[0]
+    if not isinstance(selection, FieldNode):
+        # Fragment spreads / inline fragments at the top level could smuggle a
+        # disallowed field past a name check — only a plain field is permitted.
+        raise ToolError(
+            "Query rejected: the top-level selection must be a plain field (no fragments)."
+        )
+
+    field_name = selection.name.value  # real field name — ignores any alias
     if field_name not in _ALLOWED_SUBSCRIPTION_FIELDS:
         raise ToolError(
             f"Subscription field '{field_name}' is not allowed. "
@@ -136,16 +175,33 @@ async def test_subscription_query(subscription_query: str) -> dict[str, Any]:
                     response = await asyncio.wait_for(session.ws.recv(), timeout=5.0)
                     result = json.loads(response)
 
-                    logger.info(f"[TEST_SUBSCRIPTION] Response: {result}")
-                    return {
+                    # Do NOT log or return the raw upstream frame by default — it can
+                    # carry sensitive data, and test_query is the one caller-controlled
+                    # GraphQL surface (SEC-M1). Echo it only when explicitly enabled.
+                    logger.info(
+                        "[TEST_SUBSCRIPTION] First frame received for field '%s'", field_name
+                    )
+                    payload: dict[str, Any] = {
                         "success": True,
-                        "response": result,
+                        "first_frame_received": True,
+                        "validated_field": field_name,
                         "query_tested": subscription_query,
+                        "note": "Connection succeeded and a first frame was received.",
                     }
+                    if _raw_subscription_probe_enabled():
+                        payload["response"] = result
+                    else:
+                        payload["response"] = (
+                            f"<withheld> set {_RAW_PROBE_ENV}=true to include the raw "
+                            "upstream frame (debug only)."
+                        )
+                    return payload
 
                 except TimeoutError:
                     return {
                         "success": True,
+                        "first_frame_received": False,
+                        "validated_field": field_name,
                         "response": "No immediate response (subscriptions may only send data on changes)",
                         "query_tested": subscription_query,
                         "note": "Connection successful, subscription may be waiting for events",
@@ -209,6 +265,7 @@ async def diagnose_subscriptions() -> dict[str, Any]:
                 "unraid_api_url": safe_display_url(_settings.UNRAID_API_URL),
                 "api_key_configured": bool(_settings.UNRAID_API_KEY),
                 "websocket_url": ws_url_display,
+                "startup_error": get_last_startup_error(),
             },
             "subscriptions": status,
             "summary": {
@@ -227,6 +284,13 @@ async def diagnose_subscriptions() -> dict[str, Any]:
         if not diagnostic_info["environment"]["api_key_configured"]:
             recommendations.append(
                 "CRITICAL: No API key configured. Set UNRAID_API_KEY environment variable."
+            )
+
+        if diagnostic_info["environment"]["startup_error"] is not None:
+            recommendations.append(
+                "Subscription autostart failed at startup "
+                f"({diagnostic_info['environment']['startup_error']}). Live data may be "
+                "unavailable; check server logs for the root cause."
             )
 
         if diagnostic_info["summary"]["in_error_state"] > 0:

--- a/unraid_mcp/subscriptions/diagnostics.py
+++ b/unraid_mcp/subscriptions/diagnostics.py
@@ -162,8 +162,8 @@ async def test_subscription_query(subscription_query: str) -> dict[str, Any]:
         ssl_context = build_ws_ssl_context(ws_url)
 
         # Shared handshake: connect -> connection_init -> connection_ack -> subscribe.
-        # ack_timeout=None keeps the historical bare recv() (no deadline) on the ack;
-        # ping_interval=30 matches the original probe configuration.
+        # ack_timeout=None gives the ack recv() no deadline; the probe uses the slower
+        # _WS_PROBE_PING_INTERVAL keepalive cadence (vs the manager's _WS_PING_INTERVAL).
         try:
             async with graphql_ws_session(
                 ws_url,
@@ -175,9 +175,9 @@ async def test_subscription_query(subscription_query: str) -> dict[str, Any]:
                 ping_interval=_WS_PROBE_PING_INTERVAL,
                 ping_timeout=_WS_PING_TIMEOUT,
             ) as session:
-                # Wait for the first response with a timeout. The probe deliberately
-                # does NOT normalize the frame — it returns whatever the server sent
-                # first so a developer can inspect the raw subscription response.
+                # Wait for the first frame with a timeout. By default the raw frame is
+                # withheld (SEC-M1, see below) — only its receipt is reported; set the
+                # UNRAID_MCP_ENABLE_RAW_SUBSCRIPTION_PROBE flag to echo the upstream payload.
                 try:
                     response = await asyncio.wait_for(
                         session.ws.recv(), timeout=_WS_FIRST_FRAME_TIMEOUT

--- a/unraid_mcp/subscriptions/diagnostics.py
+++ b/unraid_mcp/subscriptions/diagnostics.py
@@ -70,6 +70,12 @@ _ALLOWED_SUBSCRIPTION_FIELDS = frozenset(
 # channel for whatever the upstream returns (SEC-M1).
 _RAW_PROBE_ENV = "UNRAID_MCP_ENABLE_RAW_SUBSCRIPTION_PROBE"
 
+# Cap the caller-supplied query before parsing. graphql-core's parse() is
+# synchronous and roughly linear in input size (~seconds per MB), so an
+# unbounded query would stall the event loop (CWE-400). 4096 chars is generous
+# for any real single-field subscription.
+_MAX_SUBSCRIPTION_QUERY_CHARS = 4096
+
 
 def _raw_subscription_probe_enabled() -> bool:
     """Whether test_query may echo the raw upstream frame (debug only)."""
@@ -84,9 +90,10 @@ def _validate_subscription_query(query: str) -> str:
     (a regex allowlist is bypassable via multi-field, alias, and argument
     smuggling — SEC-H1). The document must:
 
+    * be within the length cap (so an oversized query can't stall the event loop);
     * parse as valid GraphQL;
-    * contain exactly one operation, and that operation must be a ``subscription``
-      (not a query/mutation);
+    * contain exactly one definition, which must be a single ``subscription``
+      operation (no extra/orphan fragment definitions, no query/mutation);
     * select exactly one top-level field, whose **real** name (alias resolved)
       is in :data:`_ALLOWED_SUBSCRIPTION_FIELDS`.
 
@@ -96,10 +103,22 @@ def _validate_subscription_query(query: str) -> str:
     Raises:
         ToolError: If the query fails validation.
     """
+    if len(query) > _MAX_SUBSCRIPTION_QUERY_CHARS:
+        raise ToolError(
+            f"Query rejected: exceeds the maximum length "
+            f"({_MAX_SUBSCRIPTION_QUERY_CHARS} characters)."
+        )
+
     try:
         document = parse(query)
     except GraphQLError as exc:
         raise ToolError("Query rejected: not a valid GraphQL document.") from exc
+
+    # Exactly one definition — rejects orphan/extra fragment definitions that would
+    # otherwise ride along to the upstream WS unused (the validator's intent is one
+    # subscription selecting one field, with no fragments).
+    if len(document.definitions) != 1:
+        raise ToolError("Query rejected: must contain exactly one subscription operation.")
 
     operations = [d for d in document.definitions if isinstance(d, OperationDefinitionNode)]
     if len(operations) != 1:

--- a/unraid_mcp/subscriptions/diagnostics.py
+++ b/unraid_mcp/subscriptions/diagnostics.py
@@ -28,7 +28,14 @@ from ..config.logging import logger
 from ..core.exceptions import ToolError
 from ..core.utils import safe_display_url
 from .manager import subscription_manager
-from .protocol import ProtocolError, graphql_ws_session
+from .protocol import (
+    _WS_FIRST_FRAME_TIMEOUT,
+    _WS_OPEN_TIMEOUT,
+    _WS_PING_TIMEOUT,
+    _WS_PROBE_PING_INTERVAL,
+    ProtocolError,
+    graphql_ws_session,
+)
 from .resources import ensure_subscriptions_started, get_last_startup_error
 from .utils import (
     _analyze_subscription_status,
@@ -163,16 +170,18 @@ async def test_subscription_query(subscription_query: str) -> dict[str, Any]:
                 subscription_query,
                 sub_id="test",
                 ssl_context=ssl_context,
-                open_timeout=10,
+                open_timeout=_WS_OPEN_TIMEOUT,
                 ack_timeout=None,
-                ping_interval=30,
-                ping_timeout=10,
+                ping_interval=_WS_PROBE_PING_INTERVAL,
+                ping_timeout=_WS_PING_TIMEOUT,
             ) as session:
                 # Wait for the first response with a timeout. The probe deliberately
                 # does NOT normalize the frame — it returns whatever the server sent
                 # first so a developer can inspect the raw subscription response.
                 try:
-                    response = await asyncio.wait_for(session.ws.recv(), timeout=5.0)
+                    response = await asyncio.wait_for(
+                        session.ws.recv(), timeout=_WS_FIRST_FRAME_TIMEOUT
+                    )
                     result = json.loads(response)
 
                     # Do NOT log or return the raw upstream frame by default — it can

--- a/unraid_mcp/subscriptions/diagnostics.py
+++ b/unraid_mcp/subscriptions/diagnostics.py
@@ -38,7 +38,7 @@ from .protocol import (
 )
 from .resources import ensure_subscriptions_started, get_last_startup_error
 from .utils import (
-    _analyze_subscription_status,
+    analyze_subscription_status,
     build_ws_ssl_context,
     build_ws_url,
 )
@@ -254,7 +254,7 @@ async def diagnose_subscriptions() -> dict[str, Any]:
 
         # Analyze connection issues and error counts via shared helper.
         # Gates connection_issues on current failure state (Bug 5 fix).
-        error_count, connection_issues = _analyze_subscription_status(status)
+        error_count, connection_issues = analyze_subscription_status(status)
 
         # Calculate WebSocket URL — apply safe_display_url to avoid leaking
         # credentials (user:pass@host) or the raw API key embedded in the URL.

--- a/unraid_mcp/subscriptions/manager.py
+++ b/unraid_mcp/subscriptions/manager.py
@@ -8,6 +8,7 @@ error handling, reconnection logic, and authentication.
 import asyncio
 import json
 import os
+import random
 import re
 import time
 from datetime import UTC, datetime
@@ -28,8 +29,21 @@ from .utils import build_connection_init, build_ws_ssl_context, build_ws_url
 # Resource data size limits to prevent unbounded memory growth
 _MAX_RESOURCE_DATA_BYTES = 1_048_576  # 1MB
 _MAX_RESOURCE_DATA_LINES = 5_000
-# Minimum stable connection duration (seconds) before resetting reconnect counter
+
+# Reconnect backoff tuning (PERF-H2). Two thresholds decouple "reset backoff" from
+# "reset the give-up counter" so a backend that flaps just past the stable mark
+# can neither pin the reconnect cadence at the floor nor dodge the give-up ceiling:
+#   * >= _HEALTHY_CONNECTION_SECONDS  -> proven healthy: reset backoff to the floor
+#                                        AND clear the attempt counter.
+#   * >= _STABLE_CONNECTION_SECONDS   -> briefly stable (flapping): keep the attempt
+#                                        counter reset (we DID connect, don't abandon
+#                                        it) but ESCALATE backoff so we stop hammering.
+#   * <  _STABLE_CONNECTION_SECONDS   -> never stable: escalate backoff and let the
+#                                        attempt counter climb toward give-up.
 _STABLE_CONNECTION_SECONDS = 30
+_HEALTHY_CONNECTION_SECONDS = 120
+_INITIAL_RETRY_DELAY: float = 5
+_MAX_RETRY_DELAY: float = 300  # 5 minutes max
 
 
 # Subscription names that carry log content and therefore need _cap_log_content.
@@ -434,12 +448,35 @@ class SubscriptionManager:
                 logger.error(f"[SHUTDOWN] Error stopping subscription '{name}': {e}", exc_info=True)
         logger.info(f"[SHUTDOWN] Stopped {len(subscription_names)} subscription(s)")
 
+    @staticmethod
+    def _compute_reconnect_delay(
+        connected_duration: float, current_delay: float
+    ) -> tuple[float, bool]:
+        """Decide the next reconnect backoff and whether to reset the give-up counter.
+
+        Returns ``(next_delay, reset_attempts)``. Pure function of the just-ended
+        connection's duration and the current backoff — extracted from the
+        reconnect loop so the PERF-H2 invariant is unit-testable:
+
+        * A connection that flaps just past ``_STABLE_CONNECTION_SECONDS`` keeps the
+          attempt counter reset (so we don't abandon a backend we *can* reach) but
+          still escalates backoff — it can no longer pin the cadence at the floor.
+        * Only a genuinely healthy connection (``>= _HEALTHY_CONNECTION_SECONDS``)
+          resets backoff to the floor.
+        * A connection that never stabilizes escalates backoff *and* lets the
+          attempt counter climb toward the give-up ceiling.
+        """
+        if connected_duration >= _HEALTHY_CONNECTION_SECONDS:
+            return _INITIAL_RETRY_DELAY, True
+        if connected_duration >= _STABLE_CONNECTION_SECONDS:
+            return min(current_delay * 1.5, _MAX_RETRY_DELAY), True
+        return min(current_delay * 1.5, _MAX_RETRY_DELAY), False
+
     async def _subscription_loop(
         self, subscription_name: str, query: str, variables: dict[str, Any] | None
     ) -> None:
         """Main loop for maintaining a GraphQL subscription with comprehensive logging."""
-        retry_delay: int | float = 5
-        max_retry_delay = 300  # 5 minutes max
+        retry_delay: float = _INITIAL_RETRY_DELAY
 
         while True:
             attempt = self.reconnect_attempts.get(subscription_name, 0) + 1
@@ -663,35 +700,33 @@ class SubscriptionManager:
                 logger.error(f"[WEBSOCKET:{subscription_name}] {error_msg}", exc_info=True)
                 self._set_connection_state(subscription_name, "error", error_msg)
 
-            # Check if connection was stable before deciding on retry behavior
+            # Decide retry behavior from how long the just-ended connection lasted.
             start_time = self._connection_start_times.pop(subscription_name, None)
-            if start_time is not None:
-                connected_duration = time.monotonic() - start_time
-                if connected_duration >= _STABLE_CONNECTION_SECONDS:
-                    # Connection was stable — reset retry counter and backoff
-                    logger.info(
-                        f"[WEBSOCKET:{subscription_name}] Connection was stable "
-                        f"({connected_duration:.0f}s >= {_STABLE_CONNECTION_SECONDS}s), "
-                        f"resetting retry counter"
-                    )
-                    self.reconnect_attempts[subscription_name] = 0
-                    retry_delay = 5
-                else:
-                    logger.warning(
-                        f"[WEBSOCKET:{subscription_name}] Connection was unstable "
-                        f"({connected_duration:.0f}s < {_STABLE_CONNECTION_SECONDS}s), "
-                        f"keeping retry counter at {self.reconnect_attempts.get(subscription_name, 0)}"
-                    )
-                    # Only escalate backoff when connection was NOT stable
-                    retry_delay = min(retry_delay * 1.5, max_retry_delay)
+            connected_duration = (time.monotonic() - start_time) if start_time is not None else 0.0
+            retry_delay, reset_attempts = self._compute_reconnect_delay(
+                connected_duration, retry_delay
+            )
+            if reset_attempts:
+                self.reconnect_attempts[subscription_name] = 0
+                logger.info(
+                    f"[WEBSOCKET:{subscription_name}] Connection lasted {connected_duration:.0f}s "
+                    f"(>= {_STABLE_CONNECTION_SECONDS}s) — reset attempt counter"
+                )
             else:
-                # No connection was established — escalate backoff
-                retry_delay = min(retry_delay * 1.5, max_retry_delay)
+                logger.warning(
+                    f"[WEBSOCKET:{subscription_name}] Connection lasted {connected_duration:.0f}s "
+                    f"(< {_STABLE_CONNECTION_SECONDS}s) — attempt counter climbing toward give-up"
+                )
+
+            # Full jitter on the actual sleep decorrelates the ~14 concurrent loops so a
+            # shared-backend outage doesn't produce synchronized reconnect bursts (PERF-H2).
+            sleep_for = random.uniform(retry_delay * 0.5, retry_delay)  # noqa: S311 — jitter, not crypto
             logger.info(
-                f"[WEBSOCKET:{subscription_name}] Reconnecting in {retry_delay:.1f} seconds..."
+                f"[WEBSOCKET:{subscription_name}] Reconnecting in {sleep_for:.1f}s "
+                f"(backoff {retry_delay:.1f}s)..."
             )
             self._set_connection_state(subscription_name, "reconnecting")
-            await asyncio.sleep(retry_delay)
+            await asyncio.sleep(sleep_for)
 
         # The while loop exited (via break or max_retries exceeded).
         # Remove from active_subscriptions so start_subscription() can restart it.

--- a/unraid_mcp/subscriptions/manager.py
+++ b/unraid_mcp/subscriptions/manager.py
@@ -21,7 +21,17 @@ from ..config import settings as _settings
 from ..config.logging import logger
 from ..core.client import redact_sensitive
 from ..core.types import SubscriptionData
-from .protocol import CompleteEvent, DataEvent, ErrorEvent, iter_messages
+from .protocol import (
+    _WS_ACK_TIMEOUT,
+    _WS_CLOSE_TIMEOUT,
+    _WS_CONNECT_TIMEOUT,
+    _WS_PING_INTERVAL,
+    _WS_PING_TIMEOUT,
+    CompleteEvent,
+    DataEvent,
+    ErrorEvent,
+    iter_messages,
+)
 from .state import SubscriptionState, _StateFieldView
 from .utils import build_connection_init, build_ws_ssl_context, build_ws_url
 
@@ -503,7 +513,7 @@ class SubscriptionManager:
                 ssl_context = build_ws_ssl_context(ws_url)
 
                 # Connection with timeout
-                connect_timeout = 10
+                connect_timeout = _WS_CONNECT_TIMEOUT
                 logger.debug(
                     f"[WEBSOCKET:{subscription_name}] Connection timeout: {connect_timeout}s"
                 )
@@ -512,9 +522,9 @@ class SubscriptionManager:
                     ws_url,
                     subprotocols=[Subprotocol("graphql-transport-ws"), Subprotocol("graphql-ws")],
                     open_timeout=connect_timeout,
-                    ping_interval=20,
-                    ping_timeout=10,
-                    close_timeout=10,
+                    ping_interval=_WS_PING_INTERVAL,
+                    ping_timeout=_WS_PING_TIMEOUT,
+                    close_timeout=_WS_CLOSE_TIMEOUT,
                     ssl=ssl_context,
                 ) as websocket:
                     selected_proto = websocket.subprotocol or "none"
@@ -544,7 +554,7 @@ class SubscriptionManager:
 
                     # Wait for connection acknowledgment
                     logger.debug(f"[PROTOCOL:{subscription_name}] Waiting for connection_ack...")
-                    init_raw = await asyncio.wait_for(websocket.recv(), timeout=30)
+                    init_raw = await asyncio.wait_for(websocket.recv(), timeout=_WS_ACK_TIMEOUT)
 
                     try:
                         init_data = json.loads(init_raw)

--- a/unraid_mcp/subscriptions/manager.py
+++ b/unraid_mcp/subscriptions/manager.py
@@ -24,7 +24,7 @@ from ..core.types import SubscriptionData
 from .protocol import (
     _WS_ACK_TIMEOUT,
     _WS_CLOSE_TIMEOUT,
-    _WS_CONNECT_TIMEOUT,
+    _WS_OPEN_TIMEOUT,
     _WS_PING_INTERVAL,
     _WS_PING_TIMEOUT,
     CompleteEvent,
@@ -513,7 +513,7 @@ class SubscriptionManager:
                 ssl_context = build_ws_ssl_context(ws_url)
 
                 # Connection with timeout
-                connect_timeout = _WS_CONNECT_TIMEOUT
+                connect_timeout = _WS_OPEN_TIMEOUT
                 logger.debug(
                     f"[WEBSOCKET:{subscription_name}] Connection timeout: {connect_timeout}s"
                 )

--- a/unraid_mcp/subscriptions/protocol.py
+++ b/unraid_mcp/subscriptions/protocol.py
@@ -59,6 +59,33 @@ _SUBPROTOCOLS: tuple[Subprotocol, ...] = (
 )
 
 
+# ---------------------------------------------------------------------------
+# WebSocket connect / keepalive / handshake timeout constants
+# ---------------------------------------------------------------------------
+# Named lifts of the previously-hardcoded magic numbers spread across this module,
+# the snapshot helpers, the diagnostics probe, and the manager loop. Values are
+# preserved exactly per call site — where two sites legitimately differ (the ping
+# cadence is 20s for the manager/snapshot but 30s for the diagnostics probe), the
+# difference is kept as two distinct constants rather than unified.
+
+# websockets.connect open_timeout — connect deadline (manager + diagnostics probe).
+_WS_OPEN_TIMEOUT: float = 10.0
+# Manager-loop connect timeout (historically a bare int 10, kept as int).
+_WS_CONNECT_TIMEOUT: int = 10
+# Keepalive ping deadline forwarded to websockets.connect.
+_WS_PING_TIMEOUT: float = 10.0
+# Keepalive ping cadence — most call sites (session default, snapshot, manager).
+_WS_PING_INTERVAL: float = 20.0
+# Keepalive ping cadence used only by the diagnostics probe.
+_WS_PROBE_PING_INTERVAL: float = 30.0
+# websockets.connect close_timeout (manager loop only).
+_WS_CLOSE_TIMEOUT: int = 10
+# Timeout waiting for connection_ack (session default + manager handshake).
+_WS_ACK_TIMEOUT: float = 30.0
+# Deadline for the diagnostics probe's first post-subscribe frame recv().
+_WS_FIRST_FRAME_TIMEOUT: float = 5.0
+
+
 class ProtocolError(Exception):
     """Raised when the graphql-ws handshake fails (no ack / connection_error).
 
@@ -211,10 +238,10 @@ async def graphql_ws_session(
     sub_id: str,
     variables: dict[str, Any] | None = None,
     ssl_context: _ssl.SSLContext | None = None,
-    open_timeout: float = 10.0,
-    ack_timeout: float | None = 30.0,
-    ping_interval: float = 20.0,
-    ping_timeout: float = 10.0,
+    open_timeout: float = _WS_OPEN_TIMEOUT,
+    ack_timeout: float | None = _WS_ACK_TIMEOUT,
+    ping_interval: float = _WS_PING_INTERVAL,
+    ping_timeout: float = _WS_PING_TIMEOUT,
     close_timeout: float | None = None,
 ) -> AsyncIterator[GraphqlWsSession]:
     """Connect, authenticate, and subscribe over a graphql-ws WebSocket.

--- a/unraid_mcp/subscriptions/protocol.py
+++ b/unraid_mcp/subscriptions/protocol.py
@@ -69,9 +69,8 @@ _SUBPROTOCOLS: tuple[Subprotocol, ...] = (
 # difference is kept as two distinct constants rather than unified.
 
 # websockets.connect open_timeout — connect deadline (manager + diagnostics probe).
+# One constant for the single concept; websockets/asyncio accept the float fine.
 _WS_OPEN_TIMEOUT: float = 10.0
-# Manager-loop connect timeout (historically a bare int 10, kept as int).
-_WS_CONNECT_TIMEOUT: int = 10
 # Keepalive ping deadline forwarded to websockets.connect.
 _WS_PING_TIMEOUT: float = 10.0
 # Keepalive ping cadence — most call sites (session default, snapshot, manager).

--- a/unraid_mcp/subscriptions/resources.py
+++ b/unraid_mcp/subscriptions/resources.py
@@ -124,6 +124,23 @@ async def autostart_subscriptions() -> None:
         logger.info("[AUTOSTART] No log file path configured for auto-start")
 
 
+def _apply_startup_error(base: dict[str, Any], subject: str) -> dict[str, Any]:
+    """Overlay the autostart failure onto a fallback/placeholder payload, if any.
+
+    Returns ``base`` unchanged when autostart succeeded. ``subject`` is the leading
+    clause of the surfaced message (e.g. "Subscription autostart failed" or
+    "Subscription 'cpu' unavailable: autostart failed").
+    """
+    if _last_startup_error is None:
+        return base
+    return {
+        **base,
+        "status": "error",
+        "startup_error": _last_startup_error,
+        "message": f"{subject} ({_last_startup_error}). Check server logs.",
+    }
+
+
 def register_subscription_resources(mcp: FastMCP) -> None:
     """Register all subscription resources with the FastMCP instance.
 
@@ -143,14 +160,7 @@ def register_subscription_resources(mcp: FastMCP) -> None:
             "status": "No subscription data yet",
             "message": "Subscriptions auto-start on server boot. If this persists, check server logs for WebSocket/auth issues.",
         }
-        if _last_startup_error is not None:
-            fallback["status"] = "error"
-            fallback["startup_error"] = _last_startup_error
-            fallback["message"] = (
-                f"Subscription autostart failed: {_last_startup_error}. "
-                "Live data is unavailable — check server logs."
-            )
-        return json.dumps(fallback, indent=2)
+        return json.dumps(_apply_startup_error(fallback, "Subscription autostart failed"), indent=2)
 
     def _make_resource_fn(action: str) -> Callable[[], Coroutine[Any, Any, str]]:
         async def _live_resource() -> str:
@@ -181,20 +191,18 @@ def register_subscription_resources(mcp: FastMCP) -> None:
                         return json.dumps(fallback_data, indent=2)
                 except Exception as e:
                     logger.warning("[RESOURCE] On-demand fallback for '%s' failed: %s", action, e)
+            # Autostart failure is surfaced here instead of a perpetual "connecting"
+            # placeholder that would hide the dead feature (C1).
             placeholder: dict[str, Any] = {
                 "status": "connecting",
                 "message": f"Subscription '{action}' is starting. Retry in a moment.",
             }
-            if _last_startup_error is not None:
-                # Autostart failed permanently — surface it instead of a perpetual
-                # "connecting" placeholder that hides the dead feature (C1).
-                placeholder["status"] = "error"
-                placeholder["startup_error"] = _last_startup_error
-                placeholder["message"] = (
-                    f"Subscription '{action}' unavailable: autostart failed "
-                    f"({_last_startup_error}). Check server logs."
-                )
-            return json.dumps(placeholder, indent=2)
+            return json.dumps(
+                _apply_startup_error(
+                    placeholder, f"Subscription '{action}' unavailable: autostart failed"
+                ),
+                indent=2,
+            )
 
         _live_resource.__name__ = f"{action}_resource"
         _live_resource.__doc__ = (

--- a/unraid_mcp/subscriptions/resources.py
+++ b/unraid_mcp/subscriptions/resources.py
@@ -21,14 +21,31 @@ from .snapshot import subscribe_once
 
 # Global flag to track subscription startup
 _subscriptions_started = False
+# Most recent autostart failure (repr), or None if the last attempt succeeded.
+# Surfaced via get_last_startup_error() so a failed startup is observable instead
+# of silently swallowed (C1).
+_last_startup_error: str | None = None
 _startup_lock: Final[asyncio.Lock] = asyncio.Lock()
 
 _terminal_states = frozenset({"failed", "auth_failed", "max_retries_exceeded"})
 
 
+def get_last_startup_error() -> str | None:
+    """Return the most recent autostart failure (repr), or None if it succeeded."""
+    return _last_startup_error
+
+
 async def ensure_subscriptions_started() -> None:
-    """Ensure subscriptions are started, called from async context."""
-    global _subscriptions_started
+    """Ensure subscriptions are started, called from async context.
+
+    Autostart is attempted at most once. The ``_subscriptions_started`` flag is
+    latched even when the attempt fails, because the per-subscription loops that
+    autostart spawns handle their own reconnection/backoff — re-running the full
+    fan-out on every call when the backend is down would stampede WebSocket
+    connects (PERF-H1). A failure is recorded in ``_last_startup_error`` and
+    surfaced via diagnose and the live resources rather than swallowed (C1).
+    """
+    global _subscriptions_started, _last_startup_error
 
     # Fast-path: skip lock if already started
     if _subscriptions_started:
@@ -42,10 +59,21 @@ async def ensure_subscriptions_started() -> None:
         logger.info("[STARTUP] First async operation detected, starting subscriptions...")
         try:
             await autostart_subscriptions()
+        except asyncio.CancelledError:
+            # Shutdown in progress — do NOT latch; let cancellation propagate so a
+            # later (post-restart) call can retry.
+            raise
+        except Exception as e:
+            # Real failure: record it and latch anyway. The persistent loops (if any
+            # were spawned) self-heal via reconnect; a config-level failure is now
+            # visible through diagnose / the live resources instead of stampeding.
+            _last_startup_error = repr(e)
+            _subscriptions_started = True
+            logger.error(f"[STARTUP] Failed to start subscriptions: {e}", exc_info=True)
+        else:
+            _last_startup_error = None
             _subscriptions_started = True
             logger.info("[STARTUP] Subscriptions started successfully")
-        except Exception as e:
-            logger.error(f"[STARTUP] Failed to start subscriptions: {e}", exc_info=True)
 
 
 async def autostart_subscriptions() -> None:
@@ -101,12 +129,18 @@ def register_subscription_resources(mcp: FastMCP) -> None:
         if result is not None:
             data, fetched_at = result
             return json.dumps({**data, "_fetched_at": fetched_at}, indent=2)
-        return json.dumps(
-            {
-                "status": "No subscription data yet",
-                "message": "Subscriptions auto-start on server boot. If this persists, check server logs for WebSocket/auth issues.",
-            }
-        )
+        fallback: dict[str, Any] = {
+            "status": "No subscription data yet",
+            "message": "Subscriptions auto-start on server boot. If this persists, check server logs for WebSocket/auth issues.",
+        }
+        if _last_startup_error is not None:
+            fallback["status"] = "error"
+            fallback["startup_error"] = _last_startup_error
+            fallback["message"] = (
+                f"Subscription autostart failed: {_last_startup_error}. "
+                "Live data is unavailable — check server logs."
+            )
+        return json.dumps(fallback)
 
     def _make_resource_fn(action: str) -> Callable[[], Coroutine[Any, Any, str]]:
         async def _live_resource() -> str:
@@ -137,12 +171,20 @@ def register_subscription_resources(mcp: FastMCP) -> None:
                         return json.dumps(fallback_data, indent=2)
                 except Exception as e:
                     logger.warning("[RESOURCE] On-demand fallback for '%s' failed: %s", action, e)
-            return json.dumps(
-                {
-                    "status": "connecting",
-                    "message": f"Subscription '{action}' is starting. Retry in a moment.",
-                }
-            )
+            placeholder: dict[str, Any] = {
+                "status": "connecting",
+                "message": f"Subscription '{action}' is starting. Retry in a moment.",
+            }
+            if _last_startup_error is not None:
+                # Autostart failed permanently — surface it instead of a perpetual
+                # "connecting" placeholder that hides the dead feature (C1).
+                placeholder["status"] = "error"
+                placeholder["startup_error"] = _last_startup_error
+                placeholder["message"] = (
+                    f"Subscription '{action}' unavailable: autostart failed "
+                    f"({_last_startup_error}). Check server logs."
+                )
+            return json.dumps(placeholder, indent=2)
 
         _live_resource.__name__ = f"{action}_resource"
         _live_resource.__doc__ = (

--- a/unraid_mcp/subscriptions/resources.py
+++ b/unraid_mcp/subscriptions/resources.py
@@ -38,12 +38,16 @@ def get_last_startup_error() -> str | None:
 async def ensure_subscriptions_started() -> None:
     """Ensure subscriptions are started, called from async context.
 
-    Autostart is attempted at most once. The ``_subscriptions_started`` flag is
-    latched even when the attempt fails, because the per-subscription loops that
-    autostart spawns handle their own reconnection/backoff — re-running the full
-    fan-out on every call when the backend is down would stampede WebSocket
-    connects (PERF-H1). A failure is recorded in ``_last_startup_error`` and
-    surfaced via diagnose and the live resources rather than swallowed (C1).
+    Autostart is attempted at most once on success. On failure the
+    ``_subscriptions_started`` flag is latched **only if at least one subscription
+    loop was actually spawned**: those loops handle their own reconnection/backoff,
+    so re-running the full fan-out on every call (the backend-down case) would only
+    stampede WebSocket connects (PERF-H1). If autostart fails *before* spawning any
+    loop (a config/programming error, never a transient outage — the pre-spawn path
+    is pure in-memory), the flag is left unset so a later call can retry rather than
+    bricking the live resources until a restart. Either way the failure is recorded
+    in ``_last_startup_error`` and surfaced via diagnose / the live resources rather
+    than swallowed (C1).
     """
     global _subscriptions_started, _last_startup_error
 
@@ -64,12 +68,18 @@ async def ensure_subscriptions_started() -> None:
             # later (post-restart) call can retry.
             raise
         except Exception as e:
-            # Real failure: record it and latch anyway. The persistent loops (if any
-            # were spawned) self-heal via reconnect; a config-level failure is now
-            # visible through diagnose / the live resources instead of stampeding.
             _last_startup_error = repr(e)
-            _subscriptions_started = True
-            logger.error(f"[STARTUP] Failed to start subscriptions: {e}", exc_info=True)
+            # Latch only if loops were spawned (they self-heal via reconnect). If none
+            # were spawned, leave the flag unset so a later call retries instead of
+            # permanently surfacing the error for the process lifetime.
+            spawned = len(subscription_manager.active_subscriptions) > 0
+            _subscriptions_started = spawned
+            logger.error(
+                "[STARTUP] Failed to start subscriptions (loops spawned=%s): %s",
+                spawned,
+                e,
+                exc_info=True,
+            )
         else:
             _last_startup_error = None
             _subscriptions_started = True
@@ -140,7 +150,7 @@ def register_subscription_resources(mcp: FastMCP) -> None:
                 f"Subscription autostart failed: {_last_startup_error}. "
                 "Live data is unavailable — check server logs."
             )
-        return json.dumps(fallback)
+        return json.dumps(fallback, indent=2)
 
     def _make_resource_fn(action: str) -> Callable[[], Coroutine[Any, Any, str]]:
         async def _live_resource() -> str:

--- a/unraid_mcp/subscriptions/snapshot.py
+++ b/unraid_mcp/subscriptions/snapshot.py
@@ -24,6 +24,8 @@ from typing import Any
 from ..config.logging import logger
 from ..core.exceptions import ToolError
 from .protocol import (
+    _WS_PING_INTERVAL,
+    _WS_PING_TIMEOUT,
     DataEvent,
     ErrorEvent,
     ProtocolError,
@@ -62,8 +64,8 @@ async def _ws_handshake(
             ssl_context=ssl_context,
             open_timeout=timeout,
             ack_timeout=timeout,
-            ping_interval=20,
-            ping_timeout=10,
+            ping_interval=_WS_PING_INTERVAL,
+            ping_timeout=_WS_PING_TIMEOUT,
         ) as session:
             yield session
     except ProtocolError as e:

--- a/unraid_mcp/subscriptions/utils.py
+++ b/unraid_mcp/subscriptions/utils.py
@@ -72,10 +72,13 @@ def build_connection_init() -> dict[str, Any]:
     return msg
 
 
-def _analyze_subscription_status(
+def analyze_subscription_status(
     status: dict[str, Any],
 ) -> tuple[int, list[dict[str, Any]]]:
     """Analyze subscription status dict, returning error count and connection issues.
+
+    Public helper (#19): the tools layer consumes this across the package boundary,
+    so it carries no leading underscore.
 
     Only reports connection_issues for subscriptions that are currently in a
     failure state (not recovered ones that happen to have a stale last_error).

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -194,8 +194,13 @@ async def _handle_disk(
             variables = {"path": log_path, "lines": tail_lines}
 
         logger.info(f"Executing unraid action=disk subaction={subaction}")
+        # Guard the lookup so an unhandled subaction raises the clean guard below
+        # instead of a raw KeyError (#5).
+        query = _DISK_QUERIES.get(subaction)
+        if query is None:
+            raise ToolError(f"Unhandled disk subaction '{subaction}' — this is a bug")
         data = await _client.make_graphql_request(
-            _DISK_QUERIES[subaction], variables, custom_timeout=custom_timeout
+            query, variables, custom_timeout=custom_timeout
         )
 
         if subaction == "shares":

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -20,6 +20,7 @@ from ..core.utils import (
     format_bytes,
     validate_subaction,
 )
+from ..core.validation import validate_str_param
 
 
 # ===========================================================================
@@ -86,6 +87,9 @@ def _validate_path(
 
     Returns the normalized path. Raises ToolError on any violation.
     """
+    # Bound the length (SEC-M2). Applies to every path, including remote rclone
+    # destinations that intentionally skip the prefix check below.
+    validate_str_param(path, label)
     # Reject null bytes — they can truncate strings at the OS layer.
     if "\x00" in path:
         raise ToolError(f"{label} must not contain null bytes")

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -248,4 +248,7 @@ async def _handle_disk(
                 out["filter"] = {"level": level, "context": context}
             return out
 
+        # Distinct from the guard above the query lookup: this catches a subaction
+        # that IS in _DISK_QUERIES but has no render branch here (a future query
+        # added without a handler) — the request ran but nothing shaped the result.
         raise ToolError(f"Unhandled disk subaction '{subaction}' — this is a bug")

--- a/unraid_mcp/tools/_disk.py
+++ b/unraid_mcp/tools/_disk.py
@@ -134,10 +134,13 @@ async def _handle_disk(
         subaction,
         _DISK_DESTRUCTIVE,
         confirm,
-        f"Back up flash drive to **{remote_name}:{destination_path}**. Existing backups will be overwritten.",
+        {
+            "flash_backup": f"Back up flash drive to **{remote_name}:{destination_path}**. Existing backups will be overwritten.",
+        },
     )
 
     with tool_error_handler("disk", subaction, logger):
+        logger.info(f"Executing unraid action=disk subaction={subaction}")
         if subaction == "disk_details" and not disk_id:
             raise ToolError("disk_id is required for disk/disk_details")
 
@@ -175,9 +178,6 @@ async def _handle_disk(
             }
             if backup_options is not None:
                 input_data["options"] = backup_options
-            logger.info(
-                f"Executing unraid action=disk subaction={subaction} remote={remote_name!r} source={source_path!r} dest={destination_path!r}"
-            )
             data = await _client.make_graphql_request(
                 _DISK_MUTATIONS["flash_backup"], {"input": input_data}
             )
@@ -193,15 +193,12 @@ async def _handle_disk(
         elif subaction == "logs":
             variables = {"path": log_path, "lines": tail_lines}
 
-        logger.info(f"Executing unraid action=disk subaction={subaction}")
         # Guard the lookup so an unhandled subaction raises the clean guard below
         # instead of a raw KeyError (#5).
         query = _DISK_QUERIES.get(subaction)
         if query is None:
             raise ToolError(f"Unhandled disk subaction '{subaction}' — this is a bug")
-        data = await _client.make_graphql_request(
-            query, variables, custom_timeout=custom_timeout
-        )
+        data = await _client.make_graphql_request(query, variables, custom_timeout=custom_timeout)
 
         if subaction == "shares":
             shares = data.get("shares", []) or []

--- a/unraid_mcp/tools/_docker.py
+++ b/unraid_mcp/tools/_docker.py
@@ -342,6 +342,13 @@ async def _handle_docker(
             )
 
         if subaction == "restart":
+            # Resolution is by name (or short id), which `docker.container(id:)`
+            # cannot do — that field takes a full PrefixedID! and offers no
+            # name lookup. Unlike docker/details (which used the single-container
+            # field only to skip the *heavy* detail payload), restart's stop/start
+            # mutations take a PrefixedID! and have no payload to trim, so the
+            # minimal `{ id names }` resolve scan is the smallest correct fetch.
+            # A full prefixed id short-circuits below with no request at all.
             actual_id = await _resolve_container_id(container_id or "", strict=True)
             stop_data = await _client.make_graphql_request(
                 _DOCKER_MUTATIONS["stop"],

--- a/unraid_mcp/tools/_key.py
+++ b/unraid_mcp/tools/_key.py
@@ -63,7 +63,7 @@ async def _handle_key(
         subaction,
         _KEY_DESTRUCTIVE,
         confirm,
-        f"Delete API key **{key_id}**. Any clients using this key will lose access.",
+        {"delete": f"Delete API key **{key_id}**. Any clients using this key will lose access."},
     )
 
     with tool_error_handler("key", subaction, logger):

--- a/unraid_mcp/tools/_live.py
+++ b/unraid_mcp/tools/_live.py
@@ -9,6 +9,7 @@ plugin_install_updates (16 subactions).
 from typing import Any
 
 from ..config.logging import logger
+from ..config.settings import UNRAID_MCP_MAX_RESPONSE_BYTES
 from ..core.exceptions import ToolError, tool_error_handler
 from ..core.pagination import cap_list
 from ._disk import _ALLOWED_LOG_PREFIXES, _validate_path
@@ -17,6 +18,15 @@ from ._disk import _ALLOWED_LOG_PREFIXES, _validate_path
 # ===========================================================================
 # LIVE (subscriptions)
 # ===========================================================================
+
+# Byte budget for the collected-event lists (log_tail / notification_feed).
+# Each event can be large (multi-KB log ``content``), so bounding item *count*
+# alone (cap_list's primary cap) is not enough — a few huge events can still trip
+# the response-size backstop, which discards the ENTIRE response. We derive a
+# conservative ceiling from the response cap (half of it) so the surrounding
+# wrapper fields (success/subaction/path/page/...) plus JSON escaping comfortably
+# fit under the hard cap with margin to spare.
+_LIVE_EVENT_BYTE_BUDGET: int = max(1, UNRAID_MCP_MAX_RESPONSE_BYTES // 2)
 
 
 def _filter_log_event(event: dict[str, Any], level: str, context: int) -> dict[str, Any]:
@@ -126,8 +136,9 @@ async def _handle_live(
             if level is not None:
                 events = [_filter_log_event(e, level, context) for e in events]
             # Hard-cap the number of collected events so a noisy log over the
-            # window can't flood the agent's context.
-            capped, meta = cap_list(events, limit)
+            # window can't flood the agent's context. The byte budget additionally
+            # stops a few multi-KB log events from tripping the response backstop.
+            capped, meta = cap_list(events, limit, byte_budget=_LIVE_EVENT_BYTE_BUDGET)
             return {
                 "success": True,
                 "subaction": subaction,
@@ -153,8 +164,9 @@ async def _handle_live(
                 collect_for=collect_for,
                 timeout=timeout,
             )
-            # Hard-cap the number of collected events (see log_tail above).
-            capped, meta = cap_list(events, limit)
+            # Hard-cap the number of collected events (see log_tail above), plus
+            # the byte budget so large events can't nuke the whole response.
+            capped, meta = cap_list(events, limit, byte_budget=_LIVE_EVENT_BYTE_BUDGET)
             return {
                 "success": True,
                 "subaction": subaction,

--- a/unraid_mcp/tools/_oidc.py
+++ b/unraid_mcp/tools/_oidc.py
@@ -48,7 +48,12 @@ async def _handle_oidc(
 
     with tool_error_handler("oidc", subaction, logger):
         logger.info(f"Executing unraid action=oidc subaction={subaction}")
-        data = await _client.make_graphql_request(_OIDC_QUERIES[subaction], variables)
+        # Guard the lookup so an unhandled subaction raises the clean guard below
+        # instead of a KeyError masked as "likely a bug" (#5).
+        query = _OIDC_QUERIES.get(subaction)
+        if query is None:
+            raise ToolError(f"Unhandled oidc subaction '{subaction}' — this is a bug")
+        data = await _client.make_graphql_request(query, variables)
 
         if subaction == "providers":
             providers = data.get("oidcProviders") or []

--- a/unraid_mcp/tools/_system.py
+++ b/unraid_mcp/tools/_system.py
@@ -101,6 +101,28 @@ _SYSTEM_QUERIES: dict[str, str] = {
 
 _SYSTEM_SUBACTIONS: set[str] = set(_SYSTEM_QUERIES)
 
+# Subactions whose response is a single object echoed back under a stable key.
+# Hoisted to module scope so the dispatch table isn't rebuilt on every call.
+_SYSTEM_SIMPLE_KEYS: dict[str, str] = {
+    "registration": "registration",
+    "variables": "vars",
+    "metrics": "metrics",
+    "config": "config",
+    "owner": "owner",
+    "flash": "flash",
+    "ups_config": "upsConfiguration",
+    "server_time": "systemTime",
+}
+
+# Subactions returning a list: maps subaction -> (response_key, output_key).
+# Hoisted to module scope (see above).
+_SYSTEM_LIST_ACTIONS: dict[str, tuple[str, str]] = {
+    "services": ("services", "services"),
+    "servers": ("servers", "servers"),
+    "ups_devices": ("upsDevices", "ups_devices"),
+    "timezones": ("timeZoneOptions", "timezones"),
+}
+
 
 def _analyze_disk_health(disks: list[dict[str, Any]]) -> dict[str, int]:
     counts = {
@@ -276,18 +298,8 @@ async def _handle_system(subaction: str, device_id: str | None, limit: int = 20)
                 raise ToolError(f"UPS device '{device_id}' not found")
             return dict(result)
 
-        simple_dict = {
-            "registration": "registration",
-            "variables": "vars",
-            "metrics": "metrics",
-            "config": "config",
-            "owner": "owner",
-            "flash": "flash",
-            "ups_config": "upsConfiguration",
-            "server_time": "systemTime",
-        }
-        if subaction in simple_dict:
-            result = data.get(simple_dict[subaction])
+        if subaction in _SYSTEM_SIMPLE_KEYS:
+            result = data.get(_SYSTEM_SIMPLE_KEYS[subaction])
             if result is None:
                 if subaction == "registration":
                     raise ToolError(
@@ -297,14 +309,8 @@ async def _handle_system(subaction: str, device_id: str | None, limit: int = 20)
                 return {}
             return dict(result)
 
-        list_actions = {
-            "services": ("services", "services"),
-            "servers": ("servers", "servers"),
-            "ups_devices": ("upsDevices", "ups_devices"),
-            "timezones": ("timeZoneOptions", "timezones"),
-        }
-        if subaction in list_actions:
-            response_key, output_key = list_actions[subaction]
+        if subaction in _SYSTEM_LIST_ACTIONS:
+            response_key, output_key = _SYSTEM_LIST_ACTIONS[subaction]
             raw_items = data.get(response_key) or []
             items = list(raw_items) if isinstance(raw_items, list) else []
             # timezones returns 400+ unbounded IANA entries — cap it and surface

--- a/unraid_mcp/tools/_system.py
+++ b/unraid_mcp/tools/_system.py
@@ -135,7 +135,11 @@ async def _handle_system(subaction: str, device_id: str | None, limit: int = 20)
     if subaction == "ups_device" and not device_id:
         raise ToolError("device_id is required for system/ups_device")
 
-    query = _SYSTEM_QUERIES[subaction]
+    # Guard the lookup so an in-set-but-unhandled subaction raises a clean error
+    # instead of a raw KeyError (#5). Every real system subaction is a query.
+    query = _SYSTEM_QUERIES.get(subaction)
+    if query is None:
+        raise ToolError(f"Unhandled system subaction '{subaction}' — this is a bug")
     variables: dict[str, Any] | None = {"id": device_id} if subaction == "ups_device" else None
 
     with tool_error_handler("system", subaction, logger):

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -941,70 +941,15 @@ def register_unraid_tool(mcp: FastMCP) -> None:
 
         # Pack the flat keyword args into the structured input model. The tool
         # signature stays flat (so the MCP input schema is unchanged), but the
-        # rest of the routing operates on the validated model.
-        inp = UnraidInput(
-            action=action,
-            subaction=subaction,
-            confirm=confirm,
-            device_id=device_id,
-            disk_id=disk_id,
-            correct=correct,
-            slot=slot,
-            log_path=log_path,
-            tail_lines=tail_lines,
-            remote_name=remote_name,
-            source_path=source_path,
-            destination_path=destination_path,
-            backup_options=backup_options,
-            container_id=container_id,
-            network_id=network_id,
-            container_ids=container_ids,
-            with_image=with_image,
-            autostart_entries=autostart_entries,
-            organizer_input=organizer_input,
-            vm_id=vm_id,
-            notification_id=notification_id,
-            notification_ids=notification_ids,
-            notification_type=notification_type,
-            importance=importance,
-            offset=offset,
-            limit=limit,
-            list_type=list_type,
-            title=title,
-            subject=subject,
-            description=description,
-            key_id=key_id,
-            name=name,
-            roles=roles,
-            permissions=permissions,
-            permissions_input=permissions_input,
-            names=names,
-            bundled=bundled,
-            restart=restart,
-            url=url,
-            plugin_name=plugin_name,
-            forced=forced,
-            operation_id=operation_id,
-            provider_type=provider_type,
-            config_data=config_data,
-            settings_input=settings_input,
-            ups_config=ups_config,
-            config_input=config_input,
-            comment=comment,
-            sys_model=sys_model,
-            connect_input=connect_input,
-            onboarding_input=onboarding_input,
-            theme_name=theme_name,
-            locale=locale,
-            provider_id=provider_id,
-            token=token,
-            subscription_query=subscription_query,
-            path=path,
-            collect_for=collect_for,
-            timeout=timeout,
-            level=level,
-            context=context,
-        )
+        # rest of the routing operates on the validated model. Build the model
+        # straight from the bound parameters instead of restating all ~60 names by
+        # hand (#4): at this point locals() holds exactly the tool parameters, so
+        # we drop `ctx` (not a model field) and pass the rest. `extra="forbid"`
+        # still catches any signature/model drift, and a contract test asserts the
+        # two field sets stay identical. (locals() is captured into a variable
+        # first because a comprehension has its own scope.)
+        _params = locals()
+        inp = UnraidInput(**{k: v for k, v in _params.items() if k != "ctx"})
 
         handler = _ACTION_DISPATCH.get(action)
         if handler is None:

--- a/unraid_mcp/tools/unraid.py
+++ b/unraid_mcp/tools/unraid.py
@@ -125,7 +125,7 @@ async def _handle_health(subaction: str, ctx: Context | None) -> dict[str, Any] 
         is_configured,
     )
     from ..core.utils import safe_display_url
-    from ..subscriptions.utils import _analyze_subscription_status
+    from ..subscriptions.utils import analyze_subscription_status
 
     if subaction == "setup":
         if is_configured():
@@ -191,7 +191,7 @@ async def _handle_health(subaction: str, ctx: Context | None) -> dict[str, Any] 
 
             await ensure_subscriptions_started()
             status = await subscription_manager.get_subscription_status()
-            error_count, connection_issues = _analyze_subscription_status(status)
+            error_count, connection_issues = analyze_subscription_status(status)
             return {
                 "timestamp": datetime.datetime.now(datetime.UTC).isoformat(),
                 "environment": {

--- a/uv.lock
+++ b/uv.lock
@@ -1628,6 +1628,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "graphql-core" },
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -1639,7 +1640,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "build" },
-    { name = "graphql-core" },
     { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1653,19 +1653,19 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
-    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "fastmcp", specifier = ">=3.0.0,<4.0.0" },
+    { name = "graphql-core", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.35.0" },
-    { name = "websockets", specifier = ">=15.0.1" },
+    { name = "websockets", specifier = ">=15.0.1,<17.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.2" },
-    { name = "graphql-core", specifier = ">=3.2.0" },
     { name = "hypothesis", specifier = ">=6.151.9" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=1.2.0" },


### PR DESCRIPTION
## Summary

Implements the fixes from a full multi-dimensional code review of the `unraid_mcp/`
source, then a second adversarial PR-review pass over the result. Every one of the 64
reviewed issues is accounted for: **44 fixed with code + tests**, 12 reasoned
no-change/deferred (with rationale), 8 verified non-defects.

**47 files changed, +2199/−562, across 23 commits.** No `feat`/breaking commits — this
is a `fix`/`refactor`/`perf`/`docs`/`test` change set (release-please → patch bump).

## Highlights

### Security
- **`test_query` GraphQL allowlist bypass (confirmed exploitable)** — replaced the
  first-field-only regex with a `graphql-core` **AST validator** (exactly one allowlisted,
  alias-resolved top-level field). Added regression tests for every smuggling vector
  (multi-field, alias, fragment, argument injection, wrong operation, invalid GraphQL).
- **Raw subscription frame** no longer echoed by default (debug-flag gated).
- `_validate_path` length cap on every remote path; `UNRAID_MCP_HOST` defaults to loopback
  (Docker sets `0.0.0.0` itself); bearer-token read surfaces kept consistent.

### Reliability / correctness
- **Silent subscription-startup failure** now latches (conditionally — only when loops were
  spawned) and **surfaces** `_last_startup_error` via diagnose + the live resources, instead
  of silently dying + stampeding reconnects.
- **Reconnect backoff** decoupled "reset backoff" from "reset the give-up ceiling" + added
  jitter (a flapping backend can no longer pin a ~5s reconnect cadence forever).
- **Dispatcher fall-through**: a contract sweep found and fixed 3 real raw-`KeyError`
  fall-throughs (system/oidc/disk); the `UnraidInput` 60-field manual repack is now a
  `locals()` build guarded by a signature/model drift test.
- **Logging overwrite** driven by an in-process byte counter (no per-emit `stat()`), with the
  one-record-per-rotation undercount fixed.

### Performance
- Byte-aware `cap_list` so a few large list items can't trip the response backstop and discard
  the whole response; cheaper response-size measurement; extracted/idempotent client helpers.

### Docs / CI
- Fixed stale runbook refs (deleted smoke scripts → `tests/test_live.sh`), env-var hierarchy,
  GUARDRAILS redaction/log-prefix lists, README typecheck command; added `docs/ROLLBACK.md`.
- CI: Python 3.12+3.13 matrix, blocking PR-time Trivy scan; stdlib Docker healthcheck;
  optional compose `env_file`; documented the release PAT-expiry footgun.

## Verification
- **1454 unit/contract tests pass** (+64 added this branch), **60 integration pass**, `ruff`
  + `ty` clean.
- Second-pass PR review (code-reviewer, test-analyzer, silent-failure-hunter, comment-analyzer)
  surfaced 1 real bug (logging undercount), 1 robustness refinement (conditional latch), 2 stale
  comments, and several test gaps — **all addressed** in the final 4 commits.

## Reasoned deferrals (not silently dropped)
Response-shape unification (#7, breaking → major bump), `match/case` conversion (#32, cosmetic),
`from __future__ annotations` (#33, breaks the pydantic models), the `handler_context` extraction
(#6, high-churn — correctness covered by the new guard sweep), and the health-handler move (#47,
deliberately in `unraid.py` to break a circular import). Each documented.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Security hardening and stability pass across subscriptions, client, and tooling: AST‑validated GraphQL subscription queries with a 4KB input cap and single‑definition rule, safer defaults, smarter reconnects, and byte‑aware response limits. Fixes 44 review issues with extensive tests (now covering edge paths in logging and response limiting); no breaking changes.

- **Bug Fixes**
  - GraphQL `test_query`: validate the parsed AST (exactly one allowlisted subscription field), cap input to 4096 chars, and require a single definition. Tests cover multi‑field/alias/fragment/argument smuggling and oversize cases.
  - Logging: overwrite handler re‑accounts the in‑flight record after rotation and writes the reset marker only on successful overwrite.
  - Safer defaults/guards: `UNRAID_MCP_HOST=127.0.0.1` by default; raw upstream frames gated by `UNRAID_MCP_ENABLE_RAW_SUBSCRIPTION_PROBE`; path length cap applied to all paths; redaction extended by key and value shape.
  - Correctness: guarded dispatcher fall‑throughs (no raw `KeyError`), idempotent start via numeric 304, live event lists use byte‑aware capping, conditional autostart latch with surfaced errors, and reconnect backoff decoupled with jitter. Named WS timeouts consolidate magic numbers.
  - Coverage: add tests for response‑limit multi‑block early‑bail and non‑text fallback, failed‑rotation path (no reset marker on reopen failure), and non‑finite float formatting to "N/A".

- **Refactors**
  - Helpers/API cleanup: faster multi‑block response measurement; client 429‑retry/idempotent helpers; public `analyze_subscription_status`; hoisted system dispatch tables; deduped startup‑error handling; clarified bearer‑token surface.
  - Dependencies/CI/Docker/docs: promote `graphql-core` to runtime; cap `fastmcp<4` and `websockets<17`; test matrix for Python 3.12/3.13; blocking PR‑time Trivy scan loads the PR image locally (amd64‑only), disables SBOM/provenance on PRs, and is scoped to library (Python dependency) CVEs; stdlib Docker healthcheck and optional compose `env_file`; added `docs/ROLLBACK.md` and PAT‑expiry note in release workflow; updated scripts/Justfile/docs; style‑only `ruff` format of new tests.

<sup>Written for commit 069541040a735c9afc294bbe613aed9bdab9c8a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional raw WebSocket frame visibility for subscription diagnostics.
  * Implemented byte-based response budgeting for live event feeds.

* **Bug Fixes**
  * Improved health check reliability using Python-based HTTP validation.
  * Fixed bearer token synchronization across configuration surfaces.
  * Enhanced rate-limiter integration validation.

* **Security**
  * Tightened allowed log paths and expanded secret detection patterns.
  * Added pre-merge vulnerability scanning for Docker images.
  * Changed default host binding to loopback-only for security.

* **Documentation**
  * Added release rollback runbook.
  * Updated CI matrix testing for multiple Python versions.

* **Tests**
  * Comprehensive concurrency-safety test coverage added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->