### PR TITLE
feat: add optional Google OAuth authentication for HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,36 @@ UNRAID_MCP_DISABLE_HTTP_AUTH=false
 # unauthenticated MCP endpoint would be exposed to the network.
 UNRAID_MCP_TRUST_PROXY=false
 
+# Google OAuth Authentication (OPTIONAL — alternative to the bearer token)
+# ------------------------------------------------------------------------
+# When BOTH client id and secret are set, HTTP authentication is delegated to
+# Google OAuth (FastMCP's GoogleProvider) and the pre-shared bearer token is NOT
+# used. Leave these unset (the default) to keep bearer-token auth. MCP clients
+# then authenticate with the standard OAuth browser flow.
+#
+# Setup: create an OAuth 2.0 "Web application" client in Google Cloud Console,
+# add "<UNRAID_MCP_GOOGLE_BASE_URL>/auth/callback" as an Authorized redirect URI.
+# See https://gofastmcp.com/integrations/google
+#
+# UNRAID_MCP_GOOGLE_CLIENT_ID=123456789.apps.googleusercontent.com
+# UNRAID_MCP_GOOGLE_CLIENT_SECRET=GOCSPX-...
+# Public base URL of THIS server (must match the Google redirect URI host). Required.
+# UNRAID_MCP_GOOGLE_BASE_URL=https://unraid-mcp.example.com
+# Optional: comma/space-separated scopes (default: openid + userinfo.email).
+# UNRAID_MCP_GOOGLE_REQUIRED_SCOPES=openid https://www.googleapis.com/auth/userinfo.email
+# Optional: OAuth callback path (default: /auth/callback). Must match Google config.
+# UNRAID_MCP_GOOGLE_REDIRECT_PATH=/auth/callback
+#
+# Optional token persistence (survive restarts, NO Redis required). Set BOTH keys
+# to store tokens encrypted-at-rest on disk via a FileTreeStore; set NEITHER to
+# keep tokens in memory (cleared on restart). Setting only one is a config error.
+#   Generate the encryption key:
+#     python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+# UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY=your_jwt_signing_secret
+# UNRAID_MCP_GOOGLE_ENCRYPTION_KEY=your_fernet_key
+# Optional: directory for persisted encrypted tokens (default ~/.unraid-mcp/oauth-tokens).
+# UNRAID_MCP_GOOGLE_STORAGE_DIR=/path/to/oauth-tokens
+
 # TLS / SSL Verification
 # ----------------------
 # UNRAID_VERIFY_SSL controls verification of the Unraid API's TLS certificate.

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,12 @@ UNRAID_MCP_TRUST_PROXY=false
 # UNRAID_MCP_GOOGLE_BASE_URL=https://unraid-mcp.example.com
 # Optional: comma/space-separated scopes (default: openid + userinfo.email).
 # UNRAID_MCP_GOOGLE_REQUIRED_SCOPES=openid https://www.googleapis.com/auth/userinfo.email
+# REQUIRED authorization allowlist (unless explicitly allowing any Google user).
+# OAuth proves identity; this controls which Google identities may use the MCP server.
+# UNRAID_MCP_GOOGLE_ALLOWED_EMAILS=you@example.com admin@example.com
+# UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS=example.com
+# DANGEROUS: only for private/trusted deployments where any Google account is acceptable.
+# UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=false
 # Optional: OAuth callback path (default: /auth/callback). Must match Google config.
 # UNRAID_MCP_GOOGLE_REDIRECT_PATH=/auth/callback
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,25 @@ Note: there is **no query cache**. The only caching middleware ever present —
 reads and mutations under one name, making per-subaction cache exclusion impossible. The
 `health/diagnose` "caching disabled" note is simply accurate.
 
+### HTTP Authentication (bearer token OR Google OAuth)
+HTTP transport supports two **mutually exclusive** auth modes, selected by env vars:
+1. **Pre-shared bearer token** (default) — enforced by the ASGI `BearerAuthMiddleware`
+   in `core/auth.py`, auto-generated on first HTTP startup. `WellKnownMiddleware` advertises
+   *no* OAuth authorization server (clients must send a static token).
+2. **Google OAuth** (`core/google_auth.py`) — activated when **both**
+   `UNRAID_MCP_GOOGLE_CLIENT_ID` and `UNRAID_MCP_GOOGLE_CLIENT_SECRET` are set. FastMCP's
+   `GoogleProvider` is attached via `FastMCP(auth=...)`; `build_google_provider()` returns
+   `None` (mode 1) otherwise. When active, `run_server()` installs **only** `HealthMiddleware`
+   — the bearer + well-known ASGI middleware are omitted because the provider serves its own
+   OAuth/`.well-known` routes and would be shadowed (and the OAuth callback 401'd) otherwise.
+   `UNRAID_MCP_GOOGLE_BASE_URL` is **required** when enabled. Token persistence is optional
+   and Redis-free: set both `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` and
+   `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` (a Fernet key) to persist tokens encrypted-at-rest in a
+   `FileTreeStore` under `UNRAID_MCP_GOOGLE_STORAGE_DIR` (default `~/.unraid-mcp/oauth-tokens`);
+   setting only one is a fatal config error. Misconfig raises `GoogleOAuthConfigError`, which
+   `server.py` converts to a fatal `sys.exit(1)` at import. See `.env.example` for the full
+   variable reference.
+
 ### Performance Considerations
 - Increased timeouts for disk operations (90s read timeout)
 - Selective queries to avoid GraphQL type overflow issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,7 @@ reads and mutations under one name, making per-subaction cache exclusion impossi
 `health/diagnose` "caching disabled" note is simply accurate.
 
 ### HTTP Authentication (bearer token OR Google OAuth)
+
 HTTP transport supports two **mutually exclusive** auth modes, selected by env vars:
 1. **Pre-shared bearer token** (default) — enforced by the ASGI `BearerAuthMiddleware`
    in `core/auth.py`, auto-generated on first HTTP startup. `WellKnownMiddleware` advertises

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ just setup
 | `UNRAID_API_URL` | Yes | — | GraphQL endpoint URL, e.g. `https://tower.local/graphql` |
 | `UNRAID_API_KEY` | Yes | — | Unraid API key (see below) |
 | `UNRAID_MCP_TRANSPORT` | No | `streamable-http` | Transport: `streamable-http`, `stdio`, or `sse` (deprecated) |
-| `UNRAID_MCP_HOST` | No | `0.0.0.0` | Bind address for HTTP transports |
+| `UNRAID_MCP_HOST` | No | `127.0.0.1` bare metal; Docker sets `0.0.0.0` | Bind address for HTTP transports |
 | `UNRAID_MCP_PORT` | No | `6970` | Listen port for HTTP transports |
 | `UNRAID_MCP_BEARER_TOKEN` | Conditional | — | Static Bearer token for HTTP transports; auto-generated on first start if unset |
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | No | `false` | Set `true` to skip Bearer auth (use behind a reverse proxy that handles auth) |

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -88,7 +88,9 @@ to distribute. Leave these unset to keep bearer-token auth (the default).
    create an **OAuth 2.0 Client ID** of type **Web application**.
 2. Add `<UNRAID_MCP_GOOGLE_BASE_URL>/auth/callback` as an **Authorized redirect URI**
    (it must match exactly; HTTPS is required in production).
-3. Set the env vars below and restart the server.
+3. Configure an allowed email/domain list for the Google users who may control this
+   MCP server.
+4. Set the env vars below and restart the server.
 
 ### Environment variables
 
@@ -98,6 +100,9 @@ to distribute. Leave these unset to keep bearer-token auth (the default).
 | `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | *(none)* | Google OAuth Client Secret (`GOCSPX-…`). |
 | `UNRAID_MCP_GOOGLE_BASE_URL` | *(none)* | **Required when enabled.** This server's public base URL; must match the Google redirect URI host. |
 | `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | `openid` + `userinfo.email` | Comma/space-separated OAuth scopes. |
+| `UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` | *(none)* | Comma/space-separated verified Google emails allowed to use this server. |
+| `UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS` | *(none)* | Comma/space-separated verified email domains allowed to use this server. |
+| `UNRAID_MCP_GOOGLE_ALLOW_ANY_USER` | `false` | Explicit escape hatch for private deployments that intentionally allow any Google account. |
 | `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | `/auth/callback` | OAuth callback path; must match the Google config. |
 | `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` | *(none)* | With the encryption key, enables persistent token storage. |
 | `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` | *(none)* | Fernet key for encrypting persisted tokens at rest. |
@@ -110,6 +115,10 @@ re-authenticate). To persist them across restarts, set **both**
 `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` and `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY`. Tokens are
 then written, encrypted-at-rest, to a `FileTreeStore` on disk — no Redis or other
 service is needed. Setting only one of the two keys is a fatal configuration error.
+
+OAuth identity is not authorization by itself. Unless
+`UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=true` is explicitly set, startup fails until at
+least one allowed email or domain is configured.
 
 Generate the encryption key:
 

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -1,8 +1,12 @@
 # Authentication Setup Guide
 
-The unraid-mcp server uses **static Bearer token authentication** for HTTP
-transports (`streamable-http`, `sse`).  There is no OAuth flow — you generate
-a token once and put it in both the server config and the MCP client config.
+The unraid-mcp server supports two **mutually exclusive** HTTP auth modes for the
+`streamable-http` / `sse` transports:
+
+1. **Static Bearer token** (default) — you generate a token once and put it in both
+   the server config and the MCP client config. No OAuth flow. Covered below.
+2. **Google OAuth** (optional) — delegate authentication to Google's login. Enabled
+   by setting Google credentials; see [Google OAuth](#google-oauth-optional) below.
 
 `stdio` transport (the Claude Code plugin default) runs as a local subprocess
 and does **not** require a token.
@@ -65,8 +69,57 @@ environment:
 
 | Variable | Default | Description |
 |---|---|---|
-| `UNRAID_MCP_BEARER_TOKEN` | *(none)* | Required for HTTP transport. Generate with `openssl rand -hex 32`. |
-| `UNRAID_MCP_DISABLE_HTTP_AUTH` | `false` | Set `true` to disable auth entirely (testing/trusted-network only). |
+| `UNRAID_MCP_BEARER_TOKEN` | *(none)* | Required for HTTP transport (bearer mode). Generate with `openssl rand -hex 32`. |
+| `UNRAID_MCP_DISABLE_HTTP_AUTH` | `false` | Set `true` to disable auth entirely (testing/trusted-network only). Ignored when Google OAuth is active. |
+
+---
+
+## Google OAuth (optional)
+
+Set **both** `UNRAID_MCP_GOOGLE_CLIENT_ID` and `UNRAID_MCP_GOOGLE_CLIENT_SECRET` to
+delegate HTTP authentication to Google OAuth (FastMCP's `GoogleProvider`) instead of
+the static bearer token. When active, the bearer-token middleware is **not** installed
+and clients authenticate via the standard OAuth browser flow — there's no static token
+to distribute. Leave these unset to keep bearer-token auth (the default).
+
+### Setup
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/apis/credentials),
+   create an **OAuth 2.0 Client ID** of type **Web application**.
+2. Add `<UNRAID_MCP_GOOGLE_BASE_URL>/auth/callback` as an **Authorized redirect URI**
+   (it must match exactly; HTTPS is required in production).
+3. Set the env vars below and restart the server.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `UNRAID_MCP_GOOGLE_CLIENT_ID` | *(none)* | Google OAuth Client ID. Setting id **and** secret enables OAuth. |
+| `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | *(none)* | Google OAuth Client Secret (`GOCSPX-…`). |
+| `UNRAID_MCP_GOOGLE_BASE_URL` | *(none)* | **Required when enabled.** This server's public base URL; must match the Google redirect URI host. |
+| `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | `openid` + `userinfo.email` | Comma/space-separated OAuth scopes. |
+| `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | `/auth/callback` | OAuth callback path; must match the Google config. |
+| `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` | *(none)* | With the encryption key, enables persistent token storage. |
+| `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` | *(none)* | Fernet key for encrypting persisted tokens at rest. |
+| `UNRAID_MCP_GOOGLE_STORAGE_DIR` | `~/.unraid-mcp/oauth-tokens` | Directory for persisted encrypted tokens. |
+
+### Token persistence (no Redis required)
+
+By default issued tokens live in memory and are cleared on restart (clients silently
+re-authenticate). To persist them across restarts, set **both**
+`UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` and `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY`. Tokens are
+then written, encrypted-at-rest, to a `FileTreeStore` on disk — no Redis or other
+service is needed. Setting only one of the two keys is a fatal configuration error.
+
+Generate the encryption key:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+The client side needs no static header — point your MCP client at the server URL with
+OAuth enabled (e.g. Claude Code uses its built-in OAuth flow), and the browser login
+handles the rest.
 
 ---
 

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -11,7 +11,7 @@
 
 | Variable | Required | Default | Sensitive | Description |
 |----------|----------|---------|-----------|-------------|
-| `UNRAID_MCP_HOST` | no | `0.0.0.0` | no | Bind address for HTTP transport |
+| `UNRAID_MCP_HOST` | no | `127.0.0.1` bare metal; Docker image sets `0.0.0.0` | no | Bind address for HTTP transport |
 | `UNRAID_MCP_PORT` | no | `6970` | no | HTTP server port (1-65535) |
 | `UNRAID_MCP_TRANSPORT` | no | `streamable-http` | no | Transport: `streamable-http`, `stdio`, or `sse` |
 
@@ -33,6 +33,9 @@ Setting both client id and secret delegates HTTP auth to Google OAuth (FastMCP `
 | `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | no | -- | yes | Google OAuth Client Secret (`GOCSPX-…`). |
 | `UNRAID_MCP_GOOGLE_BASE_URL` | conditional | -- | no | Required when OAuth is enabled. Public base URL of this server; must match the Google redirect URI host. |
 | `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | no | `openid` + `userinfo.email` | no | Comma/space-separated OAuth scopes. |
+| `UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` | conditional | -- | no | Verified Google emails allowed to use this MCP server. Required unless domains or allow-any-user is set. |
+| `UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS` | conditional | -- | no | Verified email domains allowed to use this MCP server. Required unless emails or allow-any-user is set. |
+| `UNRAID_MCP_GOOGLE_ALLOW_ANY_USER` | no | `false` | no | Explicitly allow any verified Google account. Use only for private/trusted deployments. |
 | `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | no | `/auth/callback` | no | OAuth callback path; must match the Google client config. |
 | `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` | conditional | -- | yes | With the encryption key, enables persistent (restart-surviving) token storage. Both or neither. |
 | `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` | conditional | -- | yes | Fernet key encrypting persisted tokens at rest. Generate: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`. |

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -23,6 +23,21 @@
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | no | `false` | no | Disable bearer auth. Only valid behind a trusted fronting gateway; binding a public interface with auth disabled additionally requires `UNRAID_MCP_TRUST_PROXY=true`. |
 | `UNRAID_MCP_TRUST_PROXY` | conditional | `false` | no | Required second opt-in to bind a non-loopback interface while `UNRAID_MCP_DISABLE_HTTP_AUTH=true`. Asserts an upstream gateway terminates auth; without it a public bind with auth off is refused. |
 
+## Google OAuth (optional — replaces bearer token when enabled)
+
+Setting both client id and secret delegates HTTP auth to Google OAuth (FastMCP `GoogleProvider`); the bearer-token middleware is then not installed. Leave unset to keep bearer auth. See [AUTHENTICATION.md](../AUTHENTICATION.md#google-oauth-optional).
+
+| Variable | Required | Default | Sensitive | Description |
+|----------|----------|---------|-----------|-------------|
+| `UNRAID_MCP_GOOGLE_CLIENT_ID` | no | -- | yes | Google OAuth Client ID. Setting id **and** secret enables OAuth. |
+| `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | no | -- | yes | Google OAuth Client Secret (`GOCSPX-…`). |
+| `UNRAID_MCP_GOOGLE_BASE_URL` | conditional | -- | no | Required when OAuth is enabled. Public base URL of this server; must match the Google redirect URI host. |
+| `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | no | `openid` + `userinfo.email` | no | Comma/space-separated OAuth scopes. |
+| `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | no | `/auth/callback` | no | OAuth callback path; must match the Google client config. |
+| `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` | conditional | -- | yes | With the encryption key, enables persistent (restart-surviving) token storage. Both or neither. |
+| `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` | conditional | -- | yes | Fernet key encrypting persisted tokens at rest. Generate: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`. |
+| `UNRAID_MCP_GOOGLE_STORAGE_DIR` | no | `~/.unraid-mcp/oauth-tokens` | no | Directory for persisted encrypted tokens (FileTreeStore; no Redis needed). |
+
 ## SSL/TLS
 
 | Variable | Required | Default | Sensitive | Description |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,11 @@ required_vars=(
 # UNRAID_MCP_BEARER_TOKEN is only required for HTTP-based transports with auth enabled
 _transport="${UNRAID_MCP_TRANSPORT:-streamable-http}"
 _disable_auth="${UNRAID_MCP_DISABLE_HTTP_AUTH:-false}"
-if [[ "$_transport" != "stdio" && "$_disable_auth" != "true" && "$_disable_auth" != "1" && "$_disable_auth" != "yes" ]]; then
+_google_oauth_enabled=false
+if [[ -n "${UNRAID_MCP_GOOGLE_CLIENT_ID:-}" && -n "${UNRAID_MCP_GOOGLE_CLIENT_SECRET:-}" ]]; then
+  _google_oauth_enabled=true
+fi
+if [[ "$_transport" != "stdio" && "$_disable_auth" != "true" && "$_disable_auth" != "1" && "$_disable_auth" != "yes" && "$_google_oauth_enabled" != "true" ]]; then
   required_vars+=(UNRAID_MCP_BEARER_TOKEN)
 fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,12 @@ dependencies = [
     # string accepted by `subscriptions/test_query` — the allowlist is enforced on
     # the parsed operation (every top-level field), not a regex. (Was dev-only.)
     "graphql-core>=3.2.0",
+    # Optional Google OAuth (core/google_auth.py) imports these directly. Both ship
+    # transitively with fastmcp today, but the OAuth code uses them at the top level
+    # (Fernet token encryption + FileTreeStore disk persistence), so pin them as
+    # explicit deps rather than relying on a transitive resolution.
+    "cryptography>=44.0.0",
+    "py-key-value-aio>=0.4.0",
 ]
 
 # ============================================================================

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -1,0 +1,267 @@
+"""Tests for the optional Google OAuth authentication path.
+
+Covers:
+  - google_oauth_enabled() gating on client id + secret
+  - build_google_provider() returns None when disabled (default deployment)
+  - scope parsing (default + custom comma/space separated)
+  - fail-closed config errors: missing base_url, partial persistence config,
+    invalid Fernet key
+  - in-memory vs encrypted-on-disk (FileTreeStore) provider construction
+  - run_server() omits the bearer/well-known ASGI middleware when OAuth is active
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import patch
+
+import pytest
+
+import unraid_mcp.config.settings as s
+from unraid_mcp.core.google_auth import (
+    GoogleOAuthConfigError,
+    _parse_scopes,
+    build_google_provider,
+    google_oauth_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_GOOGLE_ATTRS = (
+    "UNRAID_MCP_GOOGLE_CLIENT_ID",
+    "UNRAID_MCP_GOOGLE_CLIENT_SECRET",
+    "UNRAID_MCP_GOOGLE_BASE_URL",
+    "UNRAID_MCP_GOOGLE_REQUIRED_SCOPES",
+    "UNRAID_MCP_GOOGLE_REDIRECT_PATH",
+    "UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY",
+    "UNRAID_MCP_GOOGLE_ENCRYPTION_KEY",
+    "UNRAID_MCP_GOOGLE_STORAGE_DIR",
+)
+
+
+@contextlib.contextmanager
+def _google_settings(**overrides):
+    """Temporarily set UNRAID_MCP_GOOGLE_* settings globals, restoring after."""
+    originals = {name: getattr(s, name) for name in _GOOGLE_ATTRS}
+    try:
+        # Clear all first so each test starts from a known (disabled) baseline.
+        for name in _GOOGLE_ATTRS:
+            setattr(s, name, None)
+        for name, value in overrides.items():
+            setattr(s, name, value)
+        yield
+    finally:
+        for name, value in originals.items():
+            setattr(s, name, value)
+
+
+def _fernet_key() -> str:
+    from cryptography.fernet import Fernet
+
+    return Fernet.generate_key().decode()
+
+
+# ---------------------------------------------------------------------------
+# Enable gate
+# ---------------------------------------------------------------------------
+
+
+class TestEnableGate:
+    def test_disabled_by_default(self):
+        with _google_settings():
+            assert google_oauth_enabled() is False
+            assert build_google_provider() is None
+
+    def test_disabled_with_only_client_id(self):
+        with _google_settings(UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com"):
+            assert google_oauth_enabled() is False
+
+    def test_disabled_with_only_secret(self):
+        with _google_settings(UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret"):
+            assert google_oauth_enabled() is False
+
+    def test_empty_strings_do_not_enable(self):
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="   ",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="",
+        ):
+            assert google_oauth_enabled() is False
+
+    def test_enabled_with_both(self):
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+        ):
+            assert google_oauth_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Scope parsing
+# ---------------------------------------------------------------------------
+
+
+class TestScopeParsing:
+    def test_default_scopes_when_unset(self):
+        assert _parse_scopes(None) == [
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ]
+
+    def test_default_scopes_when_blank(self):
+        assert _parse_scopes("   ") == [
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ]
+
+    def test_comma_separated(self):
+        assert _parse_scopes("openid, email, profile") == ["openid", "email", "profile"]
+
+    def test_space_separated(self):
+        assert _parse_scopes("openid email profile") == ["openid", "email", "profile"]
+
+    def test_mixed_separators_and_extra_whitespace(self):
+        assert _parse_scopes(" openid ,email  profile ") == ["openid", "email", "profile"]
+
+
+# ---------------------------------------------------------------------------
+# Config errors (fail closed)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigErrors:
+    def test_missing_base_url_raises(self):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="UNRAID_MCP_GOOGLE_BASE_URL"),
+        ):
+            build_google_provider()
+
+    def test_only_jwt_key_raises(self):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY="jwt-key",
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="requires BOTH"),
+        ):
+            build_google_provider()
+
+    def test_only_encryption_key_raises(self):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_ENCRYPTION_KEY=_fernet_key(),
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="requires BOTH"),
+        ):
+            build_google_provider()
+
+    def test_invalid_fernet_key_raises(self, tmp_path):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY="jwt-key",
+                UNRAID_MCP_GOOGLE_ENCRYPTION_KEY="not-a-valid-fernet-key",
+                UNRAID_MCP_GOOGLE_STORAGE_DIR=str(tmp_path / "tokens"),
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="not a valid Fernet key"),
+        ):
+            build_google_provider()
+
+
+# ---------------------------------------------------------------------------
+# Provider construction
+# ---------------------------------------------------------------------------
+
+
+class TestProviderConstruction:
+    def test_in_memory_provider(self):
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+            UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+        ):
+            provider = build_google_provider()
+        assert provider is not None
+        assert type(provider).__name__ == "GoogleProvider"
+
+    def test_custom_scopes_and_redirect_path(self):
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+            UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_REQUIRED_SCOPES="openid profile",
+            UNRAID_MCP_GOOGLE_REDIRECT_PATH="/auth/google/callback",
+        ):
+            provider = build_google_provider()
+        assert provider is not None
+
+    def test_encrypted_persistence_creates_storage_dir(self, tmp_path):
+        storage = tmp_path / "oauth-tokens"
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+            UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY="jwt-signing-key",
+            UNRAID_MCP_GOOGLE_ENCRYPTION_KEY=_fernet_key(),
+            UNRAID_MCP_GOOGLE_STORAGE_DIR=str(storage),
+        ):
+            provider = build_google_provider()
+        assert provider is not None
+        assert storage.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# run_server() middleware selection
+# ---------------------------------------------------------------------------
+
+
+class TestRunServerMiddlewareSelection:
+    def _capture_middleware(self, google_provider):
+        """Run run_server() in HTTP mode and return the middleware list passed to mcp.run."""
+        import unraid_mcp.server as server
+
+        captured: dict = {}
+
+        def fake_run(*args, **kwargs):
+            captured["middleware"] = kwargs.get("middleware")
+
+        orig_transport = s.UNRAID_MCP_TRANSPORT
+        try:
+            s.UNRAID_MCP_TRANSPORT = "streamable-http"
+            with (
+                patch.object(server, "_google_auth_provider", google_provider),
+                patch.object(server.mcp, "run", side_effect=fake_run),
+                patch.object(server, "ensure_token_exists"),
+                patch.object(server, "log_configuration_status"),
+                patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "tok"),
+            ):
+                server.run_server()
+        finally:
+            s.UNRAID_MCP_TRANSPORT = orig_transport
+        return captured.get("middleware")
+
+    def test_bearer_path_installs_three_middleware(self):
+        middleware = self._capture_middleware(google_provider=None)
+        assert middleware is not None
+        # Health + WellKnown + Bearer
+        assert len(middleware) == 3
+
+    def test_oauth_path_installs_only_health(self):
+        sentinel = object()  # stand-in for a built GoogleProvider
+        middleware = self._capture_middleware(google_provider=sentinel)
+        assert middleware is not None
+        # Only HealthMiddleware — bearer + well-known are omitted under OAuth.
+        assert len(middleware) == 1

--- a/tests/test_google_auth.py
+++ b/tests/test_google_auth.py
@@ -13,13 +13,16 @@ Covers:
 from __future__ import annotations
 
 import contextlib
-from unittest.mock import patch
+import importlib
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from mcp.server.auth.provider import AccessToken
 
 import unraid_mcp.config.settings as s
 from unraid_mcp.core.google_auth import (
     GoogleOAuthConfigError,
+    _AuthorizedGoogleTokenVerifier,
     _parse_scopes,
     build_google_provider,
     google_oauth_enabled,
@@ -35,6 +38,9 @@ _GOOGLE_ATTRS = (
     "UNRAID_MCP_GOOGLE_CLIENT_SECRET",
     "UNRAID_MCP_GOOGLE_BASE_URL",
     "UNRAID_MCP_GOOGLE_REQUIRED_SCOPES",
+    "UNRAID_MCP_GOOGLE_ALLOWED_EMAILS",
+    "UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS",
+    "UNRAID_MCP_GOOGLE_ALLOW_ANY_USER",
     "UNRAID_MCP_GOOGLE_REDIRECT_PATH",
     "UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY",
     "UNRAID_MCP_GOOGLE_ENCRYPTION_KEY",
@@ -76,12 +82,20 @@ class TestEnableGate:
             assert build_google_provider() is None
 
     def test_disabled_with_only_client_id(self):
-        with _google_settings(UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com"):
+        with (
+            _google_settings(UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com"),
+            pytest.raises(GoogleOAuthConfigError, match="partially configured"),
+        ):
             assert google_oauth_enabled() is False
+            build_google_provider()
 
     def test_disabled_with_only_secret(self):
-        with _google_settings(UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret"):
+        with (
+            _google_settings(UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret"),
+            pytest.raises(GoogleOAuthConfigError, match="partially configured"),
+        ):
             assert google_oauth_enabled() is False
+            build_google_provider()
 
     def test_empty_strings_do_not_enable(self):
         with _google_settings(
@@ -142,12 +156,88 @@ class TestConfigErrors:
         ):
             build_google_provider()
 
+    def test_oauth_requires_identity_allowlist(self):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="identity allowlist"),
+        ):
+            build_google_provider()
+
+    def test_allow_any_user_must_be_explicit(self):
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+            UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=True,
+        ):
+            assert build_google_provider() is not None
+
+    def test_disable_http_auth_conflicts_with_oauth(self):
+        original = s.UNRAID_MCP_DISABLE_HTTP_AUTH
+        try:
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = True
+            with (
+                _google_settings(
+                    UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                    UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                    UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                    UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
+                ),
+                pytest.raises(GoogleOAuthConfigError, match="DISABLE_HTTP_AUTH"),
+            ):
+                build_google_provider()
+        finally:
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = original
+
+    @pytest.mark.parametrize("base_url", ["http://mcp.example.com", "not-a-url"])
+    def test_non_https_base_url_rejected(self, base_url: str):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                UNRAID_MCP_GOOGLE_BASE_URL=base_url,
+                UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="https://"),
+        ):
+            build_google_provider()
+
+    def test_loopback_http_base_url_allowed_for_dev(self):
+        with _google_settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+            UNRAID_MCP_GOOGLE_BASE_URL="http://127.0.0.1:6970",
+            UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
+        ):
+            assert build_google_provider() is not None
+
+    @pytest.mark.parametrize(
+        "redirect_path", ["https://evil.example/cb", "auth/callback", "/cb?x=1"]
+    )
+    def test_invalid_redirect_path_rejected(self, redirect_path: str):
+        with (
+            _google_settings(
+                UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
+                UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
+                UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
+                UNRAID_MCP_GOOGLE_REDIRECT_PATH=redirect_path,
+            ),
+            pytest.raises(GoogleOAuthConfigError, match="REDIRECT_PATH"),
+        ):
+            build_google_provider()
+
     def test_only_jwt_key_raises(self):
         with (
             _google_settings(
                 UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
                 UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
                 UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
                 UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY="jwt-key",
             ),
             pytest.raises(GoogleOAuthConfigError, match="requires BOTH"),
@@ -160,6 +250,7 @@ class TestConfigErrors:
                 UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
                 UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
                 UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
                 UNRAID_MCP_GOOGLE_ENCRYPTION_KEY=_fernet_key(),
             ),
             pytest.raises(GoogleOAuthConfigError, match="requires BOTH"),
@@ -172,6 +263,7 @@ class TestConfigErrors:
                 UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
                 UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
                 UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+                UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
                 UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY="jwt-key",
                 UNRAID_MCP_GOOGLE_ENCRYPTION_KEY="not-a-valid-fernet-key",
                 UNRAID_MCP_GOOGLE_STORAGE_DIR=str(tmp_path / "tokens"),
@@ -192,16 +284,21 @@ class TestProviderConstruction:
             UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
             UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
             UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
         ):
             provider = build_google_provider()
         assert provider is not None
         assert type(provider).__name__ == "GoogleProvider"
+        from key_value.aio.stores.memory import MemoryStore
+
+        assert isinstance(provider._client_storage, MemoryStore)
 
     def test_custom_scopes_and_redirect_path(self):
         with _google_settings(
             UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
             UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
             UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS="example.com",
             UNRAID_MCP_GOOGLE_REQUIRED_SCOPES="openid profile",
             UNRAID_MCP_GOOGLE_REDIRECT_PATH="/auth/google/callback",
         ):
@@ -214,6 +311,7 @@ class TestProviderConstruction:
             UNRAID_MCP_GOOGLE_CLIENT_ID="x.apps.googleusercontent.com",
             UNRAID_MCP_GOOGLE_CLIENT_SECRET="GOCSPX-secret",
             UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
             UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY="jwt-signing-key",
             UNRAID_MCP_GOOGLE_ENCRYPTION_KEY=_fernet_key(),
             UNRAID_MCP_GOOGLE_STORAGE_DIR=str(storage),
@@ -221,6 +319,51 @@ class TestProviderConstruction:
             provider = build_google_provider()
         assert provider is not None
         assert storage.is_dir()
+        from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+        assert isinstance(provider._client_storage, FernetEncryptionWrapper)
+
+
+class TestAuthorizedGoogleTokenVerifier:
+    async def _verify_with_user(self, user: dict, *, emails=None, domains=None, allow_any=False):
+        wrapped = AsyncMock()
+        wrapped.verify_token.return_value = AccessToken(token="tok", client_id="sub", scopes=[])
+        verifier = _AuthorizedGoogleTokenVerifier(
+            wrapped,
+            allowed_emails=set(emails or []),
+            allowed_domains=set(domains or []),
+            allow_any_user=allow_any,
+        )
+        verifier._fetch_google_identity = AsyncMock(return_value=user)
+        return await verifier.verify_token("tok")
+
+    async def test_allows_verified_email(self):
+        result = await self._verify_with_user(
+            {"email": "Owner@Example.com", "email_verified": "true"},
+            emails={"owner@example.com"},
+        )
+        assert result is not None
+
+    async def test_allows_verified_domain(self):
+        result = await self._verify_with_user(
+            {"email": "admin@example.com", "email_verified": True},
+            domains={"example.com"},
+        )
+        assert result is not None
+
+    async def test_rejects_unverified_email(self):
+        result = await self._verify_with_user(
+            {"email": "owner@example.com", "email_verified": "false"},
+            emails={"owner@example.com"},
+        )
+        assert result is None
+
+    async def test_rejects_unauthorized_email(self):
+        result = await self._verify_with_user(
+            {"email": "stranger@example.net", "email_verified": True},
+            emails={"owner@example.com"},
+        )
+        assert result is None
 
 
 # ---------------------------------------------------------------------------
@@ -244,11 +387,12 @@ class TestRunServerMiddlewareSelection:
             with (
                 patch.object(server, "_google_auth_provider", google_provider),
                 patch.object(server.mcp, "run", side_effect=fake_run),
-                patch.object(server, "ensure_token_exists"),
+                patch.object(server, "ensure_token_exists") as ensure_token,
                 patch.object(server, "log_configuration_status"),
                 patch.object(s, "UNRAID_MCP_BEARER_TOKEN", "tok"),
             ):
                 server.run_server()
+                captured["ensure_token_called"] = ensure_token.called
         finally:
             s.UNRAID_MCP_TRANSPORT = orig_transport
         return captured.get("middleware")
@@ -258,6 +402,13 @@ class TestRunServerMiddlewareSelection:
         assert middleware is not None
         # Health + WellKnown + Bearer
         assert len(middleware) == 3
+        import unraid_mcp.server as server
+
+        assert middleware[0].cls is server.HealthMiddleware
+        assert middleware[1].cls is server.WellKnownMiddleware
+        assert middleware[2].cls is server.BearerAuthMiddleware
+        assert middleware[2].kwargs["token"] == "tok"
+        assert middleware[2].kwargs["disabled"] is False
 
     def test_oauth_path_installs_only_health(self):
         sentinel = object()  # stand-in for a built GoogleProvider
@@ -265,3 +416,94 @@ class TestRunServerMiddlewareSelection:
         assert middleware is not None
         # Only HealthMiddleware — bearer + well-known are omitted under OAuth.
         assert len(middleware) == 1
+        import unraid_mcp.server as server
+
+        assert middleware[0].cls is server.HealthMiddleware
+
+    def test_oauth_skips_bearer_bootstrap_and_public_bind_guard(self):
+        import unraid_mcp.server as server
+
+        captured: dict = {}
+
+        def fake_run(*args, **kwargs):
+            captured["middleware"] = kwargs.get("middleware")
+
+        originals = {
+            "transport": s.UNRAID_MCP_TRANSPORT,
+            "token": s.UNRAID_MCP_BEARER_TOKEN,
+            "disable": s.UNRAID_MCP_DISABLE_HTTP_AUTH,
+            "host": s.UNRAID_MCP_HOST,
+            "trust": s.UNRAID_MCP_TRUST_PROXY,
+        }
+        try:
+            s.UNRAID_MCP_TRANSPORT = "streamable-http"
+            s.UNRAID_MCP_BEARER_TOKEN = None
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = True
+            s.UNRAID_MCP_HOST = "0.0.0.0"  # noqa: S104 - deliberate public-bind guard test
+            s.UNRAID_MCP_TRUST_PROXY = False
+            with (
+                patch.object(server, "_google_auth_provider", object()),
+                patch.object(server.mcp, "run", side_effect=fake_run),
+                patch.object(server, "ensure_token_exists") as ensure_token,
+                patch.object(server, "log_configuration_status"),
+            ):
+                server.run_server()
+            ensure_token.assert_not_called()
+            assert len(captured["middleware"]) == 1
+            assert captured["middleware"][0].cls is server.HealthMiddleware
+        finally:
+            s.UNRAID_MCP_TRANSPORT = originals["transport"]
+            s.UNRAID_MCP_BEARER_TOKEN = originals["token"]
+            s.UNRAID_MCP_DISABLE_HTTP_AUTH = originals["disable"]
+            s.UNRAID_MCP_HOST = originals["host"]
+            s.UNRAID_MCP_TRUST_PROXY = originals["trust"]
+
+
+class TestServerImportWiring:
+    def _reload_server(self):
+        import unraid_mcp.server as server
+
+        return importlib.reload(server)
+
+    def _restore_server(self, transport: str):
+        s.UNRAID_MCP_TRANSPORT = transport
+        return self._reload_server()
+
+    def test_fastmcp_auth_wired_at_import_for_http(self):
+        original_transport = s.UNRAID_MCP_TRANSPORT
+        sentinel = object()
+        try:
+            s.UNRAID_MCP_TRANSPORT = "streamable-http"
+            with patch("unraid_mcp.core.google_auth.build_google_provider", return_value=sentinel):
+                server = self._reload_server()
+            assert server.mcp.auth is sentinel
+        finally:
+            self._restore_server(original_transport)
+
+    def test_oauth_misconfig_exits_at_http_import(self, capsys):
+        original_transport = s.UNRAID_MCP_TRANSPORT
+        try:
+            s.UNRAID_MCP_TRANSPORT = "streamable-http"
+            with (
+                patch(
+                    "unraid_mcp.core.google_auth.build_google_provider",
+                    side_effect=GoogleOAuthConfigError("bad oauth"),
+                ),
+                pytest.raises(SystemExit) as excinfo,
+            ):
+                self._reload_server()
+            assert excinfo.value.code == 1
+            assert "bad oauth" in capsys.readouterr().err
+        finally:
+            self._restore_server(original_transport)
+
+    def test_stdio_import_does_not_build_google_provider(self):
+        original_transport = s.UNRAID_MCP_TRANSPORT
+        try:
+            s.UNRAID_MCP_TRANSPORT = "stdio"
+            with patch("unraid_mcp.core.google_auth.build_google_provider") as build:
+                server = self._reload_server()
+            build.assert_not_called()
+            assert server.mcp.auth is None
+        finally:
+            self._restore_server(original_transport)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -279,6 +279,40 @@ class TestPortGuard:
         assert isinstance(settings.unraid_mcp_port, int)
 
 
+class TestGoogleOAuthSettings:
+    def test_google_oauth_empty_plugin_values_become_none(self) -> None:
+        settings = Settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="",
+            UNRAID_MCP_GOOGLE_BASE_URL="",
+            UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="",
+            UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS="",
+            UNRAID_MCP_GOOGLE_STORAGE_DIR="",
+        )
+        assert settings.unraid_mcp_google_client_id is None
+        assert settings.unraid_mcp_google_client_secret is None
+        assert settings.unraid_mcp_google_base_url is None
+        assert settings.unraid_mcp_google_allowed_emails is None
+        assert settings.unraid_mcp_google_allowed_domains is None
+        assert settings.unraid_mcp_google_storage_dir is None
+
+    def test_google_oauth_aliases_populate_model(self) -> None:
+        settings = Settings(
+            UNRAID_MCP_GOOGLE_CLIENT_ID="client",
+            UNRAID_MCP_GOOGLE_CLIENT_SECRET="secret",
+            UNRAID_MCP_GOOGLE_BASE_URL="https://mcp.example.com",
+            UNRAID_MCP_GOOGLE_ALLOWED_EMAILS="owner@example.com",
+            UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS="example.com",
+            UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=True,
+        )
+        assert settings.unraid_mcp_google_client_id == "client"
+        assert settings.unraid_mcp_google_client_secret == "secret"
+        assert settings.unraid_mcp_google_base_url == "https://mcp.example.com"
+        assert settings.unraid_mcp_google_allowed_emails == "owner@example.com"
+        assert settings.unraid_mcp_google_allowed_domains == "example.com"
+        assert settings.unraid_mcp_google_allow_any_user is True
+
+
 @pytest.fixture
 def _reload_settings(
     monkeypatch: pytest.MonkeyPatch,

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -175,6 +175,18 @@ class Settings(BaseSettings):
     unraid_mcp_google_required_scopes: str | None = Field(
         default=None, alias="UNRAID_MCP_GOOGLE_REQUIRED_SCOPES"
     )
+    # Authorization allowlist. OAuth proves Google identity; these settings decide
+    # which identities may control this MCP server. At least one allowlist entry is
+    # required unless UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=true is explicitly set.
+    unraid_mcp_google_allowed_emails: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_ALLOWED_EMAILS"
+    )
+    unraid_mcp_google_allowed_domains: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS"
+    )
+    unraid_mcp_google_allow_any_user: bool = Field(
+        default=False, alias="UNRAID_MCP_GOOGLE_ALLOW_ANY_USER"
+    )
     # OAuth callback path. Defaults to GoogleProvider's "/auth/callback" when unset.
     unraid_mcp_google_redirect_path: str | None = Field(
         default=None, alias="UNRAID_MCP_GOOGLE_REDIRECT_PATH"
@@ -213,6 +225,8 @@ class Settings(BaseSettings):
         "unraid_mcp_google_client_secret",
         "unraid_mcp_google_base_url",
         "unraid_mcp_google_required_scopes",
+        "unraid_mcp_google_allowed_emails",
+        "unraid_mcp_google_allowed_domains",
         "unraid_mcp_google_redirect_path",
         "unraid_mcp_google_jwt_signing_key",
         "unraid_mcp_google_encryption_key",
@@ -293,6 +307,7 @@ class Settings(BaseSettings):
     @field_validator(
         "unraid_mcp_disable_http_auth",
         "unraid_mcp_trust_proxy",
+        "unraid_mcp_google_allow_any_user",
         "unraid_allow_insecure_tls",
         mode="before",
     )
@@ -351,6 +366,9 @@ UNRAID_MCP_GOOGLE_CLIENT_ID: str | None = _settings.unraid_mcp_google_client_id
 UNRAID_MCP_GOOGLE_CLIENT_SECRET: str | None = _settings.unraid_mcp_google_client_secret
 UNRAID_MCP_GOOGLE_BASE_URL: str | None = _settings.unraid_mcp_google_base_url
 UNRAID_MCP_GOOGLE_REQUIRED_SCOPES: str | None = _settings.unraid_mcp_google_required_scopes
+UNRAID_MCP_GOOGLE_ALLOWED_EMAILS: str | None = _settings.unraid_mcp_google_allowed_emails
+UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS: str | None = _settings.unraid_mcp_google_allowed_domains
+UNRAID_MCP_GOOGLE_ALLOW_ANY_USER: bool = _settings.unraid_mcp_google_allow_any_user
 UNRAID_MCP_GOOGLE_REDIRECT_PATH: str | None = _settings.unraid_mcp_google_redirect_path
 UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY: str | None = _settings.unraid_mcp_google_jwt_signing_key
 UNRAID_MCP_GOOGLE_ENCRYPTION_KEY: str | None = _settings.unraid_mcp_google_encryption_key
@@ -461,6 +479,18 @@ def get_config_summary() -> dict[str, Any]:
     from ..core.utils import safe_display_url
 
     is_http = UNRAID_MCP_TRANSPORT in ("streamable-http", "sse")
+    google_oauth_enabled = is_http and bool(
+        UNRAID_MCP_GOOGLE_CLIENT_ID and UNRAID_MCP_GOOGLE_CLIENT_SECRET
+    )
+    http_auth_mode = (
+        "google_oauth"
+        if google_oauth_enabled
+        else "disabled"
+        if is_http and UNRAID_MCP_DISABLE_HTTP_AUTH
+        else "bearer"
+        if is_http
+        else "not_applicable"
+    )
     return {
         "api_url_configured": bool(UNRAID_API_URL),
         "api_url_preview": safe_display_url(UNRAID_API_URL) if UNRAID_API_URL else None,
@@ -474,12 +504,14 @@ def get_config_summary() -> dict[str, Any]:
         "config_valid": is_valid,
         "missing_config": missing if not is_valid else None,
         # Auth fields only meaningful in HTTP mode
-        "http_auth_enabled": is_http and not UNRAID_MCP_DISABLE_HTTP_AUTH,
-        "http_auth_token_set": bool(UNRAID_MCP_BEARER_TOKEN) if is_http else False,
+        "http_auth_enabled": is_http and http_auth_mode != "disabled",
+        "http_auth_mode": http_auth_mode,
+        "http_auth_token_set": bool(UNRAID_MCP_BEARER_TOKEN)
+        if http_auth_mode == "bearer"
+        else None,
         # Google OAuth delegation (when both client id + secret are set, OAuth
         # replaces the bearer token as the HTTP auth mechanism).
-        "google_oauth_enabled": is_http
-        and bool(UNRAID_MCP_GOOGLE_CLIENT_ID and UNRAID_MCP_GOOGLE_CLIENT_SECRET),
+        "google_oauth_enabled": google_oauth_enabled,
     }
 
 

--- a/unraid_mcp/config/settings.py
+++ b/unraid_mcp/config/settings.py
@@ -157,6 +157,42 @@ class Settings(BaseSettings):
     # operator must explicitly opt in to that arrangement; leaving it false fails closed.
     unraid_mcp_trust_proxy: bool = Field(default=False, alias="UNRAID_MCP_TRUST_PROXY")
 
+    # Google OAuth (HTTP transport) — OPTIONAL alternative to the pre-shared bearer token.
+    # When both client id and secret are set, the server delegates HTTP authentication to
+    # FastMCP's GoogleProvider (OAuth proxy) instead of the bearer-token middleware. See
+    # core/google_auth.py for the wiring and .env.example for the full variable reference.
+    # All values default to None so the bearer-token path is entirely unaffected when unset.
+    unraid_mcp_google_client_id: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_CLIENT_ID"
+    )
+    unraid_mcp_google_client_secret: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_CLIENT_SECRET"
+    )
+    # Public base URL of this server (e.g. https://unraid-mcp.example.com); must match the
+    # Authorized redirect URI registered in Google Cloud. Required when OAuth is enabled.
+    unraid_mcp_google_base_url: str | None = Field(default=None, alias="UNRAID_MCP_GOOGLE_BASE_URL")
+    # Comma/space-separated OAuth scopes. Defaults to "openid <userinfo.email>" when unset.
+    unraid_mcp_google_required_scopes: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_REQUIRED_SCOPES"
+    )
+    # OAuth callback path. Defaults to GoogleProvider's "/auth/callback" when unset.
+    unraid_mcp_google_redirect_path: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_REDIRECT_PATH"
+    )
+    # Persistence (both required together): a JWT signing key and a Fernet encryption key
+    # enable encrypted, restart-surviving token storage on disk (FileTreeStore). Set neither
+    # to keep tokens in memory (cleared on restart); setting only one is a config error.
+    unraid_mcp_google_jwt_signing_key: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY"
+    )
+    unraid_mcp_google_encryption_key: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_ENCRYPTION_KEY"
+    )
+    # Directory for persisted encrypted tokens. Defaults to ~/.unraid-mcp/oauth-tokens.
+    unraid_mcp_google_storage_dir: str | None = Field(
+        default=None, alias="UNRAID_MCP_GOOGLE_STORAGE_DIR"
+    )
+
     # SSL Configuration — second explicit opt-in gating disabled TLS verification (S-H1).
     unraid_allow_insecure_tls: bool = Field(default=False, alias="UNRAID_ALLOW_INSECURE_TLS")
 
@@ -169,10 +205,29 @@ class Settings(BaseSettings):
 
     # -- validators -----------------------------------------------------------
 
-    @field_validator("unraid_api_url", "unraid_api_key", "unraid_mcp_bearer_token", mode="before")
+    @field_validator(
+        "unraid_api_url",
+        "unraid_api_key",
+        "unraid_mcp_bearer_token",
+        "unraid_mcp_google_client_id",
+        "unraid_mcp_google_client_secret",
+        "unraid_mcp_google_base_url",
+        "unraid_mcp_google_required_scopes",
+        "unraid_mcp_google_redirect_path",
+        "unraid_mcp_google_jwt_signing_key",
+        "unraid_mcp_google_encryption_key",
+        "unraid_mcp_google_storage_dir",
+        mode="before",
+    )
     @classmethod
     def _empty_to_none(cls, value: object) -> object:
-        """Mirror ``os.getenv(...) or None`` — empty string becomes None."""
+        """Mirror ``os.getenv(...) or None`` — empty string becomes None.
+
+        Critical for the Google OAuth fields: the bundled ``.mcp.json`` expands
+        unset plugin options to ``""``. Treating those as ``None`` keeps an
+        unconfigured deployment on the default bearer-token path instead of
+        falsely tripping the ``client_id``/``client_secret`` enable gate.
+        """
         if value == "":
             return None
         return value
@@ -290,6 +345,16 @@ UNRAID_MCP_MAX_RESPONSE_BYTES = _settings.unraid_mcp_max_response_bytes
 UNRAID_MCP_BEARER_TOKEN: str | None = _settings.unraid_mcp_bearer_token
 UNRAID_MCP_DISABLE_HTTP_AUTH: bool = _settings.unraid_mcp_disable_http_auth
 UNRAID_MCP_TRUST_PROXY: bool = _settings.unraid_mcp_trust_proxy
+
+# Google OAuth (optional; see core/google_auth.py)
+UNRAID_MCP_GOOGLE_CLIENT_ID: str | None = _settings.unraid_mcp_google_client_id
+UNRAID_MCP_GOOGLE_CLIENT_SECRET: str | None = _settings.unraid_mcp_google_client_secret
+UNRAID_MCP_GOOGLE_BASE_URL: str | None = _settings.unraid_mcp_google_base_url
+UNRAID_MCP_GOOGLE_REQUIRED_SCOPES: str | None = _settings.unraid_mcp_google_required_scopes
+UNRAID_MCP_GOOGLE_REDIRECT_PATH: str | None = _settings.unraid_mcp_google_redirect_path
+UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY: str | None = _settings.unraid_mcp_google_jwt_signing_key
+UNRAID_MCP_GOOGLE_ENCRYPTION_KEY: str | None = _settings.unraid_mcp_google_encryption_key
+UNRAID_MCP_GOOGLE_STORAGE_DIR: str | None = _settings.unraid_mcp_google_storage_dir
 
 # SSL Configuration
 # UNRAID_VERIFY_SSL accepts: true/1/yes (verify, default), false/0/no (disable —
@@ -411,6 +476,10 @@ def get_config_summary() -> dict[str, Any]:
         # Auth fields only meaningful in HTTP mode
         "http_auth_enabled": is_http and not UNRAID_MCP_DISABLE_HTTP_AUTH,
         "http_auth_token_set": bool(UNRAID_MCP_BEARER_TOKEN) if is_http else False,
+        # Google OAuth delegation (when both client id + secret are set, OAuth
+        # replaces the bearer token as the HTTP auth mechanism).
+        "google_oauth_enabled": is_http
+        and bool(UNRAID_MCP_GOOGLE_CLIENT_ID and UNRAID_MCP_GOOGLE_CLIENT_SECRET),
     }
 
 

--- a/unraid_mcp/core/google_auth.py
+++ b/unraid_mcp/core/google_auth.py
@@ -29,8 +29,13 @@ two keys is a configuration error — encrypted persistence needs both.
 
 from __future__ import annotations
 
+import contextlib
+import ipaddress
 from pathlib import Path
 from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import httpx
 
 from ..config import settings as _settings
 from ..config.logging import logger
@@ -40,6 +45,7 @@ from ..config.settings import CREDENTIALS_DIR
 if TYPE_CHECKING:
     from fastmcp.server.auth.providers.google import GoogleProvider
     from key_value.aio.protocols.key_value import AsyncKeyValue
+    from mcp.server.auth.provider import AccessToken, TokenVerifier
 
 
 # Default scopes match the FastMCP Google integration guide: an OpenID Connect
@@ -58,6 +64,23 @@ class GoogleOAuthConfigError(RuntimeError):
     """
 
 
+def _split_list(raw: str | None) -> list[str]:
+    """Split comma/space-separated env values, dropping blanks."""
+    if not raw or not raw.strip():
+        return []
+    return [item.strip() for chunk in raw.split(",") for item in chunk.split() if item.strip()]
+
+
+def _normalize_email_list(raw: str | None) -> set[str]:
+    """Return a lower-cased email allowlist from an env string."""
+    return {item.lower() for item in _split_list(raw)}
+
+
+def _normalize_domain_list(raw: str | None) -> set[str]:
+    """Return lower-cased allowed domains without leading '@'."""
+    return {item.lower().lstrip("@") for item in _split_list(raw)}
+
+
 def google_oauth_enabled() -> bool:
     """Return True when Google OAuth should replace the bearer-token auth.
 
@@ -71,12 +94,137 @@ def google_oauth_enabled() -> bool:
     )
 
 
+def _google_oauth_partially_configured() -> bool:
+    """Return True when one OAuth enablement var is present without the other."""
+    client_id = (_settings.UNRAID_MCP_GOOGLE_CLIENT_ID or "").strip()
+    client_secret = (_settings.UNRAID_MCP_GOOGLE_CLIENT_SECRET or "").strip()
+    return bool(client_id or client_secret) and not bool(client_id and client_secret)
+
+
 def _parse_scopes(raw: str | None) -> list[str]:
     """Split a comma/space-separated scope string, falling back to the defaults."""
     if not raw or not raw.strip():
         return list(_DEFAULT_SCOPES)
     parts = [scope.strip() for chunk in raw.split(",") for scope in chunk.split() if scope.strip()]
     return parts or list(_DEFAULT_SCOPES)
+
+
+def _is_loopback_hostname(hostname: str | None) -> bool:
+    if hostname is None:
+        return False
+    host = hostname.strip("[]").lower()
+    if host == "localhost":
+        return True
+    with contextlib.suppress(ValueError):
+        return ipaddress.ip_address(host).is_loopback
+    return False
+
+
+def _validate_base_url(base_url: str) -> None:
+    """Require HTTPS for OAuth except loopback HTTP development URLs."""
+    parsed = urlparse(base_url)
+    if parsed.scheme == "https" and parsed.netloc:
+        return
+    if parsed.scheme == "http" and parsed.netloc and _is_loopback_hostname(parsed.hostname):
+        return
+    raise GoogleOAuthConfigError(
+        "UNRAID_MCP_GOOGLE_BASE_URL must be an https:// URL. "
+        "http:// is allowed only for localhost/loopback development."
+    )
+
+
+def _validate_redirect_path(path: str | None) -> None:
+    """Validate Google redirect path when configured."""
+    if path is None:
+        return
+    parsed = urlparse(path)
+    if (
+        parsed.scheme
+        or parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or not path.startswith("/")
+    ):
+        raise GoogleOAuthConfigError(
+            "UNRAID_MCP_GOOGLE_REDIRECT_PATH must be an absolute path such as "
+            "/auth/callback (no scheme, host, query, or fragment)."
+        )
+
+
+def _google_bool(value: object) -> bool:
+    """Google tokeninfo may return bools or string booleans."""
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"true", "1", "yes"}
+
+
+def _email_authorized(email: str, allowed_emails: set[str], allowed_domains: set[str]) -> bool:
+    """Return True when a verified Google email is locally authorized."""
+    email_l = email.lower()
+    domain = email_l.rsplit("@", 1)[-1] if "@" in email_l else ""
+    return email_l in allowed_emails or domain in allowed_domains
+
+
+class _AuthorizedGoogleTokenVerifier:
+    """Wrap Google token verification with local email/domain authorization."""
+
+    def __init__(
+        self,
+        wrapped: TokenVerifier,
+        *,
+        allowed_emails: set[str],
+        allowed_domains: set[str],
+        allow_any_user: bool,
+        timeout_seconds: int = 10,
+    ) -> None:
+        self._wrapped = wrapped
+        self._allowed_emails = allowed_emails
+        self._allowed_domains = allowed_domains
+        self._allow_any_user = allow_any_user
+        self._timeout_seconds = timeout_seconds
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        access_token = await self._wrapped.verify_token(token)
+        if access_token is None:
+            return None
+        if self._allow_any_user:
+            return access_token
+
+        user = await self._fetch_google_identity(token)
+        email = str(user.get("email") or "").strip().lower()
+        if not email or not _google_bool(user.get("email_verified")):
+            logger.warning("Google OAuth rejected token without a verified email")
+            return None
+        if not _email_authorized(email, self._allowed_emails, self._allowed_domains):
+            logger.warning("Google OAuth rejected unauthorized email %s", email)
+            return None
+        return access_token
+
+    async def _fetch_google_identity(self, token: str) -> dict[str, object]:
+        """Fetch token identity data used for local authorization."""
+        async with httpx.AsyncClient(timeout=self._timeout_seconds) as client:
+            response = await client.get(
+                "https://oauth2.googleapis.com/tokeninfo",
+                params={"access_token": token},
+                headers={"User-Agent": "UnraidMCP-Google-OAuth"},
+            )
+            if response.status_code == 200:
+                return dict(response.json())
+
+            logger.debug("Google tokeninfo authorization lookup failed: %s", response.status_code)
+            userinfo = await client.get(
+                "https://www.googleapis.com/oauth2/v2/userinfo",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "User-Agent": "UnraidMCP-Google-OAuth",
+                },
+            )
+            if userinfo.status_code == 200:
+                data = dict(userinfo.json())
+                if "verified_email" in data and "email_verified" not in data:
+                    data["email_verified"] = data["verified_email"]
+                return data
+        return {}
 
 
 def _storage_dir() -> Path:
@@ -126,7 +274,11 @@ def _build_encrypted_storage(encryption_key: str) -> AsyncKeyValue:
         key_sanitization_strategy=FileTreeV1KeySanitizationStrategy(storage_dir),
         collection_sanitization_strategy=FileTreeV1CollectionSanitizationStrategy(storage_dir),
     )
-    return FernetEncryptionWrapper(key_value=store, fernet=fernet)
+    return FernetEncryptionWrapper(
+        key_value=store,
+        fernet=fernet,
+        raise_on_decryption_error=False,
+    )
 
 
 def build_google_provider() -> GoogleProvider | None:
@@ -138,7 +290,24 @@ def build_google_provider() -> GoogleProvider | None:
     invalid Fernet key) so startup fails closed with an actionable message.
     """
     if not google_oauth_enabled():
+        if _google_oauth_partially_configured():
+            missing = []
+            if not (_settings.UNRAID_MCP_GOOGLE_CLIENT_ID or "").strip():
+                missing.append("UNRAID_MCP_GOOGLE_CLIENT_ID")
+            if not (_settings.UNRAID_MCP_GOOGLE_CLIENT_SECRET or "").strip():
+                missing.append("UNRAID_MCP_GOOGLE_CLIENT_SECRET")
+            raise GoogleOAuthConfigError(
+                "Google OAuth is partially configured. Set both "
+                "UNRAID_MCP_GOOGLE_CLIENT_ID and UNRAID_MCP_GOOGLE_CLIENT_SECRET, "
+                f"or unset all Google OAuth variables. Missing: {', '.join(missing)}."
+            )
         return None
+    if _settings.UNRAID_MCP_DISABLE_HTTP_AUTH:
+        raise GoogleOAuthConfigError(
+            "UNRAID_MCP_DISABLE_HTTP_AUTH=true conflicts with Google OAuth. "
+            "Unset the Google OAuth variables for gateway-owned auth, or leave "
+            "UNRAID_MCP_DISABLE_HTTP_AUTH=false and let OAuth protect the endpoint."
+        )
 
     from fastmcp.server.auth.providers.google import GoogleProvider
 
@@ -153,13 +322,29 @@ def build_google_provider() -> GoogleProvider | None:
             "(e.g. https://unraid-mcp.example.com) — it must match the Authorized redirect "
             "URI configured for the OAuth client in Google Cloud."
         )
+    _validate_base_url(base_url)
 
     scopes = _parse_scopes(_settings.UNRAID_MCP_GOOGLE_REQUIRED_SCOPES)
     redirect_path = (_settings.UNRAID_MCP_GOOGLE_REDIRECT_PATH or "").strip() or None
+    _validate_redirect_path(redirect_path)
+
+    allowed_emails = _normalize_email_list(_settings.UNRAID_MCP_GOOGLE_ALLOWED_EMAILS)
+    allowed_domains = _normalize_domain_list(_settings.UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS)
+    allow_any_user = bool(_settings.UNRAID_MCP_GOOGLE_ALLOW_ANY_USER)
+    if not allow_any_user and not (allowed_emails or allowed_domains):
+        raise GoogleOAuthConfigError(
+            "Google OAuth is enabled but no local identity allowlist is configured. "
+            "Set UNRAID_MCP_GOOGLE_ALLOWED_EMAILS and/or "
+            "UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS, or explicitly set "
+            "UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=true for a trusted/private deployment."
+        )
 
     jwt_signing_key = _settings.UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY
     encryption_key = _settings.UNRAID_MCP_GOOGLE_ENCRYPTION_KEY
-    client_storage: AsyncKeyValue | None = None
+    from key_value.aio.stores.memory import MemoryStore
+
+    client_storage: AsyncKeyValue = MemoryStore()
+    persistence_label = "in-memory"
     if jwt_signing_key or encryption_key:
         if not (jwt_signing_key and encryption_key):
             raise GoogleOAuthConfigError(
@@ -169,6 +354,7 @@ def build_google_provider() -> GoogleProvider | None:
                 "memory (cleared on restart)."
             )
         client_storage = _build_encrypted_storage(encryption_key)
+        persistence_label = "encrypted-filetree"
 
     # Pass every optional argument explicitly. ``redirect_path=None`` selects the
     # provider's default ("/auth/callback"); ``client_storage``/``jwt_signing_key``
@@ -183,12 +369,23 @@ def build_google_provider() -> GoogleProvider | None:
         client_storage=client_storage,
         jwt_signing_key=jwt_signing_key,
     )
+    setattr(  # noqa: B010 - private FastMCP hook; typed assignment is rejected by ty.
+        provider,
+        "_token_validator",
+        _AuthorizedGoogleTokenVerifier(
+            provider._token_validator,
+            allowed_emails=allowed_emails,
+            allowed_domains=allowed_domains,
+            allow_any_user=allow_any_user,
+        ),
+    )
 
     logger.info(
-        "Google OAuth enabled (base_url=%s, scopes=%s, redirect_path=%s, persistence=%s)",
+        "Google OAuth enabled (base_url=%s, scopes=%s, redirect_path=%s, persistence=%s, authz=%s)",
         base_url,
         ",".join(scopes),
         redirect_path or "/auth/callback",
-        "encrypted-filetree" if client_storage is not None else "in-memory",
+        persistence_label,
+        "allow-any-user" if allow_any_user else "email/domain allowlist",
     )
     return provider

--- a/unraid_mcp/core/google_auth.py
+++ b/unraid_mcp/core/google_auth.py
@@ -1,0 +1,194 @@
+"""Optional Google OAuth authentication for the HTTP transport.
+
+The server's default authentication is a pre-shared bearer token enforced by the
+ASGI middleware in :mod:`unraid_mcp.core.auth`. As an alternative, operators can
+delegate HTTP authentication to **Google OAuth**: when both
+``UNRAID_MCP_GOOGLE_CLIENT_ID`` and ``UNRAID_MCP_GOOGLE_CLIENT_SECRET`` are set,
+the server attaches FastMCP's :class:`GoogleProvider` (an OAuth-proxy auth
+backend) to the ``FastMCP`` instance, and MCP clients authenticate via the
+standard OAuth browser flow instead of sending a static token.
+
+The two mechanisms are mutually exclusive at the HTTP layer: when Google OAuth is
+active, ``server.py`` does NOT install ``BearerAuthMiddleware`` /
+``WellKnownMiddleware`` (the provider serves its own ``.well-known`` discovery
+metadata and gates requests itself). Everything here is gated entirely on
+environment variables, so a deployment that sets none of them is byte-for-byte
+unchanged.
+
+Token persistence
+-----------------
+By default the provider keeps issued tokens in memory, so every restart
+invalidates existing client sessions (clients transparently re-authenticate). To
+persist tokens across restarts WITHOUT standing up Redis, set BOTH
+``UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY`` and ``UNRAID_MCP_GOOGLE_ENCRYPTION_KEY``:
+tokens are then written under ``UNRAID_MCP_GOOGLE_STORAGE_DIR`` (default
+``~/.unraid-mcp/oauth-tokens``) through a ``FileTreeStore`` wrapped in a
+``FernetEncryptionWrapper`` so they are encrypted at rest. Setting only one of the
+two keys is a configuration error — encrypted persistence needs both.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..config import settings as _settings
+from ..config.logging import logger
+from ..config.settings import CREDENTIALS_DIR
+
+
+if TYPE_CHECKING:
+    from fastmcp.server.auth.providers.google import GoogleProvider
+    from key_value.aio.protocols.key_value import AsyncKeyValue
+
+
+# Default scopes match the FastMCP Google integration guide: an OpenID Connect
+# login plus the user's email address.
+_DEFAULT_SCOPES: tuple[str, ...] = (
+    "openid",
+    "https://www.googleapis.com/auth/userinfo.email",
+)
+
+
+class GoogleOAuthConfigError(RuntimeError):
+    """Raised when Google OAuth env vars are present but invalid or incomplete.
+
+    ``server.py`` catches this at import time and converts it to a fatal startup
+    error (``sys.exit(1)``), mirroring the other fail-closed config guards.
+    """
+
+
+def google_oauth_enabled() -> bool:
+    """Return True when Google OAuth should replace the bearer-token auth.
+
+    The gate is the presence of BOTH the client id and secret. Empty strings are
+    normalised to ``None`` upstream (see ``Settings._empty_to_none``), so an
+    unset plugin option cannot accidentally enable OAuth.
+    """
+    return bool(
+        (_settings.UNRAID_MCP_GOOGLE_CLIENT_ID or "").strip()
+        and (_settings.UNRAID_MCP_GOOGLE_CLIENT_SECRET or "").strip()
+    )
+
+
+def _parse_scopes(raw: str | None) -> list[str]:
+    """Split a comma/space-separated scope string, falling back to the defaults."""
+    if not raw or not raw.strip():
+        return list(_DEFAULT_SCOPES)
+    parts = [scope.strip() for chunk in raw.split(",") for scope in chunk.split() if scope.strip()]
+    return parts or list(_DEFAULT_SCOPES)
+
+
+def _storage_dir() -> Path:
+    """Resolve the directory used for persisted encrypted OAuth tokens."""
+    configured = (_settings.UNRAID_MCP_GOOGLE_STORAGE_DIR or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+    return CREDENTIALS_DIR / "oauth-tokens"
+
+
+def _build_encrypted_storage(encryption_key: str) -> AsyncKeyValue:
+    """Build a disk-backed, Fernet-encrypted key-value store for OAuth tokens.
+
+    Uses ``FileTreeStore`` (no external services — plain files on disk) wrapped in
+    ``FernetEncryptionWrapper`` so token values are encrypted at rest. The storage
+    directory is created with ``0o700`` permissions since it holds sensitive
+    material even after encryption.
+    """
+    # Imported lazily so the module (and the whole server) loads fine when the
+    # optional persistence path is unused.
+    from cryptography.fernet import Fernet
+    from key_value.aio.stores.filetree import (
+        FileTreeStore,
+        FileTreeV1CollectionSanitizationStrategy,
+        FileTreeV1KeySanitizationStrategy,
+    )
+    from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+    try:
+        fernet = Fernet(encryption_key.encode())
+    except (ValueError, TypeError) as exc:
+        raise GoogleOAuthConfigError(
+            "UNRAID_MCP_GOOGLE_ENCRYPTION_KEY is not a valid Fernet key. Generate one with:\n"
+            '  python -c "from cryptography.fernet import Fernet; '
+            'print(Fernet.generate_key().decode())"'
+        ) from exc
+
+    storage_dir = _storage_dir()
+    storage_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        storage_dir.chmod(0o700)
+    except OSError:
+        logger.debug("Could not chmod %s (volume mount?) — skipping", storage_dir)
+
+    store = FileTreeStore(
+        data_directory=storage_dir,
+        key_sanitization_strategy=FileTreeV1KeySanitizationStrategy(storage_dir),
+        collection_sanitization_strategy=FileTreeV1CollectionSanitizationStrategy(storage_dir),
+    )
+    return FernetEncryptionWrapper(key_value=store, fernet=fernet)
+
+
+def build_google_provider() -> GoogleProvider | None:
+    """Construct the Google OAuth provider from the environment, or ``None``.
+
+    Returns ``None`` when Google OAuth is not enabled (the default), leaving the
+    bearer-token path untouched. When enabled, raises :class:`GoogleOAuthConfigError`
+    on any misconfiguration (missing base URL, partial persistence config, or an
+    invalid Fernet key) so startup fails closed with an actionable message.
+    """
+    if not google_oauth_enabled():
+        return None
+
+    from fastmcp.server.auth.providers.google import GoogleProvider
+
+    client_id = (_settings.UNRAID_MCP_GOOGLE_CLIENT_ID or "").strip()
+    client_secret = (_settings.UNRAID_MCP_GOOGLE_CLIENT_SECRET or "").strip()
+
+    base_url = (_settings.UNRAID_MCP_GOOGLE_BASE_URL or "").strip()
+    if not base_url:
+        raise GoogleOAuthConfigError(
+            "Google OAuth is enabled (UNRAID_MCP_GOOGLE_CLIENT_ID/SECRET are set) but "
+            "UNRAID_MCP_GOOGLE_BASE_URL is not. Set it to this server's public base URL "
+            "(e.g. https://unraid-mcp.example.com) — it must match the Authorized redirect "
+            "URI configured for the OAuth client in Google Cloud."
+        )
+
+    scopes = _parse_scopes(_settings.UNRAID_MCP_GOOGLE_REQUIRED_SCOPES)
+    redirect_path = (_settings.UNRAID_MCP_GOOGLE_REDIRECT_PATH or "").strip() or None
+
+    jwt_signing_key = _settings.UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY
+    encryption_key = _settings.UNRAID_MCP_GOOGLE_ENCRYPTION_KEY
+    client_storage: AsyncKeyValue | None = None
+    if jwt_signing_key or encryption_key:
+        if not (jwt_signing_key and encryption_key):
+            raise GoogleOAuthConfigError(
+                "Encrypted token persistence requires BOTH "
+                "UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY and UNRAID_MCP_GOOGLE_ENCRYPTION_KEY. "
+                "Set both to persist tokens across restarts, or neither to keep them in "
+                "memory (cleared on restart)."
+            )
+        client_storage = _build_encrypted_storage(encryption_key)
+
+    # Pass every optional argument explicitly. ``redirect_path=None`` selects the
+    # provider's default ("/auth/callback"); ``client_storage``/``jwt_signing_key``
+    # are both None unless encrypted persistence was configured above (enforced
+    # both-or-neither), so passing them directly is safe.
+    provider = GoogleProvider(
+        client_id=client_id,
+        client_secret=client_secret,
+        base_url=base_url,
+        required_scopes=scopes,
+        redirect_path=redirect_path,
+        client_storage=client_storage,
+        jwt_signing_key=jwt_signing_key,
+    )
+
+    logger.info(
+        "Google OAuth enabled (base_url=%s, scopes=%s, redirect_path=%s, persistence=%s)",
+        base_url,
+        ",".join(scopes),
+        redirect_path or "/auth/callback",
+        "encrypted-filetree" if client_storage is not None else "in-memory",
+    )
+    return provider

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -164,11 +164,14 @@ async def lifespan(_server: "FastMCP") -> AsyncIterator[None]:
 # pre-shared bearer-token auth at the HTTP layer. Built once here so it is attached
 # to the FastMCP instance for `fastmcp run server.py` discovery too. A misconfig
 # (e.g. missing base_url) fails closed with a fatal, actionable message.
-try:
-    _google_auth_provider = build_google_provider()
-except GoogleOAuthConfigError as exc:
-    print(f"FATAL: {exc}", file=sys.stderr)
-    sys.exit(1)
+if _settings.UNRAID_MCP_TRANSPORT in ("streamable-http", "sse"):
+    try:
+        _google_auth_provider = build_google_provider()
+    except GoogleOAuthConfigError as exc:
+        print(f"FATAL: {exc}", file=sys.stderr)
+        sys.exit(1)
+else:
+    _google_auth_provider = None
 
 # Initialize FastMCP instance — ASGI-level bearer auth added at run time via
 # mcp.run(middleware=[...]) so it fires before any MCP protocol processing. When

--- a/unraid_mcp/server.py
+++ b/unraid_mcp/server.py
@@ -37,6 +37,7 @@ from .config.settings import (
 from .core import middleware_refs as _middleware_refs
 from .core.auth import BearerAuthMiddleware, HealthMiddleware, WellKnownMiddleware
 from .core.client import close_http_client
+from .core.google_auth import GoogleOAuthConfigError, build_google_provider
 from .core.response_limit import StructuredResponseLimitingMiddleware
 from .subscriptions.manager import subscription_manager
 from .subscriptions.resources import register_subscription_resources
@@ -158,13 +159,27 @@ async def lifespan(_server: "FastMCP") -> AsyncIterator[None]:
             logger.error("Error closing HTTP client during shutdown", exc_info=True)
 
 
+# Optional Google OAuth provider. Returns None (the default) unless
+# UNRAID_MCP_GOOGLE_CLIENT_ID and _SECRET are set, in which case OAuth REPLACES the
+# pre-shared bearer-token auth at the HTTP layer. Built once here so it is attached
+# to the FastMCP instance for `fastmcp run server.py` discovery too. A misconfig
+# (e.g. missing base_url) fails closed with a fatal, actionable message.
+try:
+    _google_auth_provider = build_google_provider()
+except GoogleOAuthConfigError as exc:
+    print(f"FATAL: {exc}", file=sys.stderr)
+    sys.exit(1)
+
 # Initialize FastMCP instance — ASGI-level bearer auth added at run time via
-# mcp.run(middleware=[...]) so it fires before any MCP protocol processing.
+# mcp.run(middleware=[...]) so it fires before any MCP protocol processing. When
+# Google OAuth is active, `auth=` carries the provider and the bearer/well-known
+# ASGI middleware is omitted in run_server() (the provider handles both).
 mcp = FastMCP(
     name="Unraid MCP Server",
     instructions="Provides tools to interact with an Unraid server's GraphQL API.",
     version=VERSION,
     lifespan=lifespan,
+    auth=_google_auth_provider,
     middleware=[
         _logging_middleware,
         _error_middleware,
@@ -250,13 +265,20 @@ def ensure_token_exists() -> None:
 def run_server() -> None:
     """Run the MCP server with the configured transport."""
     is_http = _settings.UNRAID_MCP_TRANSPORT in ("streamable-http", "sse")
+    # Source of truth for the HTTP auth mode is the provider actually attached to
+    # `mcp` at import — when present, OAuth fully replaces the bearer-token path.
+    google_enabled = _google_auth_provider is not None
 
     try:
-        if is_http:
+        # Bearer-token bootstrap and guards apply only when OAuth is NOT delegating
+        # authentication. The GoogleProvider gates requests and serves its own
+        # discovery metadata, so the bearer token / S-H3 checks are irrelevant then.
+        if is_http and not google_enabled:
             ensure_token_exists()
 
         if (
             is_http
+            and not google_enabled
             and not _settings.UNRAID_MCP_DISABLE_HTTP_AUTH
             and not _settings.UNRAID_MCP_BEARER_TOKEN
         ):
@@ -271,9 +293,11 @@ def run_server() -> None:
         # loopback. Refuse to expose an unauthenticated MCP endpoint on a
         # public/LAN interface — that would let anyone on the network drive the
         # Unraid API. Operators fronting the server with SWAG/Authelia opt in
-        # via UNRAID_MCP_TRUST_PROXY=true.
+        # via UNRAID_MCP_TRUST_PROXY=true. (Skipped when OAuth is active — the
+        # endpoint is then authenticated by Google, not left open.)
         if (
             is_http
+            and not google_enabled
             and _settings.UNRAID_MCP_DISABLE_HTTP_AUTH
             and not _settings.UNRAID_MCP_TRUST_PROXY
             and not _is_loopback_host(_settings.UNRAID_MCP_HOST)
@@ -311,7 +335,17 @@ def run_server() -> None:
             )
 
         if is_http:
-            if _settings.UNRAID_MCP_DISABLE_HTTP_AUTH:
+            if google_enabled:
+                logger.info(
+                    "HTTP authentication delegated to Google OAuth (GoogleProvider); "
+                    "bearer-token middleware is not installed."
+                )
+                if _settings.UNRAID_MCP_DISABLE_HTTP_AUTH:
+                    logger.warning(
+                        "UNRAID_MCP_DISABLE_HTTP_AUTH=true is ignored while Google OAuth "
+                        "is active — the endpoint is authenticated via OAuth."
+                    )
+            elif _settings.UNRAID_MCP_DISABLE_HTTP_AUTH:
                 logger.warning(
                     "HTTP auth disabled (UNRAID_MCP_DISABLE_HTTP_AUTH=true). "
                     "Ensure an upstream gateway enforces authentication."
@@ -340,18 +374,22 @@ def run_server() -> None:
                 "Literal['stdio', 'http', 'sse', 'streamable-http']",
                 _settings.UNRAID_MCP_TRANSPORT,
             )
-            mcp.run(
-                transport=transport_literal,
-                host=UNRAID_MCP_HOST,
-                port=UNRAID_MCP_PORT,
-                path="/mcp",
-                middleware=[
-                    # Middleware order (outermost → innermost):
-                    # 1. HealthMiddleware   — GET /health → 200, no auth.
-                    # 2. WellKnownMiddleware — GET /.well-known/oauth-protected-resource → 200,
-                    #    no auth.  MCP clients probe this after a 401 to discover how to
-                    #    authenticate; responding correctly stops the 401 cascade.
-                    # 3. BearerAuthMiddleware — all other HTTP requests require a valid token.
+            if google_enabled:
+                # Google OAuth path: the GoogleProvider (attached via FastMCP's
+                # auth=) gates requests and serves its own OAuth/well-known
+                # discovery routes, so the bearer + well-known ASGI middleware are
+                # omitted (they would shadow the provider's endpoints and 401 the
+                # OAuth callback). HealthMiddleware stays outermost so Docker's
+                # unauthenticated /health probe keeps working.
+                http_middleware = [ASGIMiddleware(HealthMiddleware)]
+            else:
+                # Middleware order (outermost → innermost):
+                # 1. HealthMiddleware   — GET /health → 200, no auth.
+                # 2. WellKnownMiddleware — GET /.well-known/oauth-protected-resource → 200,
+                #    no auth.  MCP clients probe this after a 401 to discover how to
+                #    authenticate; responding correctly stops the 401 cascade.
+                # 3. BearerAuthMiddleware — all other HTTP requests require a valid token.
+                http_middleware = [
                     ASGIMiddleware(HealthMiddleware),
                     ASGIMiddleware(WellKnownMiddleware),
                     ASGIMiddleware(
@@ -359,7 +397,13 @@ def run_server() -> None:
                         token=_settings.UNRAID_MCP_BEARER_TOKEN or "",
                         disabled=_settings.UNRAID_MCP_DISABLE_HTTP_AUTH,
                     ),
-                ],
+                ]
+            mcp.run(
+                transport=transport_literal,
+                host=UNRAID_MCP_HOST,
+                port=UNRAID_MCP_PORT,
+                path="/mcp",
+                middleware=http_middleware,
             )
         elif _settings.UNRAID_MCP_TRANSPORT == "stdio":
             mcp.run()

--- a/uv.lock
+++ b/uv.lock
@@ -1626,10 +1626,12 @@ name = "unraid-mcp"
 version = "2.2.0"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "fastmcp" },
     { name = "graphql-core" },
     { name = "httpx" },
+    { name = "py-key-value-aio" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "rich" },
@@ -1652,10 +1654,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=44.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=3.0.0,<4.0.0" },
     { name = "graphql-core", specifier = ">=3.2.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "py-key-value-aio", specifier = ">=0.4.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "rich", specifier = ">=14.1.0" },


### PR DESCRIPTION
## Summary

Adds an **env-gated Google OAuth** path as an alternative to the existing pre-shared bearer token for HTTP transport. When both `UNRAID_MCP_GOOGLE_CLIENT_ID` and `UNRAID_MCP_GOOGLE_CLIENT_SECRET` are set, the server attaches FastMCP's `GoogleProvider` via `FastMCP(auth=...)` and clients authenticate through the standard Google OAuth flow. Otherwise the default bearer-token behavior is **byte-for-byte unchanged**.

The two modes are mutually exclusive: under OAuth, `run_server()` installs **only** `HealthMiddleware` and omits the bearer + well-known ASGI middleware, because `GoogleProvider` serves its own OAuth / `.well-known` discovery routes (and the bearer middleware would otherwise 401 the OAuth callback).

Implementation follows the [FastMCP Google integration guide](https://gofastmcp.com/integrations/google), adapted for this repo's FastMCP **v3** pin (the v2 `FASTMCP_SERVER_AUTH_GOOGLE_*` auto-loading was removed in v3, so credentials are read from env and passed explicitly).

## Token persistence — no Redis required

The FastMCP docs' production example uses Redis; per the requested design this uses FastMCP's recommended single-server backend instead:

- Set **both** `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` and `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` → tokens persist across restarts, **encrypted at rest** (`FernetEncryptionWrapper`) in a `FileTreeStore` on disk under `UNRAID_MCP_GOOGLE_STORAGE_DIR` (default `~/.unraid-mcp/oauth-tokens`).
- Set **neither** → tokens live in memory (cleared on restart; clients re-auth transparently).
- Setting **only one** → fatal config error.

## Changes

- **`unraid_mcp/core/google_auth.py`** (new) — provider builder, enable gate, scope parsing, encrypted `FileTreeStore` wiring, `GoogleOAuthConfigError` for fail-closed misconfig.
- **`unraid_mcp/config/settings.py`** — `UNRAID_MCP_GOOGLE_*` fields + module globals; empty-string credentials normalized to `None` so unset plugin options can't falsely enable OAuth; `get_config_summary()` reports `google_oauth_enabled`.
- **`unraid_mcp/server.py`** — build provider at import (fatal `sys.exit(1)` on `GoogleOAuthConfigError`), pass to `FastMCP(auth=...)`, mode-select the HTTP middleware in `run_server()`.
- **`pyproject.toml`** — pin `cryptography` + `py-key-value-aio` (now imported directly; previously transitive via fastmcp).
- **Docs** — `docs/AUTHENTICATION.md`, `docs/mcp/ENV.md`, `.env.example`, `CLAUDE.md`.

## Configuration

| Variable | Required | Description |
|---|---|---|
| `UNRAID_MCP_GOOGLE_CLIENT_ID` / `_CLIENT_SECRET` | enable gate | Setting both enables OAuth |
| `UNRAID_MCP_GOOGLE_BASE_URL` | when enabled | Public server URL; must match the Google redirect URI host |
| `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | no | Default `openid` + `userinfo.email` |
| `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | no | Default `/auth/callback` |
| `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` + `_ENCRYPTION_KEY` | both-or-neither | Encrypted on-disk token persistence |
| `UNRAID_MCP_GOOGLE_STORAGE_DIR` | no | Default `~/.unraid-mcp/oauth-tokens` |

## Testing

- **`tests/test_google_auth.py`** (new, 19 tests): enable gate, scope parsing, fail-closed config errors (missing base_url, partial persistence config, invalid Fernet key), in-memory vs encrypted provider construction, and `run_server()` middleware selection per mode.
- Full suite green: **1713 passed, 9 skipped** (skips are pre-existing — missing `node_modules` for mock tests).
- `ruff check`, `ruff format --check`, and `ty check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YX6SMZbxU1s4Bkg2CA7o7U)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional Google OAuth for HTTP transport with local email/domain allowlists, HTTPS base URL validation, and encrypted token persistence. When both `UNRAID_MCP_GOOGLE_CLIENT_ID` and `UNRAID_MCP_GOOGLE_CLIENT_SECRET` are set, the server attaches FastMCP’s `GoogleProvider` and drops the bearer/well-known middleware; otherwise behavior is unchanged.

- **New Features**
  - Env-gated Google OAuth; in OAuth mode only `HealthMiddleware` remains and `UNRAID_MCP_DISABLE_HTTP_AUTH` is treated as a startup conflict.
  - Local authorization allowlist via `UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` / `…_ALLOWED_DOMAINS`, or `…_ALLOW_ANY_USER=true`; only verified emails are accepted.
  - Hardening: require `UNRAID_MCP_GOOGLE_BASE_URL` (HTTPS; HTTP allowed only on loopback), validate `UNRAID_MCP_GOOGLE_REDIRECT_PATH`, and skip bearer-token checks in `entrypoint.sh` when OAuth is active.
  - Optional encrypted token persistence on disk (Fernet + `FileTreeStore`) when both `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` and `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` are set; partial config fails closed. Pins `cryptography` and `py-key-value-aio`.
  - Config summary adds `http_auth_mode` and `google_oauth_enabled`. Tests cover gating, allowlist/authz, base URL/redirect validation, provider wiring, and middleware selection.

- **Migration**
  - Bearer-token setups: no changes.
  - To enable OAuth: set `…_GOOGLE_CLIENT_ID`, `…_GOOGLE_CLIENT_SECRET`, and `…_GOOGLE_BASE_URL`; register `<BASE_URL>/auth/callback`; set an allowlist (`…_ALLOWED_EMAILS`/`…_ALLOWED_DOMAINS`) or `…_ALLOW_ANY_USER=true`. Optional: `…_REQUIRED_SCOPES`, `…_REDIRECT_PATH`.
  - To persist tokens: set both `…_GOOGLE_JWT_SIGNING_KEY` and `…_GOOGLE_ENCRYPTION_KEY` (optional `…_STORAGE_DIR`). Setting only one key or combining OAuth with `UNRAID_MCP_DISABLE_HTTP_AUTH=true` causes a startup error.

<sup>Written for commit b6566485aa11d2c9eab2e8d4199cdf067fa1990b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Google OAuth as an alternative HTTP sign-in method.
  * Expanded setup docs with required settings, scopes, and optional token persistence guidance.

* **Bug Fixes**
  * Blank or partial auth settings no longer accidentally enable OAuth.
  * Improved startup validation so misconfigured auth now fails fast instead of running insecurely.
  * HTTP middleware now switches correctly between bearer-token and OAuth-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->