### PR TITLE
fix: preserve schema drift issue label

### DIFF
--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -93,14 +93,14 @@ jobs:
           max_body_bytes=60000
           append_with_budget() {
             file="$1"
-            label="$2"
+            section_label="$2"
             reserve="$3"
             current_bytes="$(wc -c < issue-body.md)"
             remaining_bytes="$((max_body_bytes - current_bytes - reserve))"
             if [ "$remaining_bytes" -le 0 ]; then
               {
                 echo
-                echo "_${label} omitted to keep this issue body under ${max_body_bytes} bytes._"
+                echo "_${section_label} omitted to keep this issue body under ${max_body_bytes} bytes._"
                 echo "_See the workflow artifact for the complete content._"
               } >> issue-body.md
               return
@@ -112,7 +112,7 @@ jobs:
               {
                 echo
                 echo
-                echo "_${label} truncated to keep this issue body under ${max_body_bytes} bytes._"
+                echo "_${section_label} truncated to keep this issue body under ${max_body_bytes} bytes._"
                 echo "_See the workflow artifact for the complete content._"
               } >> issue-body.md
             else


### PR DESCRIPTION
## Summary
- prevent the schema drift workflow's append helper from overwriting the GitHub issue label variable
- keep the issue label as `schema-drift` while still using human-readable section labels in the generated issue body

## Verification
- `git diff --check`
- shell reproduction confirms `label` remains `schema-drift` after both `append_with_budget` calls
- `actionlint .github/workflows/schema-drift.yml`

## Failure reviewed
The failing scheduled Schema drift run reached real SDL drift handling, then failed when `gh issue edit/create` tried to add label `Schema diff`. The helper function assigned `label=""`, so the final call `append_with_budget schema.diff "Schema diff" 300` clobbered the intended `schema-drift` label.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the schema drift workflow so it preserves the GitHub issue label `schema-drift`. Keeps readable section labels in the issue body without breaking `gh issue` calls.

- **Bug Fixes**
  - Renamed the local variable in `append_with_budget` from `label` to `section_label` and updated references, so the real issue label is not clobbered during body assembly.

<sup>Written for commit 16d6d3be3ab793553b8c9c248005de1b5dd9fbcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

