### PR TITLE
[codex] Fix Docker runtime Python mismatch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     schedule:
       interval: "weekly"
 
-  # Keep the Dockerfile base images fresh (digest-pinned FROM lines).
+  # Keep the Dockerfile base images fresh.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev
 
 # ── Stage 2: Runtime ────────────────────────────────────────────────────────────
-FROM python@sha256:4d7dd74c5b2d3151fe58eb8ecc9c56be13471a240ce5423ba765b04f8f95ebe8 AS runtime
-# tag: python:3.12-slim-bookworm  (digest pinned for reproducibility; Dependabot bumps it)
+FROM python:3.12-slim-bookworm AS runtime
+# Runtime Python must match the builder's Python 3.12 virtualenv layout.
 
 RUN groupadd --gid 1000 mcp && \
     useradd --uid 1000 --gid mcp --create-home mcp

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -36,6 +36,13 @@ def test_container_configs_use_runtime_port_variable() -> None:
     assert "${UNRAID_MCP_PORT:-6970}" in dockerfile
 
 
+def test_docker_runtime_python_matches_builder_minor_version() -> None:
+    dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
+    assert "uv:python3.12-bookworm-slim" in dockerfile
+    assert "FROM python:3.12-slim-bookworm AS runtime" in dockerfile
+    assert "FROM python@sha256:" not in dockerfile
+
+
 def test_test_live_script_uses_safe_counters_and_resource_failures() -> None:
     script = (PROJECT_ROOT / "tests" / "test_live.sh").read_text()
     assert "(( PASS++ ))" in script


### PR DESCRIPTION
## Summary

Closes #89 by changing the Docker runtime stage from a digest-only `python` base image to `python:3.12-slim-bookworm`, matching the `uv:python3.12-bookworm-slim` builder stage.

## Root cause

Dependabot updated the digest-only runtime base to a Python 3.14 image while the builder still created a Python 3.12 virtualenv. At runtime, Python 3.14 looked for `/app/.venv/lib/python3.14/site-packages`, so the installed project package under the Python 3.12 venv layout was not importable.

## Changes

- Pin the runtime stage to `python:3.12-slim-bookworm`.
- Add a regression test that checks the builder/runtime Python minor alignment and rejects `FROM python@sha256:` in the Dockerfile.
- Update the Dependabot Docker comment now that the runtime base is intentionally tag-pinned.

## Validation

- `uv run pytest tests/test_review_regressions.py -q`
- `uv run ruff check tests/test_review_regressions.py`
- `docker build -t unraid-mcp:issue-89-runtime-python .`
- `docker run --rm --entrypoint python unraid-mcp:issue-89-runtime-python -c "import sys, unraid_mcp; print(sys.version.split()[0]); print(unraid_mcp.__file__)"` -> Python `3.12.13`, `/app/unraid_mcp/__init__.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Docker runtime to Python 3.12 to match the builder, fixing import failures caused by mismatched venv paths. Adds a test to prevent regressions.

- **Bug Fixes**
  - Set runtime base to `python:3.12-slim-bookworm`, matching `uv:python3.12-bookworm-slim`.
  - Added test to ensure builder/runtime Python minors match and to block `FROM python@sha256:`.
  - Updated Docker `Dependabot` comment to reflect tag pinning.

<sup>Written for commit b8b528654a170f2645479872f82b701ca7861193. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

