### PR TITLE
test: add GraphQL operation parity coverage

### DIFF
--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,0 +1,72 @@
+name: Schema drift
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift:
+    name: Compare vendored Unraid SDL to upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Fetch upstream SDL
+        run: |
+          curl -fsSL \
+            https://raw.githubusercontent.com/unraid/api/main/api/generated-schema.graphql \
+            -o upstream-schema.graphql
+
+      - name: Diff vendored schema
+        id: diff
+        run: |
+          if diff -u docs/unraid/UNRAID-SCHEMA.graphql upstream-schema.graphql > schema.diff; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "Vendored Unraid SDL is up to date."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "Unraid SDL has drifted from the vendored copy:"
+            cat schema.diff
+          fi
+
+      - name: Open or update drift issue
+        if: steps.diff.outputs.drift == 'true'
+        run: |
+          title='Unraid GraphQL schema drift detected'
+          {
+            echo 'The vendored `docs/unraid/UNRAID-SCHEMA.graphql` no longer matches'
+            echo "Unraid's published SDL at \`unraid/api@main\`."
+            echo
+            echo 'Re-vendor the schema, then run the schema and dispatch contract tests'
+            echo 'to surface which queries, mutations, and mock responses need updates.'
+            echo
+            echo '<details><summary>diff</summary>'
+            echo
+            echo '```diff'
+            head -c 60000 schema.diff
+            echo
+            echo '```'
+            echo
+            echo '</details>'
+          } > issue-body.md
+
+          existing="$(
+            gh issue list \
+              --state open \
+              --search "$title in:title" \
+              --json number \
+              --jq '.[0].number // ""'
+          )"
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --body-file issue-body.md
+          else
+            gh issue create --title "$title" --body-file issue-body.md
+          fi

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -40,22 +40,22 @@ jobs:
       - name: Open or update drift issue
         if: steps.diff.outputs.drift == 'true'
         run: |
-          title='Unraid GraphQL schema drift detected'
+          title="Unraid GraphQL schema drift detected"
           {
-            echo 'The vendored `docs/unraid/UNRAID-SCHEMA.graphql` no longer matches'
+            echo "The vendored \`docs/unraid/UNRAID-SCHEMA.graphql\` no longer matches"
             echo "Unraid's published SDL at \`unraid/api@main\`."
             echo
-            echo 'Re-vendor the schema, then run the schema and dispatch contract tests'
-            echo 'to surface which queries, mutations, and mock responses need updates.'
+            echo "Re-vendor the schema, then run the schema and dispatch contract tests"
+            echo "to surface which queries, mutations, and mock responses need updates."
             echo
-            echo '<details><summary>diff</summary>'
+            echo "<details><summary>diff</summary>"
             echo
-            echo '```diff'
+            echo "\`\`\`diff"
             head -c 60000 schema.diff
             echo
-            echo '```'
+            echo "\`\`\`"
             echo
-            echo '</details>'
+            echo "</details>"
           } > issue-body.md
 
           existing="$(
@@ -63,10 +63,28 @@ jobs:
               --state open \
               --search "$title in:title" \
               --json number \
-              --jq '.[0].number // ""'
+              --jq ".[0].number // \"\""
           )"
           if [ -n "$existing" ]; then
             gh issue edit "$existing" --body-file issue-body.md
           else
             gh issue create --title "$title" --body-file issue-body.md
+          fi
+
+      - name: Close resolved drift issue
+        if: steps.diff.outputs.drift == 'false'
+        run: |
+          title="Unraid GraphQL schema drift detected"
+          existing="$(
+            gh issue list \
+              --state open \
+              --search "$title in:title" \
+              --json number \
+              --jq ".[0].number // \"\""
+          )"
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" \
+              --body "The vendored Unraid SDL now matches \`unraid/api@main\`; closing this drift report."
+            gh issue close "$existing" \
+              --comment "Schema drift resolved by the current vendored SDL."
           fi

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -90,7 +90,26 @@ Validate GraphQL query strings against the Unraid API schema (119 tests):
 uv run pytest tests/schema/
 ```
 
-Uses `graphql-core` to parse and validate all query dicts.
+Uses `graphql-core` to parse and validate all query/mutation dicts, drives the
+real consolidated `unraid` tool dispatch to verify every GraphQL operation is
+actually emitted by the action/subaction path, and validates the offline mock
+Unraid scenarios against the selected response shapes. The dispatch contract
+covers reads and mutations.
+
+To print the complete generated GraphQL operation inventory or the API root-field
+parity report:
+
+```bash
+scripts/list_graphql_operations.py
+scripts/list_graphql_operations.py --json
+scripts/report_api_parity.py
+scripts/report_api_parity.py --json
+```
+
+The parity report compares the vendored Unraid SDL root query/mutation/
+subscription fields against the exposed operation inventory. Missing mutation
+roots fail the schema tests unless explicitly classified; current query and
+subscription gaps are documented as intentional in `tests/schema/api_parity.py`.
 
 ### HTTP layer tests (`tests/http_layer/`)
 

--- a/docs/mcp/TESTS.md
+++ b/docs/mcp/TESTS.md
@@ -107,9 +107,10 @@ scripts/report_api_parity.py --json
 ```
 
 The parity report compares the vendored Unraid SDL root query/mutation/
-subscription fields against the exposed operation inventory. Missing mutation
-roots fail the schema tests unless explicitly classified; current query and
-subscription gaps are documented as intentional in `tests/schema/api_parity.py`.
+subscription fields against the emitted GraphQL inventory, including internal
+helper queries and live subscription queries. Missing mutation/subscription
+roots fail the schema tests unless explicitly classified; current query gaps are
+documented as intentional in `unraid_mcp/devtools/api_parity.py`.
 
 ### HTTP layer tests (`tests/http_layer/`)
 

--- a/scripts/list_graphql_operations.py
+++ b/scripts/list_graphql_operations.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env -S uv run python
+"""Print the complete GraphQL operation inventory for live smoke tooling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load_cases() -> list[tuple[str, str, str]]:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    from tests.schema.operation_inventory import all_operation_cases
+
+    return all_operation_cases()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args()
+
+    rows = [
+        {"action": action, "subaction": subaction, "operation": _operation_name(query)}
+        for action, subaction, query in _load_cases()
+    ]
+
+    if args.json:
+        print(json.dumps(rows, indent=2, sort_keys=True))
+        return 0
+
+    width_action = max(len(row["action"]) for row in rows)
+    width_subaction = max(len(row["subaction"]) for row in rows)
+    for row in rows:
+        print(
+            f"{row['action']:<{width_action}}  "
+            f"{row['subaction']:<{width_subaction}}  "
+            f"{row['operation']}"
+        )
+    print(f"\n{len(rows)} GraphQL operations")
+    return 0
+
+
+def _operation_name(query: str) -> str:
+    words = query.strip().split()
+    if len(words) >= 2 and words[0] in {"query", "mutation", "subscription"}:
+        return words[1].split("(", 1)[0]
+    return words[0] if words else ""
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/list_graphql_operations.py
+++ b/scripts/list_graphql_operations.py
@@ -8,11 +8,13 @@ import json
 import sys
 from pathlib import Path
 
+from graphql import OperationDefinitionNode, parse
+
 
 def _load_cases() -> list[tuple[str, str, str]]:
     repo_root = Path(__file__).resolve().parents[1]
     sys.path.insert(0, str(repo_root))
-    from tests.schema.operation_inventory import all_operation_cases
+    from unraid_mcp.devtools.graphql_inventory import all_operation_cases
 
     return all_operation_cases()
 
@@ -44,10 +46,15 @@ def main() -> int:
 
 
 def _operation_name(query: str) -> str:
-    words = query.strip().split()
-    if len(words) >= 2 and words[0] in {"query", "mutation", "subscription"}:
-        return words[1].split("(", 1)[0]
-    return words[0] if words else ""
+    doc = parse(query)
+    operation = next(
+        definition
+        for definition in doc.definitions
+        if isinstance(definition, OperationDefinitionNode)
+    )
+    if operation.name is not None:
+        return operation.name.value
+    return f"anonymous_{operation.operation.value}"
 
 
 if __name__ == "__main__":

--- a/scripts/report_api_parity.py
+++ b/scripts/report_api_parity.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S uv run python
+"""Report Unraid GraphQL root-field coverage for exposed operations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_report() -> dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(repo_root))
+    from tests.schema.api_parity import api_parity_report
+
+    return api_parity_report()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args()
+
+    report = _load_report()
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+
+    print("Unraid GraphQL API parity")
+    print(f"owned operations: {report['operation_count']}")
+    print()
+    for section in ("query", "mutation", "subscription"):
+        data = report[section]
+        print(
+            f"{section:<12} {data['used']:>3}/{data['total']:<3} used  "
+            f"{len(data['missing']):>2} missing  "
+            f"{len(data['unclassified_missing']):>2} unclassified"
+        )
+
+    for section in ("query", "subscription"):
+        intentional = report[section]["intentional"]
+        if not intentional:
+            continue
+        print()
+        print(f"intentional {section} gaps:")
+        for name, reason in intentional.items():
+            print(f"  {name}: {reason}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_api_parity.py
+++ b/scripts/report_api_parity.py
@@ -13,7 +13,7 @@ from typing import Any
 def _load_report() -> dict[str, Any]:
     repo_root = Path(__file__).resolve().parents[1]
     sys.path.insert(0, str(repo_root))
-    from tests.schema.api_parity import api_parity_report
+    from unraid_mcp.devtools.api_parity import api_parity_report
 
     return api_parity_report()
 
@@ -29,7 +29,7 @@ def main() -> int:
         return 0
 
     print("Unraid GraphQL API parity")
-    print(f"owned operations: {report['operation_count']}")
+    print(f"tracked GraphQL documents: {report['operation_count']}")
     print()
     for section in ("query", "mutation", "subscription"):
         data = report[section]

--- a/tests/mcporter/README.md
+++ b/tests/mcporter/README.md
@@ -9,7 +9,7 @@ Live integration smoke-tests for the unraid-mcp server.
 Use the generated inventory before adding or updating live smoke tests. It is
 derived from the same action/subaction query and mutation dictionaries that the
 schema dispatch contract tests exercise, so it includes **all** GraphQL reads and
-mutations:
+mutations plus internal helper queries and live subscription documents:
 
 ```bash
 scripts/list_graphql_operations.py

--- a/tests/mcporter/README.md
+++ b/tests/mcporter/README.md
@@ -4,6 +4,31 @@ Live integration smoke-tests for the unraid-mcp server.
 
 ---
 
+## Generated GraphQL Operation Inventory
+
+Use the generated inventory before adding or updating live smoke tests. It is
+derived from the same action/subaction query and mutation dictionaries that the
+schema dispatch contract tests exercise, so it includes **all** GraphQL reads and
+mutations:
+
+```bash
+scripts/list_graphql_operations.py
+scripts/list_graphql_operations.py --json
+```
+
+Use the root-field parity report when checking whether that inventory tracks the
+vendored Unraid schema surface:
+
+```bash
+scripts/report_api_parity.py
+scripts/report_api_parity.py --json
+```
+
+Live smoke scripts should consume this inventory or be checked against it rather
+than carrying a hand-maintained action list.
+
+---
+
 ## Canonical runner — `tests/test_live.sh`
 
 Non-destructive integration smoke-tests now live in a single canonical runner,

--- a/tests/schema/api_parity.py
+++ b/tests/schema/api_parity.py
@@ -1,0 +1,124 @@
+"""Root-field parity report between Unraid GraphQL schema and exposed operations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from graphql import FieldNode, GraphQLObjectType, OperationDefinitionNode, parse
+
+from tests.schema.mock_unraid import schema
+from tests.schema.operation_inventory import all_operation_cases
+
+
+INTENTIONAL_QUERY_GAPS: dict[str, str] = {
+    "connect": (
+        "Connect reads are exposed through narrower remoteAccess/cloud actions; "
+        "connect mutations cover the write surface."
+    ),
+    "customization": (
+        "Customization reads use publicTheme/isFreshInstall/isSSOEnabled roots, "
+        "with writes routed through the customization mutation namespace."
+    ),
+    "display": "Display data is exposed through system/display via info.display.",
+    "network": "Network data is exposed through system/network via servers/vars.",
+    "server": "Server data is exposed through system/server, system/servers, and related info roots.",
+}
+
+_SUBSCRIPTION_GAP_REASON = (
+    "Subscription roots are covered by live resources and subscription diagnostics, "
+    "not by the owned query/mutation operation inventory."
+)
+INTENTIONAL_SUBSCRIPTION_GAPS: dict[str, str] = dict.fromkeys(
+    (
+        "arraySubscription",
+        "displaySubscription",
+        "dockerContainerStats",
+        "logFile",
+        "notificationAdded",
+        "notificationsOverview",
+        "notificationsWarningsAndAlerts",
+        "ownerSubscription",
+        "parityHistorySubscription",
+        "pluginInstallUpdates",
+        "serversSubscription",
+        "systemMetricsCpu",
+        "systemMetricsCpuTelemetry",
+        "systemMetricsMemory",
+        "systemMetricsTemperature",
+        "upsUpdates",
+    ),
+    _SUBSCRIPTION_GAP_REASON,
+)
+INTENTIONAL_MUTATION_GAPS: dict[str, str] = {}
+
+
+def api_parity_report() -> dict[str, Any]:
+    """Return schema root-field coverage for the current operation inventory."""
+    used_by_kind = _used_root_fields_by_kind()
+    sections = {
+        "query": _section(
+            schema_fields=_root_fields("query"),
+            used_fields=used_by_kind["query"],
+            intentional_gaps=INTENTIONAL_QUERY_GAPS,
+        ),
+        "mutation": _section(
+            schema_fields=_root_fields("mutation"),
+            used_fields=used_by_kind["mutation"],
+            intentional_gaps=INTENTIONAL_MUTATION_GAPS,
+        ),
+        "subscription": _section(
+            schema_fields=_root_fields("subscription"),
+            used_fields=used_by_kind["subscription"],
+            intentional_gaps=INTENTIONAL_SUBSCRIPTION_GAPS,
+        ),
+    }
+    return {
+        "operation_count": len(all_operation_cases()),
+        **sections,
+    }
+
+
+def _section(
+    *,
+    schema_fields: set[str],
+    used_fields: set[str],
+    intentional_gaps: dict[str, str],
+) -> dict[str, Any]:
+    missing = schema_fields - used_fields
+    intentional_missing = missing & set(intentional_gaps)
+    return {
+        "total": len(schema_fields),
+        "used": len(used_fields & schema_fields),
+        "missing": sorted(missing),
+        "intentional": {name: intentional_gaps[name] for name in sorted(intentional_missing)},
+        "unclassified_missing": sorted(missing - set(intentional_gaps)),
+        "stale_intentional_gaps": sorted(set(intentional_gaps) - missing),
+        "unknown_used_fields": sorted(used_fields - schema_fields),
+    }
+
+
+def _root_fields(kind: str) -> set[str]:
+    graphql_schema = schema()
+    root_type = {
+        "query": graphql_schema.query_type,
+        "mutation": graphql_schema.mutation_type,
+        "subscription": graphql_schema.subscription_type,
+    }[kind]
+    if not isinstance(root_type, GraphQLObjectType):
+        return set()
+    return set(root_type.fields)
+
+
+def _used_root_fields_by_kind() -> dict[str, set[str]]:
+    used: dict[str, set[str]] = defaultdict(set)
+    for _action, _subaction, operation in all_operation_cases():
+        doc = parse(operation)
+        for definition in doc.definitions:
+            if not isinstance(definition, OperationDefinitionNode):
+                continue
+            kind = definition.operation.value
+            for selection in definition.selection_set.selections:
+                if isinstance(selection, FieldNode):
+                    used[kind].add(selection.name.value)
+    return used

--- a/tests/schema/mock_unraid.py
+++ b/tests/schema/mock_unraid.py
@@ -46,11 +46,11 @@ def _schema_shaped_response(query: str) -> dict[str, Any]:
         for definition in doc.definitions
         if isinstance(definition, OperationDefinitionNode)
     )
-    root_type = (
-        graphql_schema.mutation_type
-        if op.operation.value == "mutation"
-        else graphql_schema.query_type
-    )
+    root_type = {
+        "query": graphql_schema.query_type,
+        "mutation": graphql_schema.mutation_type,
+        "subscription": graphql_schema.subscription_type,
+    }[op.operation.value]
     assert root_type is not None
     return _selection_object(root_type, op.selection_set.selections, ())
 
@@ -92,10 +92,10 @@ def _sample_value(graphql_type: Any, selections: Any, path: tuple[str, ...]) -> 
 def _sample_scalar(name: str, path: tuple[str, ...]) -> Any:
     field = path[-1]
     joined = ".".join(path)
-    if field == "id" and "docker" in path:
-        return CONTAINER_ID
     if field == "id" and "network" in joined.lower():
         return "network-1"
+    if field == "id" and "docker" in path:
+        return CONTAINER_ID
     if field == "id" and "upsDeviceById" in path:
         return "server-1"
     if field == "id" and "disk" in joined.lower():

--- a/tests/schema/mock_unraid.py
+++ b/tests/schema/mock_unraid.py
@@ -1,0 +1,150 @@
+"""Schema-shaped offline Unraid GraphQL mock used by contract tests."""
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from graphql import (
+    FieldNode,
+    GraphQLEnumType,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLScalarType,
+    GraphQLSchema,
+    OperationDefinitionNode,
+    build_schema,
+    parse,
+)
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "unraid" / "UNRAID-SCHEMA.graphql"
+CONTAINER_ID = "a" * 64
+SCENARIOS = ("healthy", "degraded", "parity-running", "disk-failing")
+
+
+def mock_graphql_response(query: str, scenario: str = "healthy") -> dict[str, Any]:
+    """Return a schema-shaped data payload for ``query`` under ``scenario``."""
+    if scenario not in SCENARIOS:
+        raise ValueError(f"unknown mock Unraid scenario: {scenario}")
+
+    response = _schema_shaped_response(query)
+    _apply_scenario(response, scenario)
+    return response
+
+
+@lru_cache(maxsize=1)
+def schema() -> GraphQLSchema:
+    return build_schema(SCHEMA_PATH.read_text())
+
+
+def _schema_shaped_response(query: str) -> dict[str, Any]:
+    graphql_schema = schema()
+    doc = parse(query)
+    op = next(
+        definition
+        for definition in doc.definitions
+        if isinstance(definition, OperationDefinitionNode)
+    )
+    root_type = (
+        graphql_schema.mutation_type
+        if op.operation.value == "mutation"
+        else graphql_schema.query_type
+    )
+    assert root_type is not None
+    return _selection_object(root_type, op.selection_set.selections, ())
+
+
+def _selection_object(
+    parent_type: GraphQLObjectType,
+    selections: Any,
+    path: tuple[str, ...],
+) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for selection in selections:
+        if not isinstance(selection, FieldNode):
+            continue
+        field_name = selection.name.value
+        response_key = selection.alias.value if selection.alias else field_name
+        field = parent_type.fields[field_name]
+        out[response_key] = _sample_value(
+            field.type,
+            selection.selection_set.selections if selection.selection_set else (),
+            (*path, response_key),
+        )
+    return out
+
+
+def _sample_value(graphql_type: Any, selections: Any, path: tuple[str, ...]) -> Any:
+    if isinstance(graphql_type, GraphQLNonNull):
+        return _sample_value(graphql_type.of_type, selections, path)
+    if isinstance(graphql_type, GraphQLList):
+        return [_sample_value(graphql_type.of_type, selections, (*path, "0"))]
+    if isinstance(graphql_type, GraphQLObjectType):
+        return _selection_object(graphql_type, selections, path)
+    if isinstance(graphql_type, GraphQLEnumType):
+        return next(iter(graphql_type.values))
+    if isinstance(graphql_type, GraphQLScalarType):
+        return _sample_scalar(graphql_type.name, path)
+    return None
+
+
+def _sample_scalar(name: str, path: tuple[str, ...]) -> Any:
+    field = path[-1]
+    joined = ".".join(path)
+    if field == "id" and "docker" in path:
+        return CONTAINER_ID
+    if field == "id" and "network" in joined.lower():
+        return "network-1"
+    if field == "id" and "upsDeviceById" in path:
+        return "server-1"
+    if field == "id" and "disk" in joined.lower():
+        return "disk-1"
+    if field == "path" and "logFile" in path:
+        return "/var/log/syslog"
+    if field == "hostname":
+        return "tower"
+    if field == "name":
+        return "name"
+    if name in {"String", "ID", "PrefixedID"}:
+        return "value"
+    if name == "URL":
+        return "https://example.com"
+    if name == "DateTime":
+        return "2026-06-23T00:00:00Z"
+    if name == "BigInt":
+        return "1"
+    if name == "Boolean":
+        return True
+    if name in {"Int", "Port"}:
+        return 1
+    if name == "Float":
+        return 1.0
+    if name == "JSON":
+        return {}
+    return "value"
+
+
+def _apply_scenario(response: dict[str, Any], scenario: str) -> None:
+    if scenario == "healthy":
+        return
+
+    array = response.get("array")
+    if isinstance(array, dict):
+        parity = array.get("parityCheckStatus")
+        if scenario == "parity-running" and isinstance(parity, dict):
+            parity.update({"running": True, "paused": False, "progress": 50, "speed": "152 MB/s"})
+        if scenario == "degraded":
+            for disk in _list_values(array.get("disks")):
+                if isinstance(disk, dict):
+                    disk.update({"status": "DISK_DSBL", "numErrors": "1"})
+
+    disks = response.get("disks")
+    if scenario == "disk-failing":
+        for disk in _list_values(disks):
+            if isinstance(disk, dict):
+                disk["smartStatus"] = "UNKNOWN"
+
+
+def _list_values(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []

--- a/tests/schema/operation_inventory.py
+++ b/tests/schema/operation_inventory.py
@@ -1,0 +1,75 @@
+"""Complete GraphQL operation inventory used by schema contract tests."""
+
+from collections.abc import Iterable
+
+from unraid_mcp.tools._array import _ARRAY_MUTATIONS, _ARRAY_QUERIES
+from unraid_mcp.tools._connect import _CONNECT_MUTATIONS, _CONNECT_QUERIES
+from unraid_mcp.tools._customization import _CUSTOMIZATION_MUTATIONS, _CUSTOMIZATION_QUERIES
+from unraid_mcp.tools._disk import _DISK_MUTATIONS, _DISK_QUERIES
+from unraid_mcp.tools._docker import (
+    _DOCKER_BULK_MUTATIONS,
+    _DOCKER_MUTATIONS,
+    _DOCKER_ORGANIZER,
+    _DOCKER_QUERIES,
+    _DOCKER_ROOT_MUTATIONS,
+)
+from unraid_mcp.tools._health import _HEALTH_QUERIES
+from unraid_mcp.tools._key import _KEY_MUTATIONS, _KEY_QUERIES
+from unraid_mcp.tools._notification import _NOTIFICATION_MUTATIONS, _NOTIFICATION_QUERIES
+from unraid_mcp.tools._oidc import _OIDC_QUERIES
+from unraid_mcp.tools._onboarding import (
+    _ONBOARDING_INPUT_MUTATIONS,
+    _ONBOARDING_QUERIES,
+    _ONBOARDING_SIMPLE_MUTATIONS,
+)
+from unraid_mcp.tools._plugin import _PLUGIN_MUTATIONS, _PLUGIN_QUERIES
+from unraid_mcp.tools._rclone import _RCLONE_MUTATIONS, _RCLONE_QUERIES
+from unraid_mcp.tools._setting import _SETTING_MUTATIONS
+from unraid_mcp.tools._system import _SYSTEM_QUERIES
+from unraid_mcp.tools._user import _USER_QUERIES
+from unraid_mcp.tools._vm import _VM_MUTATIONS, _VM_QUERIES
+
+
+def operation_dicts() -> Iterable[tuple[str, dict[str, str]]]:
+    docker_organizer = {name: spec["mutation"] for name, spec in _DOCKER_ORGANIZER.items()}
+    return (
+        ("system", _SYSTEM_QUERIES),
+        ("health", {"check": _HEALTH_QUERIES["comprehensive_health"]}),
+        ("array", _ARRAY_QUERIES),
+        ("array", _ARRAY_MUTATIONS),
+        ("disk", _DISK_QUERIES),
+        ("disk", _DISK_MUTATIONS),
+        ("docker", _DOCKER_QUERIES),
+        ("docker", _DOCKER_MUTATIONS),
+        ("docker", _DOCKER_BULK_MUTATIONS),
+        ("docker", _DOCKER_ROOT_MUTATIONS),
+        ("docker", docker_organizer),
+        ("vm", _VM_QUERIES),
+        ("vm", _VM_MUTATIONS),
+        ("notification", _NOTIFICATION_QUERIES),
+        ("notification", _NOTIFICATION_MUTATIONS),
+        ("rclone", _RCLONE_QUERIES),
+        ("rclone", _RCLONE_MUTATIONS),
+        ("user", _USER_QUERIES),
+        ("key", _KEY_QUERIES),
+        ("key", _KEY_MUTATIONS),
+        ("setting", _SETTING_MUTATIONS),
+        ("connect", _CONNECT_QUERIES),
+        ("connect", _CONNECT_MUTATIONS),
+        ("customization", _CUSTOMIZATION_QUERIES),
+        ("customization", _CUSTOMIZATION_MUTATIONS),
+        ("plugin", _PLUGIN_QUERIES),
+        ("plugin", _PLUGIN_MUTATIONS),
+        ("oidc", _OIDC_QUERIES),
+        ("onboarding", _ONBOARDING_QUERIES),
+        ("onboarding", _ONBOARDING_SIMPLE_MUTATIONS),
+        ("onboarding", _ONBOARDING_INPUT_MUTATIONS),
+    )
+
+
+def all_operation_cases() -> list[tuple[str, str, str]]:
+    cases: list[tuple[str, str, str]] = []
+    for action, operations in operation_dicts():
+        for subaction, query in operations.items():
+            cases.append((action, subaction, query))
+    return cases

--- a/tests/schema/test_api_parity.py
+++ b/tests/schema/test_api_parity.py
@@ -1,6 +1,6 @@
 """API root-field parity checks for exposed GraphQL operations."""
 
-from tests.schema.api_parity import (
+from unraid_mcp.devtools.api_parity import (
     INTENTIONAL_QUERY_GAPS,
     INTENTIONAL_SUBSCRIPTION_GAPS,
     api_parity_report,
@@ -30,8 +30,8 @@ def test_mutation_root_field_parity_is_complete() -> None:
     assert report["mutation"]["intentional"] == {}
 
 
-def test_subscription_roots_are_tracked_separately_from_owned_operations() -> None:
+def test_subscription_root_field_parity_is_complete() -> None:
     report = api_parity_report()
 
-    assert report["subscription"]["missing"] == sorted(INTENTIONAL_SUBSCRIPTION_GAPS)
-    assert set(report["subscription"]["intentional"]) == set(INTENTIONAL_SUBSCRIPTION_GAPS)
+    assert report["subscription"]["missing"] == []
+    assert report["subscription"]["intentional"] == INTENTIONAL_SUBSCRIPTION_GAPS

--- a/tests/schema/test_api_parity.py
+++ b/tests/schema/test_api_parity.py
@@ -1,0 +1,37 @@
+"""API root-field parity checks for exposed GraphQL operations."""
+
+from tests.schema.api_parity import (
+    INTENTIONAL_QUERY_GAPS,
+    INTENTIONAL_SUBSCRIPTION_GAPS,
+    api_parity_report,
+)
+
+
+def test_unraid_api_root_field_gaps_are_explicit() -> None:
+    report = api_parity_report()
+
+    for section in ("query", "mutation", "subscription"):
+        assert report[section]["unclassified_missing"] == []
+        assert report[section]["stale_intentional_gaps"] == []
+        assert report[section]["unknown_used_fields"] == []
+
+
+def test_current_query_gaps_are_intentional() -> None:
+    report = api_parity_report()
+
+    assert report["query"]["missing"] == sorted(INTENTIONAL_QUERY_GAPS)
+    assert set(report["query"]["intentional"]) == set(INTENTIONAL_QUERY_GAPS)
+
+
+def test_mutation_root_field_parity_is_complete() -> None:
+    report = api_parity_report()
+
+    assert report["mutation"]["missing"] == []
+    assert report["mutation"]["intentional"] == {}
+
+
+def test_subscription_roots_are_tracked_separately_from_owned_operations() -> None:
+    report = api_parity_report()
+
+    assert report["subscription"]["missing"] == sorted(INTENTIONAL_SUBSCRIPTION_GAPS)
+    assert set(report["subscription"]["intentional"]) == set(INTENTIONAL_SUBSCRIPTION_GAPS)

--- a/tests/schema/test_dispatch_contract.py
+++ b/tests/schema/test_dispatch_contract.py
@@ -13,16 +13,12 @@ import pytest
 from conftest import make_tool_fn
 
 from tests.schema.mock_unraid import CONTAINER_ID, mock_graphql_response
-from tests.schema.operation_inventory import all_operation_cases
-from unraid_mcp.tools._docker import _DOCKER_ORGANIZER
+from unraid_mcp.devtools.graphql_inventory import dispatch_operation_cases
+from unraid_mcp.tools._docker import _DOCKER_ORGANIZER, _DOCKER_RESOLVE_QUERY
 
 
 def _make_tool():
     return make_tool_fn("unraid_mcp.tools.unraid", "register_unraid_tool", "unraid")
-
-
-def _all_operation_cases() -> list[tuple[str, str, str]]:
-    return all_operation_cases()
 
 
 def _call_kwargs(action: str, subaction: str) -> dict[str, Any]:
@@ -108,13 +104,13 @@ def _organizer_input(subaction: str) -> dict[str, Any]:
     return {key: defaults[key] for key in allowed}
 
 
-def _mock_graphql_response(query: str) -> dict[str, Any]:
+def _mock_graphql_response(query: str, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
     return mock_graphql_response(query)
 
 
 @pytest.mark.parametrize(
     ("action", "subaction", "expected_query"),
-    _all_operation_cases(),
+    dispatch_operation_cases(),
     ids=lambda value: value if isinstance(value, str) else None,
 )
 async def test_every_graphql_operation_is_emitted_by_dispatch(
@@ -126,11 +122,26 @@ async def test_every_graphql_operation_is_emitted_by_dispatch(
     """Every query/mutation dict entry is reachable through real tool dispatch."""
     mock_graphql_request.side_effect = _mock_graphql_response
 
-    try:
-        await _make_tool()(**_call_kwargs(action, subaction))
-    except Exception:
-        if not mock_graphql_request.call_args_list:
-            raise
+    await _make_tool()(**_call_kwargs(action, subaction))
 
     emitted_queries = [call.args[0] for call in mock_graphql_request.call_args_list]
     assert expected_query in emitted_queries
+
+
+async def test_docker_name_resolution_query_is_emitted_by_dispatch(
+    mock_graphql_request: AsyncMock,
+) -> None:
+    """Docker name/short-ID paths emit the internal resolver query."""
+    mock_graphql_request.side_effect = _mock_graphql_response
+
+    await _make_tool()(
+        **{
+            **_call_kwargs("docker", "details"),
+            "action": "docker",
+            "subaction": "details",
+            "container_id": "value",
+        }
+    )
+
+    emitted_queries = [call.args[0] for call in mock_graphql_request.call_args_list]
+    assert _DOCKER_RESOLVE_QUERY in emitted_queries

--- a/tests/schema/test_dispatch_contract.py
+++ b/tests/schema/test_dispatch_contract.py
@@ -1,0 +1,136 @@
+"""Dispatch-level GraphQL contract tests.
+
+These tests validate the GraphQL operations that the consolidated ``unraid``
+tool actually emits after action/subaction routing and argument packing. This
+complements ``test_query_validation.py``, which validates the raw operation
+dicts directly.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from conftest import make_tool_fn
+
+from tests.schema.mock_unraid import CONTAINER_ID, mock_graphql_response
+from tests.schema.operation_inventory import all_operation_cases
+from unraid_mcp.tools._docker import _DOCKER_ORGANIZER
+
+
+def _make_tool():
+    return make_tool_fn("unraid_mcp.tools.unraid", "register_unraid_tool", "unraid")
+
+
+def _all_operation_cases() -> list[tuple[str, str, str]]:
+    return all_operation_cases()
+
+
+def _call_kwargs(action: str, subaction: str) -> dict[str, Any]:
+    """Representative args broad enough to satisfy every GraphQL subaction."""
+    organizer_input = _organizer_input(subaction)
+    return {
+        "action": action,
+        "subaction": subaction,
+        "confirm": True,
+        "device_id": "server-1",
+        "disk_id": "disk-1",
+        "correct": True,
+        "slot": 1,
+        "log_path": "/var/log/syslog",
+        "tail_lines": 20,
+        "remote_name": "remote",
+        "source_path": "/boot/config",
+        "destination_path": "/mnt/user/destination",
+        "backup_options": {},
+        "container_id": CONTAINER_ID,
+        "network_id": "network-1",
+        "container_ids": [CONTAINER_ID],
+        "with_image": False,
+        "autostart_entries": [{"id": "docker-1", "autostart": True}],
+        "organizer_input": organizer_input,
+        "vm_id": "vm-1",
+        "notification_id": "notification-1",
+        "notification_ids": ["notification-1"],
+        "notification_type": "UNREAD",
+        "importance": "INFO",
+        "offset": 0,
+        "limit": 20,
+        "list_type": "UNREAD",
+        "title": "Title",
+        "subject": "Subject",
+        "description": "Description",
+        "key_id": "key-1",
+        "name": "name",
+        "roles": ["ADMIN"],
+        "permissions": ["READ_ANY"],
+        "permissions_input": [{"resource": "all", "actions": ["READ_ANY"]}],
+        "names": ["plugin"],
+        "bundled": False,
+        "restart": True,
+        "url": "https://example.com/plugin.plg",
+        "plugin_name": "plugin",
+        "forced": False,
+        "operation_id": "operation-1",
+        "provider_type": "b2",
+        "config_data": {},
+        "settings_input": {},
+        "ups_config": {},
+        "config_input": {},
+        "comment": "comment",
+        "sys_model": "model",
+        "connect_input": {},
+        "onboarding_input": {},
+        "theme_name": "white",
+        "locale": "en_US",
+        "provider_id": "provider-1",
+        "token": "session-token",
+    }
+
+
+def _organizer_input(subaction: str) -> dict[str, Any]:
+    spec = _DOCKER_ORGANIZER.get(subaction)
+    if spec is None:
+        return {}
+    defaults: dict[str, Any] = {
+        "name": "Media",
+        "parentId": "folder-root",
+        "childrenIds": ["container-a"],
+        "sourceEntryIds": ["container-a"],
+        "position": 0.0,
+        "folderId": "folder-1",
+        "newName": "Media",
+        "entryIds": ["container-a"],
+        "destinationFolderId": "folder-1",
+        "viewId": "main",
+        "prefs": {},
+    }
+    allowed = set(spec["required"]) | set(spec["optional"])
+    return {key: defaults[key] for key in allowed}
+
+
+def _mock_graphql_response(query: str) -> dict[str, Any]:
+    return mock_graphql_response(query)
+
+
+@pytest.mark.parametrize(
+    ("action", "subaction", "expected_query"),
+    _all_operation_cases(),
+    ids=lambda value: value if isinstance(value, str) else None,
+)
+async def test_every_graphql_operation_is_emitted_by_dispatch(
+    action: str,
+    subaction: str,
+    expected_query: str,
+    mock_graphql_request: AsyncMock,
+) -> None:
+    """Every query/mutation dict entry is reachable through real tool dispatch."""
+    mock_graphql_request.side_effect = _mock_graphql_response
+
+    try:
+        await _make_tool()(**_call_kwargs(action, subaction))
+    except Exception:
+        if not mock_graphql_request.call_args_list:
+            raise
+
+    emitted_queries = [call.args[0] for call in mock_graphql_request.call_args_list]
+    assert expected_query in emitted_queries

--- a/tests/schema/test_mock_fixture_contract.py
+++ b/tests/schema/test_mock_fixture_contract.py
@@ -18,7 +18,7 @@ from graphql import (
 )
 
 from tests.schema.mock_unraid import SCENARIOS, mock_graphql_response
-from tests.schema.test_dispatch_contract import _all_operation_cases
+from unraid_mcp.devtools.graphql_inventory import all_operation_cases
 
 
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "unraid" / "UNRAID-SCHEMA.graphql"
@@ -32,7 +32,7 @@ def test_mock_scenarios_conform_to_selected_graphql_shapes() -> None:
     schema = _schema()
     errors: list[str] = []
 
-    for action, subaction, query in _all_operation_cases():
+    for action, subaction, query in all_operation_cases():
         doc = parse(query)
         validation_errors = validate(schema, doc)
         assert not validation_errors, f"{action}/{subaction} query is invalid: {validation_errors}"
@@ -42,7 +42,11 @@ def test_mock_scenarios_conform_to_selected_graphql_shapes() -> None:
             for definition in doc.definitions
             if isinstance(definition, OperationDefinitionNode)
         )
-        root_type = schema.mutation_type if op.operation.value == "mutation" else schema.query_type
+        root_type = {
+            "query": schema.query_type,
+            "mutation": schema.mutation_type,
+            "subscription": schema.subscription_type,
+        }[op.operation.value]
         assert root_type is not None
         for scenario in SCENARIOS:
             response = mock_graphql_response(query, scenario=scenario)

--- a/tests/schema/test_mock_fixture_contract.py
+++ b/tests/schema/test_mock_fixture_contract.py
@@ -1,0 +1,150 @@
+"""Schema contract for the offline GraphQL mock responses."""
+
+from pathlib import Path
+from typing import Any, get_args
+
+from graphql import (
+    FieldNode,
+    GraphQLEnumType,
+    GraphQLList,
+    GraphQLNonNull,
+    GraphQLObjectType,
+    GraphQLScalarType,
+    GraphQLSchema,
+    OperationDefinitionNode,
+    build_schema,
+    parse,
+    validate,
+)
+
+from tests.schema.mock_unraid import SCENARIOS, mock_graphql_response
+from tests.schema.test_dispatch_contract import _all_operation_cases
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "unraid" / "UNRAID-SCHEMA.graphql"
+
+
+def _schema() -> GraphQLSchema:
+    return build_schema(SCHEMA_PATH.read_text())
+
+
+def test_mock_scenarios_conform_to_selected_graphql_shapes() -> None:
+    schema = _schema()
+    errors: list[str] = []
+
+    for action, subaction, query in _all_operation_cases():
+        doc = parse(query)
+        validation_errors = validate(schema, doc)
+        assert not validation_errors, f"{action}/{subaction} query is invalid: {validation_errors}"
+
+        op = next(
+            definition
+            for definition in doc.definitions
+            if isinstance(definition, OperationDefinitionNode)
+        )
+        root_type = schema.mutation_type if op.operation.value == "mutation" else schema.query_type
+        assert root_type is not None
+        for scenario in SCENARIOS:
+            response = mock_graphql_response(query, scenario=scenario)
+            _check_selection_set(
+                schema,
+                root_type,
+                op.selection_set.selections,
+                response,
+                f"{scenario}/{action}/{subaction}",
+                errors,
+            )
+
+    assert not errors, "mock GraphQL responses violate selected shapes:\n  - " + "\n  - ".join(
+        errors
+    )
+
+
+def _check_selection_set(
+    schema: GraphQLSchema,
+    parent_type: GraphQLObjectType,
+    selections: Any,
+    value: Any,
+    path: str,
+    errors: list[str],
+) -> None:
+    if value is None:
+        return
+    if not isinstance(value, dict):
+        errors.append(f"{path}: expected object, got {type(value).__name__}")
+        return
+
+    for selection in selections:
+        if not isinstance(selection, FieldNode):
+            continue
+        field_name = selection.name.value
+        response_key = selection.alias.value if selection.alias else field_name
+        if response_key not in value:
+            errors.append(f"{path}.{response_key}: missing selected field")
+            continue
+        field = parent_type.fields.get(field_name)
+        if field is None:
+            errors.append(f"{path}.{response_key}: field not found on {parent_type.name}")
+            continue
+        _check_value(
+            schema, field.type, selection, value[response_key], f"{path}.{response_key}", errors
+        )
+
+
+def _check_value(
+    schema: GraphQLSchema,
+    graphql_type: Any,
+    selection: FieldNode,
+    value: Any,
+    path: str,
+    errors: list[str],
+) -> None:
+    if isinstance(graphql_type, GraphQLNonNull):
+        graphql_type = graphql_type.of_type
+    if value is None:
+        return
+    if isinstance(graphql_type, GraphQLList):
+        if not isinstance(value, list):
+            errors.append(f"{path}: expected list, got {type(value).__name__}")
+            return
+        for index, item in enumerate(value):
+            _check_value(schema, graphql_type.of_type, selection, item, f"{path}[{index}]", errors)
+        return
+    if isinstance(graphql_type, GraphQLObjectType):
+        _check_selection_set(
+            schema,
+            graphql_type,
+            selection.selection_set.selections if selection.selection_set else (),
+            value,
+            path,
+            errors,
+        )
+        return
+    if isinstance(graphql_type, GraphQLEnumType):
+        if value not in graphql_type.values:
+            errors.append(f"{path}: {value!r} is not a valid {graphql_type.name}")
+        return
+    if isinstance(graphql_type, GraphQLScalarType):
+        _check_scalar(graphql_type.name, value, path, errors)
+
+
+def _check_scalar(name: str, value: Any, path: str, errors: list[str]) -> None:
+    expected = {
+        "String": str,
+        "ID": str,
+        "PrefixedID": str,
+        "URL": str,
+        "DateTime": str,
+        "BigInt": str,
+        "Boolean": bool,
+        "Int": int,
+        "Port": int,
+        "Float": (int, float),
+    }.get(name)
+    if expected is not None and not isinstance(value, expected):
+        type_names = (
+            expected.__name__
+            if isinstance(expected, type)
+            else " or ".join(t.__name__ for t in get_args(expected) or expected)
+        )
+        errors.append(f"{path}: scalar {name} expected {type_names}, got {type(value).__name__}")

--- a/tests/schema/test_query_validation.py
+++ b/tests/schema/test_query_validation.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 from graphql import DocumentNode, GraphQLSchema, build_schema, parse, validate
 
+from unraid_mcp.devtools.graphql_inventory import schema_operation_dicts
+
 
 SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "unraid" / "UNRAID-SCHEMA.graphql"
 
@@ -26,83 +28,6 @@ def _validate_operation(schema: GraphQLSchema, query_str: str) -> list[str]:
     doc: DocumentNode = parse(query_str)
     errors = validate(schema, doc)
     return [str(e) for e in errors]
-
-
-def _all_domain_dicts() -> list[tuple[str, dict[str, str]]]:
-    """Return all query/mutation dicts imported directly from domain modules.
-
-    Single source of truth used by both test_all_tool_queries_validate and
-    test_total_operations_count so the two lists stay in sync automatically.
-    """
-    from unraid_mcp.tools._array import _ARRAY_MUTATIONS, _ARRAY_QUERIES
-    from unraid_mcp.tools._connect import _CONNECT_MUTATIONS, _CONNECT_QUERIES
-    from unraid_mcp.tools._customization import (
-        _CUSTOMIZATION_MUTATIONS,
-        _CUSTOMIZATION_QUERIES,
-    )
-    from unraid_mcp.tools._disk import _DISK_MUTATIONS, _DISK_QUERIES
-
-    # Docker organizer specs hold their GraphQL under a "mutation" key — flatten
-    # to a {subaction: query} dict so the bulk validator can check them too.
-    from unraid_mcp.tools._docker import (
-        _DOCKER_BULK_MUTATIONS,
-        _DOCKER_MUTATIONS,
-        _DOCKER_ORGANIZER,
-        _DOCKER_QUERIES,
-        _DOCKER_ROOT_MUTATIONS,
-    )
-    from unraid_mcp.tools._key import _KEY_MUTATIONS, _KEY_QUERIES
-    from unraid_mcp.tools._notification import (
-        _NOTIFICATION_MUTATIONS,
-        _NOTIFICATION_QUERIES,
-    )
-    from unraid_mcp.tools._oidc import _OIDC_QUERIES
-    from unraid_mcp.tools._onboarding import (
-        _ONBOARDING_INPUT_MUTATIONS,
-        _ONBOARDING_QUERIES,
-        _ONBOARDING_SIMPLE_MUTATIONS,
-    )
-    from unraid_mcp.tools._plugin import _PLUGIN_MUTATIONS, _PLUGIN_QUERIES
-    from unraid_mcp.tools._rclone import _RCLONE_MUTATIONS, _RCLONE_QUERIES
-    from unraid_mcp.tools._setting import _SETTING_MUTATIONS
-    from unraid_mcp.tools._system import _SYSTEM_QUERIES
-    from unraid_mcp.tools._user import _USER_QUERIES
-    from unraid_mcp.tools._vm import _VM_MUTATIONS, _VM_QUERIES
-
-    docker_organizer = {k: v["mutation"] for k, v in _DOCKER_ORGANIZER.items()}
-
-    return [
-        ("system/QUERIES", _SYSTEM_QUERIES),
-        ("array/QUERIES", _ARRAY_QUERIES),
-        ("array/MUTATIONS", _ARRAY_MUTATIONS),
-        ("disk/QUERIES", _DISK_QUERIES),
-        ("disk/MUTATIONS", _DISK_MUTATIONS),
-        ("docker/QUERIES", _DOCKER_QUERIES),
-        ("docker/MUTATIONS", _DOCKER_MUTATIONS),
-        ("docker/BULK_MUTATIONS", _DOCKER_BULK_MUTATIONS),
-        ("docker/ROOT_MUTATIONS", _DOCKER_ROOT_MUTATIONS),
-        ("docker/ORGANIZER", docker_organizer),
-        ("vm/QUERIES", _VM_QUERIES),
-        ("vm/MUTATIONS", _VM_MUTATIONS),
-        ("notification/QUERIES", _NOTIFICATION_QUERIES),
-        ("notification/MUTATIONS", _NOTIFICATION_MUTATIONS),
-        ("rclone/QUERIES", _RCLONE_QUERIES),
-        ("rclone/MUTATIONS", _RCLONE_MUTATIONS),
-        ("user/QUERIES", _USER_QUERIES),
-        ("key/QUERIES", _KEY_QUERIES),
-        ("key/MUTATIONS", _KEY_MUTATIONS),
-        ("setting/MUTATIONS", _SETTING_MUTATIONS),
-        ("connect/QUERIES", _CONNECT_QUERIES),
-        ("connect/MUTATIONS", _CONNECT_MUTATIONS),
-        ("customization/QUERIES", _CUSTOMIZATION_QUERIES),
-        ("customization/MUTATIONS", _CUSTOMIZATION_MUTATIONS),
-        ("plugin/QUERIES", _PLUGIN_QUERIES),
-        ("plugin/MUTATIONS", _PLUGIN_MUTATIONS),
-        ("oidc/QUERIES", _OIDC_QUERIES),
-        ("onboarding/QUERIES", _ONBOARDING_QUERIES),
-        ("onboarding/SIMPLE_MUTATIONS", _ONBOARDING_SIMPLE_MUTATIONS),
-        ("onboarding/INPUT_MUTATIONS", _ONBOARDING_INPUT_MUTATIONS),
-    ]
 
 
 # ============================================================================
@@ -1067,8 +992,7 @@ class TestSchemaCompleteness:
         from the assertion so the test suite stays green while the underlying
         tool queries are fixed incrementally.
         """
-        # All query/mutation dicts from domain modules, keyed by domain/type label
-        all_operation_dicts = _all_domain_dicts()
+        all_operation_dicts = schema_operation_dicts()
 
         # Known schema mismatches — bugs in tool implementation, not in tests.
         # Remove entries as they are fixed.
@@ -1111,7 +1035,7 @@ class TestSchemaCompleteness:
 
     def test_total_operations_count(self, schema: GraphQLSchema) -> None:
         """Verify the expected number of tool operations exist."""
-        all_dicts = [d for _, d in _all_domain_dicts()]
+        all_dicts = [d for _, d in schema_operation_dicts()]
 
         total = sum(len(d) for d in all_dicts)
         assert total >= 90, f"Expected at least 90 operations, found {total}"

--- a/unraid_mcp/devtools/api_parity.py
+++ b/unraid_mcp/devtools/api_parity.py
@@ -1,15 +1,28 @@
-"""Root-field parity report between Unraid GraphQL schema and exposed operations."""
+"""Root-field parity report between Unraid GraphQL schema and emitted operations."""
 
 from __future__ import annotations
 
 from collections import defaultdict
+from pathlib import Path
 from typing import Any
 
-from graphql import FieldNode, GraphQLObjectType, OperationDefinitionNode, parse
+from graphql import (
+    FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
+    GraphQLObjectType,
+    InlineFragmentNode,
+    OperationDefinitionNode,
+    SelectionNode,
+    SelectionSetNode,
+    build_schema,
+    parse,
+)
 
-from tests.schema.mock_unraid import schema
-from tests.schema.operation_inventory import all_operation_cases
+from unraid_mcp.devtools.graphql_inventory import all_operation_cases
 
+
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "docs" / "unraid" / "UNRAID-SCHEMA.graphql"
 
 INTENTIONAL_QUERY_GAPS: dict[str, str] = {
     "connect": (
@@ -24,33 +37,8 @@ INTENTIONAL_QUERY_GAPS: dict[str, str] = {
     "network": "Network data is exposed through system/network via servers/vars.",
     "server": "Server data is exposed through system/server, system/servers, and related info roots.",
 }
-
-_SUBSCRIPTION_GAP_REASON = (
-    "Subscription roots are covered by live resources and subscription diagnostics, "
-    "not by the owned query/mutation operation inventory."
-)
-INTENTIONAL_SUBSCRIPTION_GAPS: dict[str, str] = dict.fromkeys(
-    (
-        "arraySubscription",
-        "displaySubscription",
-        "dockerContainerStats",
-        "logFile",
-        "notificationAdded",
-        "notificationsOverview",
-        "notificationsWarningsAndAlerts",
-        "ownerSubscription",
-        "parityHistorySubscription",
-        "pluginInstallUpdates",
-        "serversSubscription",
-        "systemMetricsCpu",
-        "systemMetricsCpuTelemetry",
-        "systemMetricsMemory",
-        "systemMetricsTemperature",
-        "upsUpdates",
-    ),
-    _SUBSCRIPTION_GAP_REASON,
-)
 INTENTIONAL_MUTATION_GAPS: dict[str, str] = {}
+INTENTIONAL_SUBSCRIPTION_GAPS: dict[str, str] = {}
 
 
 def api_parity_report() -> dict[str, Any]:
@@ -99,7 +87,7 @@ def _section(
 
 
 def _root_fields(kind: str) -> set[str]:
-    graphql_schema = schema()
+    graphql_schema = build_schema(SCHEMA_PATH.read_text())
     root_type = {
         "query": graphql_schema.query_type,
         "mutation": graphql_schema.mutation_type,
@@ -112,13 +100,42 @@ def _root_fields(kind: str) -> set[str]:
 
 def _used_root_fields_by_kind() -> dict[str, set[str]]:
     used: dict[str, set[str]] = defaultdict(set)
-    for _action, _subaction, operation in all_operation_cases():
+    for _source, _name, operation in all_operation_cases():
         doc = parse(operation)
+        fragments = {
+            definition.name.value: definition
+            for definition in doc.definitions
+            if isinstance(definition, FragmentDefinitionNode)
+        }
         for definition in doc.definitions:
             if not isinstance(definition, OperationDefinitionNode):
                 continue
             kind = definition.operation.value
-            for selection in definition.selection_set.selections:
-                if isinstance(selection, FieldNode):
-                    used[kind].add(selection.name.value)
+            used[kind].update(_root_field_names(definition.selection_set, fragments))
     return used
+
+
+def _root_field_names(
+    selection_set: SelectionSetNode,
+    fragments: dict[str, FragmentDefinitionNode],
+) -> set[str]:
+    names: set[str] = set()
+    for selection in selection_set.selections:
+        names.update(_selection_root_field_names(selection, fragments))
+    return names
+
+
+def _selection_root_field_names(
+    selection: SelectionNode,
+    fragments: dict[str, FragmentDefinitionNode],
+) -> set[str]:
+    if isinstance(selection, FieldNode):
+        return {selection.name.value}
+    if isinstance(selection, InlineFragmentNode):
+        return _root_field_names(selection.selection_set, fragments)
+    if isinstance(selection, FragmentSpreadNode):
+        fragment = fragments.get(selection.name.value)
+        if fragment is None:
+            return set()
+        return _root_field_names(fragment.selection_set, fragments)
+    return set()

--- a/unraid_mcp/devtools/graphql_inventory.py
+++ b/unraid_mcp/devtools/graphql_inventory.py
@@ -1,7 +1,14 @@
-"""Complete GraphQL operation inventory used by schema contract tests."""
+"""GraphQL operation inventory shared by tests and maintenance scripts."""
 
-from collections.abc import Iterable
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+from unraid_mcp.subscriptions.queries import COLLECT_ACTIONS, SNAPSHOT_ACTIONS
 from unraid_mcp.tools._array import _ARRAY_MUTATIONS, _ARRAY_QUERIES
 from unraid_mcp.tools._connect import _CONNECT_MUTATIONS, _CONNECT_QUERIES
 from unraid_mcp.tools._customization import _CUSTOMIZATION_MUTATIONS, _CUSTOMIZATION_QUERIES
@@ -11,6 +18,7 @@ from unraid_mcp.tools._docker import (
     _DOCKER_MUTATIONS,
     _DOCKER_ORGANIZER,
     _DOCKER_QUERIES,
+    _DOCKER_RESOLVE_QUERY,
     _DOCKER_ROOT_MUTATIONS,
 )
 from unraid_mcp.tools._health import _HEALTH_QUERIES
@@ -30,7 +38,8 @@ from unraid_mcp.tools._user import _USER_QUERIES
 from unraid_mcp.tools._vm import _VM_MUTATIONS, _VM_QUERIES
 
 
-def operation_dicts() -> Iterable[tuple[str, dict[str, str]]]:
+def public_operation_dicts() -> Iterable[tuple[str, dict[str, str]]]:
+    """Return action/subaction operations exposed through the consolidated tool."""
     docker_organizer = {name: spec["mutation"] for name, spec in _DOCKER_ORGANIZER.items()}
     return (
         ("system", _SYSTEM_QUERIES),
@@ -67,9 +76,27 @@ def operation_dicts() -> Iterable[tuple[str, dict[str, str]]]:
     )
 
 
-def all_operation_cases() -> list[tuple[str, str, str]]:
+def schema_operation_dicts() -> Iterable[tuple[str, dict[str, str]]]:
+    """Return every GraphQL document emitted by runtime code paths."""
+    yield from public_operation_dicts()
+    yield ("docker_internal", {"resolve_container_id": _DOCKER_RESOLVE_QUERY})
+    yield ("live_snapshot", SNAPSHOT_ACTIONS)
+    yield ("live_collect", COLLECT_ACTIONS)
+
+
+def dispatch_operation_cases() -> list[tuple[str, str, str]]:
+    """Return public action/subaction cases that can be driven through dispatch."""
     cases: list[tuple[str, str, str]] = []
-    for action, operations in operation_dicts():
-        for subaction, query in operations.items():
-            cases.append((action, subaction, query))
+    for action, operations in public_operation_dicts():
+        for subaction, operation in operations.items():
+            cases.append((action, subaction, operation))
+    return cases
+
+
+def all_operation_cases() -> list[tuple[str, str, str]]:
+    """Return all known GraphQL documents as ``(source, name, operation)`` rows."""
+    cases: list[tuple[str, str, str]] = []
+    for source, operations in schema_operation_dicts():
+        for name, operation in operations.items():
+            cases.append((source, name, operation))
     return cases


### PR DESCRIPTION
## Summary

- add a shared GraphQL operation inventory covering public dispatch operations, internal helper queries, and live subscription documents
- add dispatch contract tests that drive the consolidated `unraid` tool and assert public operations are emitted without masking handler failures
- add explicit Docker resolver coverage for name/short-ID lookup paths
- add a schema-shaped offline Unraid mock with multiple scenarios and response-shape contract tests, including subscription roots
- add an API root-field parity report/test that classifies direct query root gaps and verifies mutation/subscription root parity
- add scheduled schema drift detection against upstream Unraid API SDL, including stale issue closure when drift resolves
- document the inventory and parity report scripts for live smoke test upkeep

Follow-up data coverage issue: #103.

## Verification

- `uv run pytest tests/schema/ -q` → 273 passed
- `uv run pytest -m "not slow and not integration" -q` → 1622 passed, 60 deselected
- `uv run ruff check unraid_mcp/devtools tests/schema scripts/list_graphql_operations.py scripts/report_api_parity.py`
- `uv run ruff format --check unraid_mcp/devtools tests/schema scripts/list_graphql_operations.py scripts/report_api_parity.py`
- `uv run ty check unraid_mcp/`
- `actionlint .github/workflows/schema-drift.yml`
- `scripts/list_graphql_operations.py --json` emits valid JSON
- `scripts/report_api_parity.py --json` emits valid JSON

## Lavra Review

Ran Lavra-style parallel review with Python correctness, security, data/schema integrity, architecture, and simplicity reviewers. Addressed all introduced findings:

- subscription parity now reads live subscription query maps and reports `16/16` subscription roots used
- schema validator, scripts, and tests share one non-test inventory helper under `unraid_mcp.devtools`
- internal Docker resolver query is included in inventory and dispatch coverage
- dispatch contract no longer swallows post-call handler failures
- mock fixture supports subscription root operations and Docker network IDs correctly
- root-field accounting handles fragment spreads and inline fragments
- schema drift workflow closes stale drift issues after drift resolves
- workflow passes `actionlint`

## Current Parity Snapshot

- tracked GraphQL documents: 163
- public dispatch operations: 146
- query roots: 52/57 used, 5 intentional query gaps
- mutation roots: 45/45 used, 0 gaps
- subscription roots: 16/16 used, 0 gaps
