### PR TITLE
docs: refresh env and marketplace references

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -100,7 +100,7 @@ setup:
         echo ".env already exists"; \
     fi
 
-# Generate a secure bearer token for UNRAID_MCP_TOKEN
+# Generate a secure bearer token for UNRAID_MCP_BEARER_TOKEN
 gen-token:
     @python3 -c "import secrets; print(secrets.token_urlsafe(32))"
 
@@ -161,4 +161,3 @@ publish:
     @echo "  3. Merge that PR -- it tags vX.Y.Z and triggers publish-pypi + docker-publish."
     @echo ""
     @echo "Version is read at runtime from package metadata; never edit version strings by hand."
-

--- a/README.md
+++ b/README.md
@@ -113,11 +113,36 @@ just setup
 | `UNRAID_MCP_TRANSPORT` | No | `streamable-http` | Transport: `streamable-http`, `stdio`, or `sse` (deprecated) |
 | `UNRAID_MCP_HOST` | No | `127.0.0.1` bare metal; Docker sets `0.0.0.0` | Bind address for HTTP transports |
 | `UNRAID_MCP_PORT` | No | `6970` | Listen port for HTTP transports |
+| `UNRAID_MCP_MAX_RESPONSE_BYTES` | No | `40000` | Max serialized tool-response size; over-cap responses return a parseable truncation marker |
 | `UNRAID_MCP_BEARER_TOKEN` | Conditional | — | Static Bearer token for HTTP transports; auto-generated on first start if unset |
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | No | `false` | Set `true` to skip Bearer auth (use behind a reverse proxy that handles auth) |
+| `UNRAID_MCP_TRUST_PROXY` | Conditional | `false` | Required when disabling HTTP auth while binding a non-loopback interface |
+| `UNRAID_MCP_GOOGLE_CLIENT_ID` | No | — | Google OAuth client ID; setting both client ID and secret replaces Bearer auth for HTTP transports |
+| `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | No | — | Google OAuth client secret |
+| `UNRAID_MCP_GOOGLE_BASE_URL` | Conditional | — | Public server base URL, required when Google OAuth is enabled |
+| `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | No | `openid` + `userinfo.email` | Comma/space-separated OAuth scopes |
+| `UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` | Conditional | — | Verified Google emails allowed to use the MCP server |
+| `UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS` | Conditional | — | Verified Google email domains allowed to use the MCP server |
+| `UNRAID_MCP_GOOGLE_ALLOW_ANY_USER` | No | `false` | Explicitly allow any verified Google account; only for private/trusted deployments |
+| `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | No | `/auth/callback` | OAuth callback path configured in Google Cloud |
+| `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` | Conditional | — | With the encryption key, enables restart-surviving encrypted token storage |
+| `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` | Conditional | — | Fernet key for encrypted OAuth token storage |
+| `UNRAID_MCP_GOOGLE_STORAGE_DIR` | No | `~/.unraid-mcp/oauth-tokens` | Directory for persisted encrypted OAuth tokens |
+| `UNRAID_VERIFY_SSL` | No | `true` | Upstream Unraid API TLS verification; may also be a CA-bundle path |
+| `UNRAID_ALLOW_INSECURE_TLS` | Conditional | `false` | Required second opt-in when `UNRAID_VERIFY_SSL=false` |
+| `UNRAID_MCP_LOG_LEVEL` | No | `INFO` | Log verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
+| `UNRAID_MCP_LOG_FILE` | No | `unraid-mcp.log` | Log filename under `logs/` or `/app/logs/` in Docker |
+| `UNRAID_AUTO_START_SUBSCRIPTIONS` | No | `true` | Auto-start live WebSocket subscriptions on boot |
+| `UNRAID_MAX_RECONNECT_ATTEMPTS` | No | `10` | Max WebSocket reconnect attempts |
+| `UNRAID_AUTOSTART_LOG_PATH` | No | auto-detect | Log file path for the log-tail subscription |
+| `UNRAID_CREDENTIALS_DIR` | No | `~/.unraid-mcp` | Override credentials directory |
 | `DOCKER_NETWORK` | No | — | External Docker network to join; leave blank for default bridge |
 | `PGID` | No | `1000` | Container process GID |
 | `PUID` | No | `1000` | Container process UID |
+
+For the full reference, including OAuth persistence and `.env` loading order, see
+[docs/mcp/ENV.md](docs/mcp/ENV.md), [docs/CONFIG.md](docs/CONFIG.md), and
+[docs/AUTHENTICATION.md](docs/AUTHENTICATION.md).
 
 ### How to find UNRAID_API_KEY
 
@@ -136,6 +161,20 @@ These are two separate credentials with different purposes:
 ### UNRAID_MCP_DISABLE_HTTP_AUTH
 
 Set this to `true` when a reverse proxy (nginx, Caddy, Traefik, SWAG) already handles authentication before requests reach the MCP server. Disabling the built-in check removes the Bearer token requirement at the MCP layer. Do not expose the server directly to untrusted networks with this flag enabled.
+
+If auth is disabled and `UNRAID_MCP_HOST` binds a non-loopback interface, the server
+also requires `UNRAID_MCP_TRUST_PROXY=true` as an explicit assertion that a trusted
+fronting gateway enforces authentication.
+
+### Google OAuth for HTTP transports
+
+Set both `UNRAID_MCP_GOOGLE_CLIENT_ID` and
+`UNRAID_MCP_GOOGLE_CLIENT_SECRET` to replace static Bearer auth with Google OAuth.
+OAuth requires `UNRAID_MCP_GOOGLE_BASE_URL` and at least one authorization allowlist
+entry (`UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` or
+`UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS`) unless
+`UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=true` is explicitly set. Google OAuth and
+`UNRAID_MCP_DISABLE_HTTP_AUTH=true` are mutually exclusive.
 
 ### Transport modes
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,11 +11,11 @@ services:
       # destructive actions and is commonly run with DISABLE_HTTP_AUTH=true behind
       # SWAG, so it must NOT be reachable directly from the network.
       # Publishing on a non-loopback interface REQUIRES auth enabled (a bearer
-      # token via UNRAID_MCP_TOKEN). Behind a reverse proxy, prefer joining the
-      # proxy's docker network over publishing the port at all.
+      # token via UNRAID_MCP_BEARER_TOKEN, or Google OAuth). Behind a reverse
+      # proxy, prefer joining the proxy's docker network over publishing the port at all.
       - "127.0.0.1:${UNRAID_MCP_PORT:-6970}:${UNRAID_MCP_PORT:-6970}"
     env_file:
-      - path: ~/.claude-homelab/.env
+      - path: ~/.unraid-mcp/.env
         required: false
     volumes:
       - ./logs:/app/logs

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -71,6 +71,7 @@ environment:
 |---|---|---|
 | `UNRAID_MCP_BEARER_TOKEN` | *(none)* | Required for HTTP transport (bearer mode). Generate with `openssl rand -hex 32`. |
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | `false` | Set `true` to disable auth entirely (testing/trusted-network only). Ignored when Google OAuth is active. |
+| `UNRAID_MCP_TRUST_PROXY` | `false` | Required when auth is disabled and `UNRAID_MCP_HOST` binds a non-loopback interface. Asserts a trusted proxy enforces auth. |
 
 ---
 
@@ -135,10 +136,11 @@ handles the rest.
 ## How it works
 
 1. The server starts an HTTP listener on port 6970.
-2. Every request must include `Authorization: Bearer <token>` or it gets a
-   `401 Unauthorized` response.
+2. In Bearer-token mode, every request must include `Authorization: Bearer <token>`
+   or it gets a `401 Unauthorized` response. In Google OAuth mode, FastMCP's
+   `GoogleProvider` serves OAuth discovery and gates requests instead.
 3. `/health` (Docker healthcheck) is always allowed without a token.
-4. `/.well-known/oauth-protected-resource` is served without a token so MCP
+4. In Bearer-token mode, `/.well-known/oauth-protected-resource` is served without a token so MCP
    clients can discover the auth scheme automatically (RFC 9728).  It returns
    `{"bearer_methods_supported":["header"]}` with no `authorization_servers`,
    telling clients to use a pre-configured Bearer token.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -26,7 +26,7 @@ Override the credentials directory with `UNRAID_CREDENTIALS_DIR`.
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `UNRAID_MCP_HOST` | `0.0.0.0` | Bind address for HTTP transport |
+| `UNRAID_MCP_HOST` | `127.0.0.1` bare metal; Docker image sets `0.0.0.0` | Bind address for HTTP transport |
 | `UNRAID_MCP_PORT` | `6970` | Port for the MCP HTTP server. Must be 1-65535. |
 | `UNRAID_MCP_TRANSPORT` | `streamable-http` | Transport method: `streamable-http`, `stdio`, or `sse` (deprecated) |
 | `UNRAID_MCP_MAX_RESPONSE_BYTES` | `40000` | Max serialized tool-response size (~10K tokens). Over-cap responses are replaced with a parseable JSON truncation marker (`{"error":"response_truncated","truncated":true,...}`). |
@@ -38,6 +38,32 @@ Override the credentials directory with `UNRAID_CREDENTIALS_DIR`.
 | `UNRAID_MCP_BEARER_TOKEN` | auto-generated | Bearer token for HTTP auth. Auto-generated on first HTTP startup if absent. Generate manually with `openssl rand -hex 32`. |
 | `UNRAID_MCP_DISABLE_HTTP_AUTH` | `false` | Set `true` to disable bearer auth. Only valid behind a trusted fronting gateway — requires `UNRAID_MCP_TRUST_PROXY=true` to bind a public interface (see below). |
 | `UNRAID_MCP_TRUST_PROXY` | `false` | Required second opt-in when auth is disabled (`UNRAID_MCP_DISABLE_HTTP_AUTH=true`) and the server binds a non-loopback interface. Asserts a fronting gateway terminates auth; without it, a public bind with auth disabled is refused. |
+
+## Google OAuth variables
+
+Google OAuth is optional and mutually exclusive with the Bearer-token middleware. It is
+enabled only when both `UNRAID_MCP_GOOGLE_CLIENT_ID` and
+`UNRAID_MCP_GOOGLE_CLIENT_SECRET` are set. When enabled, HTTP clients authenticate
+through the OAuth browser flow and the static `UNRAID_MCP_BEARER_TOKEN` is not used.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `UNRAID_MCP_GOOGLE_CLIENT_ID` | -- | Google OAuth Client ID. Setting this and the client secret enables OAuth. |
+| `UNRAID_MCP_GOOGLE_CLIENT_SECRET` | -- | Google OAuth Client Secret. Must be set with the client ID. |
+| `UNRAID_MCP_GOOGLE_BASE_URL` | -- | Required when OAuth is enabled. Public base URL of this MCP server; must be `https://` except for localhost/loopback development. The Google authorized redirect URI is this base URL plus the redirect path. |
+| `UNRAID_MCP_GOOGLE_REQUIRED_SCOPES` | `openid https://www.googleapis.com/auth/userinfo.email` | Comma/space-separated OAuth scopes. |
+| `UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` | -- | Comma/space-separated verified Google email addresses allowed to use this MCP server. Required unless domains or allow-any-user is set. |
+| `UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS` | -- | Comma/space-separated verified Google email domains allowed to use this MCP server. Required unless emails or allow-any-user is set. |
+| `UNRAID_MCP_GOOGLE_ALLOW_ANY_USER` | `false` | Explicitly allow any verified Google account. Use only for private/trusted deployments. |
+| `UNRAID_MCP_GOOGLE_REDIRECT_PATH` | `/auth/callback` | OAuth callback path. Must be an absolute path with no scheme, host, query, or fragment. |
+| `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` | -- | With `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY`, enables restart-surviving token storage. Set both keys or neither. |
+| `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` | -- | Fernet key for encrypted OAuth token storage. Generate with `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`. |
+| `UNRAID_MCP_GOOGLE_STORAGE_DIR` | `~/.unraid-mcp/oauth-tokens` | Directory for persisted encrypted OAuth tokens. Created with mode 700 where possible. |
+
+Startup fails closed when OAuth is partially configured, when OAuth is combined with
+`UNRAID_MCP_DISABLE_HTTP_AUTH=true`, when no email/domain allowlist is configured
+without `UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=true`, or when only one persistence key is
+set. See [AUTHENTICATION.md](AUTHENTICATION.md#google-oauth-optional).
 
 ## SSL variables
 
@@ -119,15 +145,45 @@ UNRAID_API_KEY=your_api_key
 UNRAID_API_URL=http://your-unraid-server
 
 # MCP Server Settings
-UNRAID_MCP_HOST=0.0.0.0
+UNRAID_MCP_HOST=127.0.0.1
 UNRAID_MCP_PORT=6970
 UNRAID_MCP_TRANSPORT=streamable-http
+UNRAID_MCP_MAX_RESPONSE_BYTES=40000
 
 # HTTP Bearer Token Authentication
 UNRAID_MCP_BEARER_TOKEN=your_bearer_token
 
 # Safety flags
 UNRAID_MCP_DISABLE_HTTP_AUTH=false
+UNRAID_MCP_TRUST_PROXY=false
+
+# Optional Google OAuth alternative to Bearer auth
+# UNRAID_MCP_GOOGLE_CLIENT_ID=123456789.apps.googleusercontent.com
+# UNRAID_MCP_GOOGLE_CLIENT_SECRET=GOCSPX-...
+# UNRAID_MCP_GOOGLE_BASE_URL=https://unraid-mcp.example.com
+# UNRAID_MCP_GOOGLE_ALLOWED_EMAILS=you@example.com
+# UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS=example.com
+# UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=false
+# UNRAID_MCP_GOOGLE_REDIRECT_PATH=/auth/callback
+# UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY=your_jwt_signing_secret
+# UNRAID_MCP_GOOGLE_ENCRYPTION_KEY=your_fernet_key
+# UNRAID_MCP_GOOGLE_STORAGE_DIR=/path/to/oauth-tokens
+
+# TLS / SSL Verification
+UNRAID_VERIFY_SSL=true
+UNRAID_ALLOW_INSECURE_TLS=false
+
+# Logging
+UNRAID_MCP_LOG_LEVEL=INFO
+UNRAID_MCP_LOG_FILE=unraid-mcp.log
+
+# Subscriptions
+UNRAID_AUTO_START_SUBSCRIPTIONS=true
+UNRAID_MAX_RECONNECT_ATTEMPTS=10
+# UNRAID_AUTOSTART_LOG_PATH=/var/log/syslog
+
+# Credentials directory override
+# UNRAID_CREDENTIALS_DIR=
 
 # Docker user / network
 DOCKER_NETWORK=

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -6,7 +6,7 @@ Complete listing of all plugin components.
 
 | Tool | Type | Module | Description |
 | --- | --- | --- | --- |
-| `unraid` | Primary (only tool) | `tools/unraid.py` | Unified action/subaction router: 19 actions, 175 subactions. The Markdown reference (`help` action) and WebSocket diagnostics (`subscriptions` action, handled in `subscriptions/diagnostics.py`) are folded into this single tool. |
+| `unraid` | Primary (only tool) | `tools/unraid.py` | Unified action/subaction router: 19 actions, 178 subactions. The Markdown reference (`help` action) and WebSocket diagnostics (`subscriptions` action, handled in `subscriptions/diagnostics.py`) are folded into this single tool. |
 
 ## MCP resources
 

--- a/docs/MARKETPLACE.md
+++ b/docs/MARKETPLACE.md
@@ -14,15 +14,16 @@ The marketplace catalog that lists all available plugins in this repository.
 - Plugin catalog with the "unraid" plugin
 - Categories and tags for discoverability
 
-### 2. Plugin Manifest (`.claude-plugin/plugin.json`)
+### 2. Plugin Manifest (`plugins/unraid/.claude-plugin/plugin.json`)
 The individual plugin configuration for the Unraid MCP server.
 
-**Location:** `.claude-plugin/plugin.json`
+**Location:** `plugins/unraid/.claude-plugin/plugin.json`
 
 **Contents:**
-- Plugin name (`unraid`), version (`1.1.2`), author
+- Plugin name (`unraid-mcp`), release-please-managed version, author
 - Repository and homepage links
-- `mcpServers` block that configures the server to run via `uv run unraid-mcp-server` in stdio mode
+- `mcpServers` reference to `plugins/unraid/.mcp.json`, which runs the published `uvx unraid-mcp` server in stdio mode
+- `userConfig` fields for `UNRAID_API_URL` and `UNRAID_API_KEY`
 
 ## MCP Tools Exposed
 
@@ -30,7 +31,7 @@ The plugin registers **a single MCP tool**:
 
 | Tool | Purpose |
 |------|---------|
-| `unraid` | The only tool — `action` (domain) + `subaction` (operation) routing, 175 subactions across 19 actions. WebSocket diagnostics and the Markdown reference are the `subscriptions` and `help` actions of this tool. |
+| `unraid` | The only tool — `action` (domain) + `subaction` (operation) routing, 178 subactions across 19 actions. WebSocket diagnostics and the Markdown reference are the `subscriptions` and `help` actions of this tool. |
 
 ### Calling Convention
 
@@ -77,7 +78,7 @@ Once pushed to GitHub, users install via:
 /plugin marketplace add jmagar/unraid-mcp
 
 # Install the Unraid plugin
-/plugin install unraid @unraid-mcp
+/plugin install unraid-mcp@unraid-mcp
 ```
 
 ### Method 2: Local Installation (Development)
@@ -89,7 +90,7 @@ For testing locally before publishing:
 /plugin marketplace add /home/jmagar/workspace/unraid-mcp
 
 # Install the plugin
-/plugin install unraid @unraid-mcp
+/plugin install unraid-mcp@unraid-mcp
 ```
 
 ### Method 3: Direct URL
@@ -124,9 +125,19 @@ Exits 0 on success, 1 if any check fails.
 
 ```text
 unraid-mcp/
-├── .claude-plugin/          # Plugin manifest + marketplace manifest
-│   ├── plugin.json          # Plugin configuration (name, version, mcpServers)
-│   └── marketplace.json     # Marketplace catalog
+├── .claude-plugin/
+│   └── marketplace.json     # Claude Code marketplace catalog
+├── .agents/plugins/
+│   └── marketplace.json     # Codex marketplace catalog
+├── plugins/unraid/
+│   ├── .claude-plugin/
+│   │   ├── plugin.json      # Claude Code plugin manifest
+│   │   └── README.md
+│   ├── .codex-plugin/
+│   │   └── plugin.json      # Codex plugin manifest
+│   ├── .mcp.json            # Shared MCP server definition
+│   ├── hooks/               # SessionStart / ConfigChange hooks
+│   └── skills/unraid/       # Client-facing skill docs and references
 ├── unraid_mcp/              # Python package (the actual MCP server)
 │   ├── main.py              # Entry point
 │   ├── server.py            # FastMCP server registration
@@ -158,29 +169,26 @@ unraid-mcp/
 
 Before publishing to GitHub:
 
-1. **Update Version Numbers** (must be in sync)
-   - `pyproject.toml` → `version = "X.Y.Z"` under `[project]`
-   - `.claude-plugin/plugin.json` → `"version": "X.Y.Z"`
-   - `.claude-plugin/marketplace.json` → `"version"` in both `metadata` and `plugins[]`
+1. **Let release-please update version-bearing files**
+   - Do not bump versions by hand.
+   - release-please keeps `pyproject.toml`, plugin manifests, extension manifests, and `CHANGELOG.md` in sync.
 
 3. **Test Locally**
    ```bash
    /plugin marketplace add .
-   /plugin install unraid @unraid-mcp
+   /plugin install unraid-mcp@unraid-mcp
    ```
 
 4. **Commit and Push**
    ```bash
-   git add .claude-plugin/
-   git commit -m "chore: bump marketplace to vX.Y.Z"
+   git add .claude-plugin/ .agents/plugins/ plugins/unraid/ gemini-extension.json
+   git commit -m "docs: update marketplace documentation"
    git push origin main
    ```
 
-5. **Create Release Tag**
-   ```bash
-   git tag -a vX.Y.Z -m "Release vX.Y.Z"
-   git push origin vX.Y.Z
-   ```
+5. **Cut releases via release-please**
+   - Merge the release-please PR.
+   - The tag triggers PyPI, GHCR, and MCP Registry publication workflows.
 
 ## User Experience
 
@@ -216,12 +224,13 @@ After installation, users can:
 To release a new version:
 
 1. Make changes to the plugin code
-2. Update version in `pyproject.toml`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`
-3. Commit and push
+2. Commit and push with Conventional Commit messages
+3. Merge the release-please PR when ready
 
 Users with the plugin installed will see the update available and can upgrade:
 ```bash
 /plugin update unraid
+/plugin update unraid-mcp
 ```
 
 ## Support

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -9,7 +9,7 @@ This guide covers how to publish `unraid-mcp` to PyPI so it can be installed via
 **Current version:** `1.1.2`
 
 The package ships a FastMCP server exposing **a single MCP tool**:
-- `unraid` — the only tool, with `action` + `subaction` routing (19 actions, 175 subactions). The Markdown reference and WebSocket diagnostics are the `help` and `subscriptions` actions of this tool.
+- `unraid` — the only tool, with `action` + `subaction` routing (19 actions, 178 subactions). The Markdown reference and WebSocket diagnostics are the `help` and `subscriptions` actions of this tool.
 
 Tool call convention: `unraid(action="docker", subaction="list")`. Discover the full surface with `unraid(action="help")`; run WebSocket diagnostics via `unraid(action="subscriptions", subaction="diagnose")`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/unraid-mcp)](https://pypi.org/project/unraid-mcp/) [![ghcr.io](https://img.shields.io/badge/ghcr.io-jmagar%2Funraid--mcp-blue?logo=docker)](https://github.com/jmagar/unraid-mcp/pkgs/container/unraid-mcp)
 
-MCP server for Unraid NAS management. Exposes a single unified `unraid` tool with 19 action domains and 175 subactions, backed by Unraid's GraphQL API and real-time WebSocket subscriptions.
+MCP server for Unraid NAS management. Exposes a single unified `unraid` tool with 19 action domains and 178 subactions, backed by Unraid's GraphQL API and real-time WebSocket subscriptions.
 
 ## Overview
 
@@ -12,7 +12,7 @@ A single MCP tool is exposed:
 
 | Tool | Purpose |
 | --- | --- |
-| `unraid` | Unified action/subaction router for all operations (19 actions, 175 subactions). The Markdown reference and WebSocket diagnostics, which used to be standalone tools, are now the `help` and `subscriptions` actions of this tool. |
+| `unraid` | Unified action/subaction router for all operations (19 actions, 178 subactions). The Markdown reference and WebSocket diagnostics, which used to be standalone tools, are now the `help` and `subscriptions` actions of this tool. |
 
 Discover the full surface with `unraid(action="help")`. WebSocket subscription diagnostics are available via `unraid(action="subscriptions", subaction="diagnose")` and `unraid(action="subscriptions", subaction="test_query", subscription_query=...)`.
 
@@ -39,7 +39,7 @@ Single entry point for all Unraid operations. Select the operation with `action`
 
 | Action | Subactions | Description |
 | --- | --- | --- |
-| `system` (23) | `overview`, `array`, `network`, `registration`, `variables`, `metrics`, `services`, `display`, `display_details`, `config`, `online`, `owner`, `settings`, `server`, `server_details`, `servers`, `network_access_urls`, `flash`, `ups_devices`, `ups_device`, `ups_config`, `server_time`, `timezones` | Server info, metrics, network, UPS |
+| `system` (25) | `overview`, `array`, `network`, `registration`, `variables`, `metrics`, `network_metrics`, `services`, `display`, `display_details`, `config`, `online`, `owner`, `settings`, `server`, `server_details`, `servers`, `network_access_urls`, `flash`, `ups_devices`, `ups_device`, `ups_config`, `server_time`, `timezones`, `network_interfaces` | Server info, metrics, network, UPS |
 | `health` (4) | `check`, `test_connection`, `diagnose`, `setup` | Health checks, connection test, credential setup |
 | `array` (14) | `parity_status`, `parity_history`, `assignable_disks`, `parity_start`, `parity_pause`, `parity_resume`, `parity_cancel`, `start_array`, `stop_array`\*, `add_disk`, `remove_disk`\*, `mount_disk`, `unmount_disk`, `clear_disk_stats`\* | Parity checks, array lifecycle, disk operations |
 | `disk` (6) | `shares`, `disks`, `disk_details`, `log_files`, `logs`, `flash_backup`\* | Shares, physical disks, log files |
@@ -55,7 +55,7 @@ Single entry point for all Unraid operations. Select the operation with `action`
 | `oidc` (5) | `providers`, `provider`, `configuration`, `public_providers`, `validate_session` | OIDC/SSO provider management |
 | `onboarding` (11) | `internal_boot_context`, `complete`, `open`, `close`, `resume`, `bypass`, `reset`\*, `set_override`, `clear_override`, `refresh_internal_boot_context`, `create_internal_boot_pool`\* | First-boot / onboarding state |
 | `user` (1) | `me` | Current authenticated user |
-| `live` (16) | `cpu`, `memory`, `cpu_telemetry`, `array_state`, `parity_progress`, `ups_status`, `notifications_overview`, `notifications_warnings`, `notification_feed`, `log_tail`, `owner`, `server_status`, `display`, `docker_container_stats`, `temperature`, `plugin_install_updates` | Real-time WebSocket subscription snapshots |
+| `live` (17) | `cpu`, `memory`, `cpu_telemetry`, `array_state`, `parity_progress`, `ups_status`, `notifications_overview`, `notifications_warnings`, `notification_feed`, `log_tail`, `owner`, `server_status`, `display`, `docker_container_stats`, `temperature`, `network_metrics`, `plugin_install_updates` | Real-time WebSocket subscription snapshots |
 | `subscriptions` (2) | `diagnose`, `test_query` (needs `subscription_query=`) | WebSocket subscription diagnostics |
 | `help` (0) | _(no subaction)_ | Returns the full Markdown action/subaction reference |
 
@@ -76,8 +76,8 @@ unraid(action="help")
 ### Marketplace
 
 ```bash
-/plugin marketplace add jmagar/claude-homelab
-/plugin install unraid-mcp @jmagar-claude-homelab
+/plugin marketplace add jmagar/unraid-mcp
+/plugin install unraid-mcp@unraid-mcp
 ```
 
 ### Local development

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -15,8 +15,8 @@ Configuration is collected by the plugin's config form — no interactive wizard
 
 1. Install as a Claude Code plugin:
    ```bash
-   /plugin marketplace add jmagar/claude-homelab
-   /plugin install unraid-mcp @jmagar-claude-homelab
+   /plugin marketplace add jmagar/unraid-mcp
+   /plugin install unraid-mcp@unraid-mcp
    ```
 
 2. In the plugin's configuration form, set:
@@ -73,10 +73,13 @@ Configuration is collected by the plugin's config form — no interactive wizard
    cd unraid-mcp
    ```
 
-2. Set up credentials (the Docker container reads from `~/.claude-homelab/.env` via env_file):
+2. Set up credentials (the Docker container reads from `~/.unraid-mcp/.env` via `env_file`):
    ```bash
-   # Ensure your credentials are in ~/.claude-homelab/.env
-   # or modify docker-compose.yaml to point to ~/.unraid-mcp/.env
+   mkdir -p ~/.unraid-mcp
+   cp .env.example ~/.unraid-mcp/.env
+   chmod 700 ~/.unraid-mcp
+   chmod 600 ~/.unraid-mcp/.env
+   # Edit ~/.unraid-mcp/.env with UNRAID_API_URL and UNRAID_API_KEY.
    ```
 
 3. Start the container:

--- a/docs/mcp/AUTH.md
+++ b/docs/mcp/AUTH.md
@@ -4,7 +4,7 @@
 
 unraid-mcp has two authentication boundaries:
 
-1. **Inbound (client to MCP server)**: Bearer token authentication on HTTP transports
+1. **Inbound (client to MCP server)**: Bearer token authentication by default on HTTP transports, or optional Google OAuth when configured
 2. **Outbound (MCP server to Unraid)**: API key authentication via `x-api-key` header
 
 ## Inbound: Bearer token (RFC 6750)
@@ -62,6 +62,31 @@ warning. This is only safe behind a fronting gateway that terminates auth itself
 a public interface with auth disabled additionally requires `UNRAID_MCP_TRUST_PROXY=true`
 (without it, the server refuses to bind publicly). Keep the container's published port
 unexposed or loopback-scoped; see [DEPLOY.md](DEPLOY.md).
+
+## Inbound: Google OAuth
+
+Setting both `UNRAID_MCP_GOOGLE_CLIENT_ID` and
+`UNRAID_MCP_GOOGLE_CLIENT_SECRET` replaces the Bearer-token middleware with
+FastMCP's Google OAuth provider for HTTP transports. OAuth mode is mutually exclusive
+with `UNRAID_MCP_DISABLE_HTTP_AUTH=true`.
+
+Required when OAuth is enabled:
+
+- `UNRAID_MCP_GOOGLE_BASE_URL`, the public base URL of this MCP server. It must be
+  HTTPS outside localhost/loopback development.
+- At least one authorization allowlist entry: `UNRAID_MCP_GOOGLE_ALLOWED_EMAILS` or
+  `UNRAID_MCP_GOOGLE_ALLOWED_DOMAINS`, unless
+  `UNRAID_MCP_GOOGLE_ALLOW_ANY_USER=true` is intentionally set.
+
+Optional persistence:
+
+- Set both `UNRAID_MCP_GOOGLE_JWT_SIGNING_KEY` and
+  `UNRAID_MCP_GOOGLE_ENCRYPTION_KEY` to persist OAuth tokens encrypted at rest under
+  `UNRAID_MCP_GOOGLE_STORAGE_DIR` (default `~/.unraid-mcp/oauth-tokens`).
+- Set neither to keep tokens in memory. Setting only one is a startup error.
+
+See [../AUTHENTICATION.md](../AUTHENTICATION.md#google-oauth-optional) for setup
+steps and the full env-var table.
 
 ### Error responses
 

--- a/docs/mcp/CLAUDE.md
+++ b/docs/mcp/CLAUDE.md
@@ -32,7 +32,7 @@ Documentation for the unraid-mcp MCP server.
 1. ENV.md -- understand required configuration
 2. AUTH.md -- set up authentication
 3. TRANSPORT.md -- choose a transport and connect
-4. TOOLS.md -- learn available operations (19 actions, 175 subactions)
+4. TOOLS.md -- learn available operations (19 actions, 178 subactions)
 5. RESOURCES.md -- discover live subscription data endpoints
 6. ELICITATION.md -- understand the destructive action gates
 
@@ -45,7 +45,7 @@ Documentation for the unraid-mcp MCP server.
 ## At a glance
 
 - **One tool**, `unraid`, routed by `action` (domain) + `subaction` (operation):
-  `unraid(action="docker", subaction="list")`. 19 actions / 175 subactions.
+  `unraid(action="docker", subaction="list")`. 19 actions / 178 subactions.
 - **Destructive subactions require `confirm=True`** (e.g. `array/stop_array`,
   `docker/remove_container`); without it, an MCP elicitation form is raised.
 - **List subactions are capped** via the `limit` param (default 20; `limit<=0` =

--- a/docs/mcp/CONNECT.md
+++ b/docs/mcp/CONNECT.md
@@ -7,17 +7,19 @@ How to connect to the unraid-mcp server from every supported client and transpor
 ### Install from marketplace
 
 ```bash
-/plugin marketplace add jmagar/claude-homelab
-/plugin install unraid-mcp @jmagar-claude-homelab
+/plugin marketplace add jmagar/unraid-mcp
+/plugin install unraid-mcp@unraid-mcp
 ```
 
-Claude Code runs the server in stdio mode via `uv run --directory <plugin-root> unraid-mcp-server`.
+Claude Code runs the published server in stdio mode via `uvx unraid-mcp`.
 
 The plugin prompts for `userConfig` values:
-- **Unraid MCP Server URL**: URL of the MCP server (default: `https://unraid.tootie.tv/mcp`)
-- **MCP Server Bearer Token**: For HTTP transport auth
 - **Unraid GraphQL API URL**: Your Unraid server's GraphQL endpoint
 - **Unraid API Key**: API key from Unraid Settings
+
+The plugin's setup hook persists those values to `~/.unraid-mcp/.env`. It does not
+prompt for a Bearer token because the plugin uses local stdio transport. Bearer tokens
+or Google OAuth apply only when you run a separate HTTP server.
 
 ### Connect to remote HTTP server
 
@@ -70,16 +72,17 @@ Replace `<SERVER>` with your Unraid (or MCP server) host.
 over `https://`. If the server requires a Bearer token, append
 `--header "Authorization: Bearer <token>"`.
 
-## Codex CLI
+## Codex
 
-The `.codex-plugin/plugin.json` provides Codex integration:
+The repo ships a Codex marketplace manifest at `.agents/plugins/marketplace.json`:
 
 ```bash
-# Install plugin
-codex plugin install ./
+codex plugin marketplace add jmagar/unraid-mcp
+# then enable `unraid-mcp@unraid-mcp` from the Codex `/plugins` view
 ```
 
-Codex discovers the MCP server via `.mcp.json` referenced in the manifest.
+Codex forwards `UNRAID_API_URL` and `UNRAID_API_KEY` by env-var name. Export them in
+the shell that launches Codex or populate `~/.unraid-mcp/.env`.
 
 ## Gemini CLI
 
@@ -97,7 +100,7 @@ The `gemini-extension.json` provides Gemini integration:
 }
 ```
 
-Settings are collected via the `settings` array for `UNRAID_API_URL` and `UNRAID_API_KEY`.
+Gemini collects `UNRAID_API_URL` and `UNRAID_API_KEY` through the extension settings.
 
 ## Direct HTTP (any client)
 

--- a/docs/mcp/DEPLOY.md
+++ b/docs/mcp/DEPLOY.md
@@ -44,11 +44,13 @@ The `docker-compose.yaml` provides:
 
 ### Environment
 
-The container reads from `~/.claude-homelab/.env` via `env_file`. Required variables:
+The container reads from `~/.unraid-mcp/.env` via `env_file`. Required variables:
 
 ```bash
 UNRAID_API_URL=https://your-unraid-server
 UNRAID_API_KEY=your_api_key
+# Required for HTTP Bearer auth. Leave unset only when using Google OAuth or
+# UNRAID_MCP_DISABLE_HTTP_AUTH=true behind a trusted proxy.
 UNRAID_MCP_BEARER_TOKEN=your_bearer_token
 ```
 
@@ -106,7 +108,7 @@ The `entrypoint.sh` validates required environment variables before starting the
 
 - `UNRAID_API_URL` -- always required
 - `UNRAID_API_KEY` -- always required
-- `UNRAID_MCP_BEARER_TOKEN` -- required for HTTP transport with auth enabled
+- `UNRAID_MCP_BEARER_TOKEN` -- required for HTTP transport with auth enabled unless Google OAuth is configured
 
 If any are missing, the container exits with a descriptive error listing the missing variables.
 

--- a/docs/mcp/ENV.md
+++ b/docs/mcp/ENV.md
@@ -14,6 +14,7 @@
 | `UNRAID_MCP_HOST` | no | `127.0.0.1` bare metal; Docker image sets `0.0.0.0` | no | Bind address for HTTP transport |
 | `UNRAID_MCP_PORT` | no | `6970` | no | HTTP server port (1-65535) |
 | `UNRAID_MCP_TRANSPORT` | no | `streamable-http` | no | Transport: `streamable-http`, `stdio`, or `sse` |
+| `UNRAID_MCP_MAX_RESPONSE_BYTES` | no | `40000` | no | Max serialized tool-response size. Over-cap responses return a parseable truncation marker. |
 
 ## Authentication
 

--- a/docs/mcp/TOOLS.md
+++ b/docs/mcp/TOOLS.md
@@ -8,7 +8,7 @@ unraid-mcp exposes a single MCP tool, `unraid`, with `action` (domain) + `subact
 |------|---------|------------|
 | `unraid` | The only tool -- action+subaction dispatch across 19 actions / 178 subactions. The Markdown reference and WebSocket diagnostics are the `help` and `subscriptions` actions. | `action`, `subaction`, plus domain-specific params |
 
-The consolidated action pattern keeps the MCP surface to one tool while supporting 175 subactions across 19 actions. Clients call `unraid(action="help")` first to discover available operations, then call `unraid` with the appropriate action and subaction. WebSocket subscription diagnostics live under `unraid(action="subscriptions", subaction="diagnose"|"test_query")`.
+The consolidated action pattern keeps the MCP surface to one tool while supporting 178 subactions across 19 actions. Clients call `unraid(action="help")` first to discover available operations, then call `unraid` with the appropriate action and subaction. WebSocket subscription diagnostics live under `unraid(action="subscriptions", subaction="diagnose"|"test_query")`.
 
 ## Primary Tool: `unraid`
 

--- a/docs/plugin/MARKETPLACES.md
+++ b/docs/plugin/MARKETPLACES.md
@@ -4,14 +4,14 @@
 
 | Marketplace | Identifier | Install method |
 |-------------|-----------|----------------|
-| Claude Plugin Marketplace | `jmagar/unraid-mcp` (via `jmagar/claude-homelab`) | `/plugin install unraid-mcp @jmagar-claude-homelab` |
+| Claude Plugin Marketplace | `jmagar/unraid-mcp` | `/plugin install unraid-mcp@unraid-mcp` |
 | MCP Registry | `tv.tootie/unraid-mcp` | Auto-discovery by MCP clients |
 | PyPI | `unraid-mcp` | `pip install unraid-mcp` or `uvx unraid-mcp` |
 | GitHub Container Registry | `ghcr.io/jmagar/unraid-mcp` | `docker pull ghcr.io/jmagar/unraid-mcp` |
 
 ## Claude Plugin Marketplace
 
-unraid-mcp is an external plugin in the `jmagar/claude-homelab` marketplace:
+unraid-mcp ships its own Claude Code marketplace manifest at `.claude-plugin/marketplace.json`:
 
 ```json
 {
@@ -30,10 +30,10 @@ unraid-mcp is an external plugin in the `jmagar/claude-homelab` marketplace:
 
 ```bash
 # Add the marketplace (one-time)
-/plugin marketplace add jmagar/claude-homelab
+/plugin marketplace add jmagar/unraid-mcp
 
 # Install the plugin
-/plugin install unraid-mcp @jmagar-claude-homelab
+/plugin install unraid-mcp@unraid-mcp
 ```
 
 ## MCP Registry


### PR DESCRIPTION
## Summary
- expand README/config/env docs to cover the full current settings surface, including Google OAuth, trust-proxy, response limits, TLS, logging, subscriptions, and credentials directory knobs
- update stale marketplace/install/deploy docs to the current `jmagar/unraid-mcp` plugin, `unraid-mcp@unraid-mcp` install ID, release-please flow, and 178-subaction tool surface
- align Docker Compose with the canonical `~/.unraid-mcp/.env` path and current auth variable names

## Sweep checks
- compared `Settings(... alias=...)` env vars against `.env.example`, `README.md`, `docs/mcp/ENV.md`, and `docs/CONFIG.md`; all settings aliases are now represented
- checked stale strings for old `~/.claude-homelab`, `UNRAID_MCP_TOKEN`, old plugin install command, and `175 subactions`

## Verification
- `just check-contract`
- `docker compose config`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded docs to cover the full environment surface (including Google OAuth, trust-proxy, response limits, TLS, logging, subscriptions, and credentials directory) and updated marketplace/install references to the current `jmagar/unraid-mcp` plugin and `unraid-mcp@unraid-mcp` handle. Aligns Docker Compose to `~/.unraid-mcp/.env` and updates counts to 19 actions / 178 subactions.

- **New Features**
  - Added Google OAuth setup and persistence docs; mutually exclusive with Bearer auth.
  - Documented `UNRAID_MCP_TRUST_PROXY` requirement when disabling HTTP auth on non-loopback binds.
  - Added `UNRAID_MCP_MAX_RESPONSE_BYTES` with truncation behavior.
  - Clarified TLS options (`UNRAID_VERIFY_SSL`, `UNRAID_ALLOW_INSECURE_TLS`), logging controls, subscription auto-start, and `UNRAID_CREDENTIALS_DIR`.
  - Updated marketplace flow to `jmagar/unraid-mcp` and install handle `unraid-mcp@unraid-mcp`; described release-please driven releases.
  - Default bind clarified: `127.0.0.1` on bare metal; Docker image uses `0.0.0.0`.

- **Migration**
  - Update env var name to `UNRAID_MCP_BEARER_TOKEN` (was `UNRAID_MCP_TOKEN` in older docs).
  - Move env file to `~/.unraid-mcp/.env` (Compose reads this by default).
  - Use new install commands:
    - `/plugin marketplace add jmagar/unraid-mcp`
    - `/plugin install unraid-mcp@unraid-mcp`
  - If disabling HTTP auth and binding publicly, set `UNRAID_MCP_TRUST_PROXY=true`.
  - If enabling Google OAuth, set client ID/secret, `UNRAID_MCP_GOOGLE_BASE_URL`, and an allowlist (`...ALLOWED_EMAILS` or `...ALLOWED_DOMAINS`) or `...ALLOW_ANY_USER=true`.

<sup>Written for commit 8188fafdd501f3b8450242064c9be6e557f9620e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

