### PR TITLE
fix: adapt to Unraid NetworkMetrics schema drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,9 +82,10 @@ Copy `.env.example` to `.env` and configure:
   from the `limit` tool param. Capped responses carry a `page` meta dict
   (`returned`/`total`/`truncated`, plus a `hint` when truncated). `limit<=0` returns everything;
   omitting `limit` uses the tool default (20). Applies to `docker/list`, `disk/shares`,
-  `disk/disks`, `array/parity_history`, and the `live/log_tail` + `live/notification_feed`
-  event lists. `docker/details` fetches a single container via `docker.container(id:)` rather
-  than over-fetching the full container list.
+  `disk/disks`, `array/parity_history`, `system/network_interfaces`, `system/network_metrics`,
+  and the `live/log_tail` + `live/notification_feed` + `live/network_metrics` event/interface
+  lists. `docker/details` fetches a single container via `docker.container(id:)` rather than
+  over-fetching the full container list.
 - **Destructive Action Safety**: `DESTRUCTIVE_ACTIONS` sets require `confirm=True` for dangerous operations
 - **Modular Architecture**: Clean separation of concerns across focused modules
 - **Error Handling**: Uses ToolError for user-facing errors, detailed logging for debugging

--- a/docs/unraid/UNRAID-API-COMPLETE-REFERENCE.md
+++ b/docs/unraid/UNRAID-API-COMPLETE-REFERENCE.md
@@ -1995,7 +1995,7 @@ Remove one or more plugins from the API. Returns false if restart was triggered 
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="subscription.systemmetricsnetwork">systemMetricsNetwork</strong></td>
-<td valign="top"><a href="#networkmetrics">NetworkMetrics</a>!</td>
+<td valign="top">[<a href="#networkmetrics">NetworkMetrics</a>!]!</td>
 <td>
 
 
@@ -6280,7 +6280,7 @@ IPv6 address details
 
 ### InfoNetworkIpv4Address
 
-IPv4 address information for a network interface
+IPv4 address assigned to a network interface
 
 <table>
 <thead>
@@ -6295,19 +6295,27 @@ IPv4 address information for a network interface
 <tr>
 <td colspan="2" valign="top"><strong id="infonetworkipv4address.address">address</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+IPv4 address
+
+</td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong id="infonetworkipv4address.cidr">cidr</strong></td>
-<td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td colspan="2" valign="top"><strong id="infonetworkipv4address.netmask">netmask</strong></td>
+<td valign="top"><a href="#string">String</a>!</td>
+<td>
+
+IPv4 netmask
+
+</td>
 </tr>
 </tbody>
 </table>
 
 ### InfoNetworkIpv6Address
 
-IPv6 address information for a network interface
+IPv6 address assigned to a network interface
 
 <table>
 <thead>
@@ -6322,12 +6330,20 @@ IPv6 address information for a network interface
 <tr>
 <td colspan="2" valign="top"><strong id="infonetworkipv6address.address">address</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
-<td></td>
+<td>
+
+IPv6 address
+
+</td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong id="infonetworkipv6address.cidr">cidr</strong></td>
+<td colspan="2" valign="top"><strong id="infonetworkipv6address.prefixlength">prefixLength</strong></td>
 <td valign="top"><a href="#int">Int</a></td>
-<td></td>
+<td>
+
+IPv6 prefix length
+
+</td>
 </tr>
 </tbody>
 </table>
@@ -7243,10 +7259,10 @@ Temperature metrics
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong id="metrics.network">network</strong></td>
-<td valign="top"><a href="#networkmetrics">NetworkMetrics</a></td>
+<td valign="top">[<a href="#networkmetrics">NetworkMetrics</a>!]!</td>
 <td>
 
-Network interface metrics
+Current network metrics for all interfaces
 
 </td>
 </tr>
@@ -7310,8 +7326,6 @@ Network interface metrics
 
 ### NetworkMetrics
 
-Network interface metrics
-
 <table>
 <thead>
 <tr>
@@ -7323,29 +7337,133 @@ Network interface metrics
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong id="networkmetrics.interface">interface</strong></td>
+<td colspan="2" valign="top"><strong id="networkmetrics.id">id</strong></td>
+<td valign="top"><a href="#prefixedid">PrefixedID</a>!</td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.name">name</strong></td>
 <td valign="top"><a href="#string">String</a>!</td>
 <td>
 
-Network interface name
+Interface identifier
 
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong id="networkmetrics.rxbytespersec">rxBytesPerSec</strong></td>
-<td valign="top"><a href="#float">Float</a></td>
+<td colspan="2" valign="top"><strong id="networkmetrics.operstate">operstate</strong></td>
+<td valign="top"><a href="#string">String</a></td>
 <td>
 
-Bytes received per second
+Operational state
 
 </td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong id="networkmetrics.txbytespersec">txBytesPerSec</strong></td>
+<td colspan="2" valign="top"><strong id="networkmetrics.bytesreceived">bytesReceived</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Total received bytes
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.bytessent">bytesSent</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Total transmitted bytes
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.packetsreceived">packetsReceived</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Total received packets
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.packetssent">packetsSent</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Total transmitted packets
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.receiveerrors">receiveErrors</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Receive errors
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.transmiterrors">transmitErrors</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Transmit errors
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.receivedropped">receiveDropped</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Dropped receive packets
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.transmitdropped">transmitDropped</strong></td>
+<td valign="top"><a href="#bigint">BigInt</a>!</td>
+<td>
+
+Dropped transmit packets
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.rxsec">rxSec</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td>
+
+Receive throughput in bytes per second
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.txsec">txSec</strong></td>
+<td valign="top"><a href="#float">Float</a>!</td>
+<td>
+
+Transmit throughput in bytes per second
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.utilizationpercent">utilizationPercent</strong></td>
 <td valign="top"><a href="#float">Float</a></td>
 <td>
 
-Bytes transmitted per second
+Estimated link utilization percentage
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong id="networkmetrics.lastupdated">lastUpdated</strong></td>
+<td valign="top"><a href="#datetime">DateTime</a>!</td>
+<td>
+
+Metric collection timestamp
 
 </td>
 </tr>

--- a/docs/unraid/UNRAID-API-SUMMARY.md
+++ b/docs/unraid/UNRAID-API-SUMMARY.md
@@ -149,7 +149,7 @@
 | `systemMetricsCpu` | `CpuUtilization!` |  —  |
 | `systemMetricsCpuTelemetry` | `CpuPackages!` |  —  |
 | `systemMetricsMemory` | `MemoryUtilization!` |  —  |
-| `systemMetricsNetwork` | `NetworkMetrics!` |  —  |
+| `systemMetricsNetwork` | `[NetworkMetrics!]!` |  —  |
 | `systemMetricsTemperature` | `TemperatureMetrics` |  —  |
 | `upsUpdates` | `UPSDevice!` |  —  |
 

--- a/docs/unraid/UNRAID-SCHEMA.graphql
+++ b/docs/unraid/UNRAID-SCHEMA.graphql
@@ -629,14 +629,6 @@ enum ConfigErrorState {
   WITHDRAWN
 }
 
-type ApiConfig {
-  version: String!
-  extraOrigins: [String!]!
-  sandbox: Boolean
-  ssoSubIds: [String!]!
-  plugins: [String!]!
-}
-
 type Permission {
   resource: Resource!
 
@@ -729,65 +721,6 @@ enum Role {
   VIEWER
 }
 
-type NotificationCounts {
-  info: Int!
-  warning: Int!
-  alert: Int!
-  total: Int!
-}
-
-type NotificationOverview {
-  unread: NotificationCounts!
-  archive: NotificationCounts!
-}
-
-type Notification implements Node {
-  id: PrefixedID!
-
-  """Also known as 'event'"""
-  title: String!
-  subject: String!
-  description: String!
-  importance: NotificationImportance!
-  link: String
-  type: NotificationType!
-
-  """ISO Timestamp for when the notification occurred"""
-  timestamp: String
-  formattedTimestamp: String
-}
-
-enum NotificationImportance {
-  ALERT
-  INFO
-  WARNING
-}
-
-enum NotificationType {
-  UNREAD
-  ARCHIVE
-}
-
-type Notifications implements Node {
-  id: PrefixedID!
-
-  """A cached overview of the notifications in the system & their severity."""
-  overview: NotificationOverview!
-  list(filter: NotificationFilter!): [Notification!]!
-
-  """
-  Deduplicated list of unread warning and alert notifications, sorted latest first.
-  """
-  warningsAndAlerts: [Notification!]!
-}
-
-input NotificationFilter {
-  importance: NotificationImportance
-  type: NotificationType!
-  offset: Int!
-  limit: Int!
-}
-
 type SsoSettings implements Node {
   id: PrefixedID!
 
@@ -822,7 +755,7 @@ interface FormSchema {
 """
 The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 """
-scalar JSON
+scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
 
 type ApiKeyFormSettings implements Node & FormSchema {
   id: PrefixedID!
@@ -1131,13 +1064,10 @@ enum OnboardingStatus {
 }
 
 type Customization {
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ACTIVATION_CODE**"
   activationCode: ActivationCode
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CUSTOMIZATIONS**\n\n#### Description:\n\nOnboarding completion state and context"
+  """Onboarding completion state and context"""
   onboarding: Onboarding!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DISPLAY**"
   availableLanguages: [Language!]
 }
 
@@ -1256,22 +1186,24 @@ type PluginInstallEvent {
 }
 
 type ArrayMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nSet array state"
+  """Set array state"""
   setState(input: ArrayStateInput!): UnraidArray!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nAdd new disk to array"
+  """Add new disk to array"""
   addDiskToArray(input: ArrayDiskInput!): UnraidArray!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nRemove existing disk from array. NOTE: The array must be stopped before running this otherwise it'll throw an error."
+  """
+  Remove existing disk from array. NOTE: The array must be stopped before running this otherwise it'll throw an error.
+  """
   removeDiskFromArray(input: ArrayDiskInput!): UnraidArray!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nMount a disk in the array"
+  """Mount a disk in the array"""
   mountArrayDisk(id: PrefixedID!): ArrayDisk!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nUnmount a disk from the array"
+  """Unmount a disk from the array"""
   unmountArrayDisk(id: PrefixedID!): ArrayDisk!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nClear statistics for a disk in the array"
+  """Clear statistics for a disk in the array"""
   clearArrayDiskStatistics(id: PrefixedID!): Boolean!
 }
 
@@ -1304,34 +1236,34 @@ input ArrayDiskInput {
 }
 
 type DockerMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nStart a container"
+  """Start a container"""
   start(id: PrefixedID!): DockerContainer!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nStop a container"
+  """Stop a container"""
   stop(id: PrefixedID!): DockerContainer!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nRestart a container"
+  """Restart a container"""
   restart(id: PrefixedID!): DockerContainer!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nPause (Suspend) a container"
+  """Pause (Suspend) a container"""
   pause(id: PrefixedID!): DockerContainer!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nUnpause (Resume) a container"
+  """Unpause (Resume) a container"""
   unpause(id: PrefixedID!): DockerContainer!
 
-  "\n#### Required Permissions:\n\n- Action: **DELETE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nRemove a container"
+  """Remove a container"""
   removeContainer(id: PrefixedID!, withImage: Boolean): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nUpdate auto-start configuration for Docker containers"
+  """Update auto-start configuration for Docker containers"""
   updateAutostartConfiguration(entries: [DockerAutostartEntryInput!]!, persistUserPreferences: Boolean): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nUpdate a container to the latest image"
+  """Update a container to the latest image"""
   updateContainer(id: PrefixedID!): DockerContainer!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nUpdate multiple containers to the latest images"
+  """Update multiple containers to the latest images"""
   updateContainers(ids: [PrefixedID!]!): [DockerContainer!]!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nUpdate all containers that have available updates"
+  """Update all containers that have available updates"""
   updateAllContainers: [DockerContainer!]!
 }
 
@@ -1347,43 +1279,43 @@ input DockerAutostartEntryInput {
 }
 
 type VmMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nStart a virtual machine"
+  """Start a virtual machine"""
   start(id: PrefixedID!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nStop a virtual machine"
+  """Stop a virtual machine"""
   stop(id: PrefixedID!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nPause a virtual machine"
+  """Pause a virtual machine"""
   pause(id: PrefixedID!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nResume a virtual machine"
+  """Resume a virtual machine"""
   resume(id: PrefixedID!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nForce stop a virtual machine"
+  """Force stop a virtual machine"""
   forceStop(id: PrefixedID!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nReboot a virtual machine"
+  """Reboot a virtual machine"""
   reboot(id: PrefixedID!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nReset a virtual machine"
+  """Reset a virtual machine"""
   reset(id: PrefixedID!): Boolean!
 }
 
 """API Key related mutations"""
 type ApiKeyMutations {
-  "\n#### Required Permissions:\n\n- Action: **CREATE_ANY**\n- Resource: **API_KEY**\n\n#### Description:\n\nCreate an API key"
+  """Create an API key"""
   create(input: CreateApiKeyInput!): ApiKey!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **API_KEY**\n\n#### Description:\n\nAdd a role to an API key"
+  """Add a role to an API key"""
   addRole(input: AddRoleForApiKeyInput!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **API_KEY**\n\n#### Description:\n\nRemove a role from an API key"
+  """Remove a role from an API key"""
   removeRole(input: RemoveRoleFromApiKeyInput!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **DELETE_ANY**\n- Resource: **API_KEY**\n\n#### Description:\n\nDelete one or more API keys"
+  """Delete one or more API keys"""
   delete(input: DeleteApiKeyInput!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **API_KEY**\n\n#### Description:\n\nUpdate an API key"
+  """Update an API key"""
   update(input: UpdateApiKeyInput!): ApiKey!
 }
 
@@ -1428,13 +1360,13 @@ input UpdateApiKeyInput {
 
 """Customization related mutations"""
 type CustomizationMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CUSTOMIZATIONS**\n\n#### Description:\n\nUpdate the UI theme (writes dynamix.cfg)"
+  """Update the UI theme (writes dynamix.cfg)"""
   setTheme(
     """Theme to apply"""
     theme: ThemeName!
   ): Theme!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CUSTOMIZATIONS**\n\n#### Description:\n\nUpdate the display locale (language)"
+  """Update the display locale (language)"""
   setLocale(
     """Locale code to apply (e.g. en_US)"""
     locale: String!
@@ -1445,25 +1377,25 @@ type CustomizationMutations {
 Parity check related mutations, WIP, response types and functionaliy will change
 """
 type ParityCheckMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nStart a parity check"
+  """Start a parity check"""
   start(correct: Boolean!): JSON!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nPause a parity check"
+  """Pause a parity check"""
   pause: JSON!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nResume a parity check"
+  """Resume a parity check"""
   resume: JSON!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **ARRAY**\n\n#### Description:\n\nCancel a parity check"
+  """Cancel a parity check"""
   cancel: JSON!
 }
 
 """RClone related mutations"""
 type RCloneMutations {
-  "\n#### Required Permissions:\n\n- Action: **CREATE_ANY**\n- Resource: **FLASH**\n\n#### Description:\n\nCreate a new RClone remote"
+  """Create a new RClone remote"""
   createRCloneRemote(input: CreateRCloneRemoteInput!): RCloneRemote!
 
-  "\n#### Required Permissions:\n\n- Action: **DELETE_ANY**\n- Resource: **FLASH**\n\n#### Description:\n\nDelete an existing RClone remote"
+  """Delete an existing RClone remote"""
   deleteRCloneRemote(input: DeleteRCloneRemoteInput!): Boolean!
 }
 
@@ -1479,34 +1411,36 @@ input DeleteRCloneRemoteInput {
 
 """Onboarding related mutations"""
 type OnboardingMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nMark onboarding as completed"
+  """Mark onboarding as completed"""
   completeOnboarding: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nReset onboarding progress (for testing)"
+  """Reset onboarding progress (for testing)"""
   resetOnboarding: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nForce the onboarding modal open"
+  """Force the onboarding modal open"""
   openOnboarding: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nClose the onboarding modal"
+  """Close the onboarding modal"""
   closeOnboarding: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nTemporarily bypass onboarding in API memory"
+  """Temporarily bypass onboarding in API memory"""
   bypassOnboarding: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nClear the temporary onboarding bypass"
+  """Clear the temporary onboarding bypass"""
   resumeOnboarding: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nOverride onboarding state for testing (in-memory only)"
+  """Override onboarding state for testing (in-memory only)"""
   setOnboardingOverride(input: OnboardingOverrideInput!): Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nClear onboarding override state and reload from disk"
+  """Clear onboarding override state and reload from disk"""
   clearOnboardingOverride: Onboarding!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nCreate and configure internal boot pool via emcmd operations"
+  """Create and configure internal boot pool via emcmd operations"""
   createInternalBootPool(input: CreateInternalBootPoolInput!): OnboardingInternalBootResult!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nRefresh the internal boot onboarding context from the latest emhttp state"
+  """
+  Refresh the internal boot onboarding context from the latest emhttp state
+  """
   refreshInternalBootContext: OnboardingInternalBootContext!
 }
 
@@ -1595,10 +1529,10 @@ input CreateInternalBootPoolInput {
 
 """Unraid plugin management mutations"""
 type UnraidPluginsMutations {
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nInstall an Unraid plugin and track installation progress"
+  """Install an Unraid plugin and track installation progress"""
   installPlugin(input: InstallPluginInput!): PluginInstallOperation!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nInstall an Unraid language pack and track installation progress"
+  """Install an Unraid language pack and track installation progress"""
   installLanguage(input: InstallPluginInput!): PluginInstallOperation!
 }
 
@@ -1920,6 +1854,24 @@ type InfoMemory implements Node {
   layout: [MemoryLayout!]!
 }
 
+"""IPv4 address assigned to a network interface"""
+type InfoNetworkIpv4Address {
+  """IPv4 address"""
+  address: String!
+
+  """IPv4 netmask"""
+  netmask: String!
+}
+
+"""IPv6 address assigned to a network interface"""
+type InfoNetworkIpv6Address {
+  """IPv6 address"""
+  address: String!
+
+  """IPv6 prefix length"""
+  prefixLength: Int
+}
+
 type InfoNetworkInterface implements Node {
   id: PrefixedID!
 
@@ -1931,6 +1883,36 @@ type InfoNetworkInterface implements Node {
 
   """MAC Address"""
   macAddress: String
+
+  """Maximum transmission unit"""
+  mtu: Int
+
+  """Link speed in Mbps"""
+  speed: Int
+
+  """Link duplex mode"""
+  duplex: String
+
+  """Whether this is an internal interface"""
+  internal: Boolean
+
+  """Whether this is a virtual interface"""
+  virtual: Boolean
+
+  """Operational state"""
+  operstate: String
+
+  """Interface type"""
+  type: String
+
+  """VLAN identifier parsed from the interface name"""
+  vlanId: Int
+
+  """IPv4 addresses assigned to this interface"""
+  ipv4Addresses: [InfoNetworkIpv4Address!]!
+
+  """IPv6 addresses assigned to this interface"""
+  ipv6Addresses: [InfoNetworkIpv6Address!]!
 
   """Connection status"""
   status: String
@@ -1961,48 +1943,6 @@ type InfoNetworkInterface implements Node {
 
   """Using DHCP for IPv6"""
   useDhcp6: Boolean
-
-  """Link speed in Mbps"""
-  speed: Int
-
-  """Duplex mode (full/half)"""
-  duplex: String
-
-  """Maximum transmission unit"""
-  mtu: Int
-
-  """Operational state"""
-  operstate: String
-
-  """Interface type"""
-  type: String
-
-  """Whether this is a virtual interface"""
-  virtual: Boolean
-
-  """VLAN identifier"""
-  vlanId: Int
-
-  """Whether this is an internal interface"""
-  internal: Boolean
-
-  """IPv4 address details"""
-  ipv4Addresses: [InfoNetworkIpv4Address!]
-
-  """IPv6 address details"""
-  ipv6Addresses: [InfoNetworkIpv6Address!]
-}
-
-"""IPv4 address information for a network interface"""
-type InfoNetworkIpv4Address {
-  address: String!
-  cidr: Int
-}
-
-"""IPv6 address information for a network interface"""
-type InfoNetworkIpv6Address {
-  address: String!
-  cidr: Int
 }
 
 type InfoOs implements Node {
@@ -2188,6 +2128,65 @@ type Info implements Node {
   primaryNetwork: InfoNetworkInterface
 }
 
+type NotificationCounts {
+  info: Int!
+  warning: Int!
+  alert: Int!
+  total: Int!
+}
+
+type NotificationOverview {
+  unread: NotificationCounts!
+  archive: NotificationCounts!
+}
+
+type Notification implements Node {
+  id: PrefixedID!
+
+  """Also known as 'event'"""
+  title: String!
+  subject: String!
+  description: String!
+  importance: NotificationImportance!
+  link: String
+  type: NotificationType!
+
+  """ISO Timestamp for when the notification occurred"""
+  timestamp: String
+  formattedTimestamp: String
+}
+
+enum NotificationImportance {
+  ALERT
+  INFO
+  WARNING
+}
+
+enum NotificationType {
+  UNREAD
+  ARCHIVE
+}
+
+type Notifications implements Node {
+  id: PrefixedID!
+
+  """A cached overview of the notifications in the system & their severity."""
+  overview: NotificationOverview!
+  list(filter: NotificationFilter!): [Notification!]!
+
+  """
+  Deduplicated list of unread warning and alert notifications, sorted latest first.
+  """
+  warningsAndAlerts: [Notification!]!
+}
+
+input NotificationFilter {
+  importance: NotificationImportance
+  type: NotificationType!
+  offset: Int!
+  limit: Int!
+}
+
 type ExplicitStatusItem {
   name: String!
   updateStatus: UpdateStatus!
@@ -2280,40 +2279,36 @@ type DockerContainer implements Node {
   autoStartWait: Int
   templatePath: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nProject/Product homepage URL"
+  """Project/Product homepage URL"""
   projectUrl: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nRegistry/Docker Hub URL"
+  """Registry/Docker Hub URL"""
   registryUrl: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nSupport page/thread URL"
+  """Support page/thread URL"""
   supportUrl: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nIcon URL"
+  """Icon URL"""
   iconUrl: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nResolved WebUI URL from template"
+  """Resolved WebUI URL from template"""
   webUiUrl: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nShell to use for console access (from template)"
+  """Shell to use for console access (from template)"""
   shell: String
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nPort mappings from template (used when container is not running)"
+  """Port mappings from template (used when container is not running)"""
   templatePorts: [ContainerPort!]
 
   """Whether the container is orphaned (no template found)"""
   isOrphaned: Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
   isUpdateAvailable: Boolean
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
   isRebuildReady: Boolean
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nWhether Tailscale is enabled for this container"
+  """Whether Tailscale is enabled for this container"""
   tailscaleEnabled: Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nTailscale status for this container (fetched via docker exec)"
+  """Tailscale status for this container (fetched via docker exec)"""
   tailscaleStatus(forceRefresh: Boolean = false): TailscaleStatus
 }
 
@@ -2443,26 +2438,16 @@ type TailscaleStatus {
 
 type Docker implements Node {
   id: PrefixedID!
+  containers(skipCache: Boolean! = false @deprecated(reason: "Caching has been removed; this parameter is now ignored")): [DockerContainer!]!
+  networks(skipCache: Boolean! = false @deprecated(reason: "Caching has been removed; this parameter is now ignored")): [DockerNetwork!]!
+  portConflicts(skipCache: Boolean! = false @deprecated(reason: "Caching has been removed; this parameter is now ignored")): DockerPortConflicts!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
-  containers(skipCache: Boolean! = false): [DockerContainer!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
-  networks(skipCache: Boolean! = false): [DockerNetwork!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
-  portConflicts(skipCache: Boolean! = false): DockerPortConflicts!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nAccess container logs. Requires specifying a target container id through resolver arguments."
+  """
+  Access container logs. Requires specifying a target container id through resolver arguments.
+  """
   logs(id: PrefixedID!, since: DateTime, tail: Int): DockerContainerLogs!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
   container(id: PrefixedID!): DockerContainer
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
-  organizer(skipCache: Boolean! = false): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
+  organizer(skipCache: Boolean! = false @deprecated(reason: "Caching has been removed; this parameter is now ignored")): ResolvedOrganizerV1!
   containerUpdateStatuses: [ExplicitStatusItem!]!
 }
 
@@ -2540,6 +2525,52 @@ type LogFileContent {
 
   """Starting line number of the content (1-indexed)"""
   startLine: Int
+}
+
+type NetworkMetrics implements Node {
+  id: PrefixedID!
+
+  """Interface identifier"""
+  name: String!
+
+  """Operational state"""
+  operstate: String
+
+  """Total received bytes"""
+  bytesReceived: BigInt!
+
+  """Total transmitted bytes"""
+  bytesSent: BigInt!
+
+  """Total received packets"""
+  packetsReceived: BigInt!
+
+  """Total transmitted packets"""
+  packetsSent: BigInt!
+
+  """Receive errors"""
+  receiveErrors: BigInt!
+
+  """Transmit errors"""
+  transmitErrors: BigInt!
+
+  """Dropped receive packets"""
+  receiveDropped: BigInt!
+
+  """Dropped transmit packets"""
+  transmitDropped: BigInt!
+
+  """Receive throughput in bytes per second"""
+  rxSec: Float!
+
+  """Transmit throughput in bytes per second"""
+  txSec: Float!
+
+  """Estimated link utilization percentage"""
+  utilizationPercent: Float
+
+  """Metric collection timestamp"""
+  lastUpdated: DateTime!
 }
 
 type TemperatureReading {
@@ -2655,20 +2686,8 @@ type Metrics implements Node {
   """Temperature metrics"""
   temperature: TemperatureMetrics
 
-  """Network interface metrics"""
-  network: NetworkMetrics
-}
-
-"""Network interface metrics"""
-type NetworkMetrics {
-  """Network interface name"""
-  interface: String!
-
-  """Bytes received per second"""
-  rxBytesPerSec: Float
-
-  """Bytes transmitted per second"""
-  txBytesPerSec: Float
+  """Current network metrics for all interfaces"""
+  network: [NetworkMetrics!]!
 }
 
 type SensorConfig {
@@ -2740,6 +2759,14 @@ enum ServerStatus {
   ONLINE
   OFFLINE
   NEVER_CONNECTED
+}
+
+type ApiConfig {
+  version: String!
+  extraOrigins: [String!]!
+  sandbox: Boolean
+  ssoSubIds: [String!]!
+  plugins: [String!]!
 }
 
 type OidcAuthorizationRule {
@@ -3250,110 +3277,66 @@ input AccessUrlObjectInput {
 scalar PrefixedID
 
 type Query {
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **API_KEY**"
   apiKeys: [ApiKey!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **API_KEY**"
   apiKey(id: PrefixedID!): ApiKey
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **PERMISSION**\n\n#### Description:\n\nAll possible roles for API keys"
+  """All possible roles for API keys"""
   apiKeyPossibleRoles: [Role!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **PERMISSION**\n\n#### Description:\n\nAll possible permissions for API keys"
+  """All possible permissions for API keys"""
   apiKeyPossiblePermissions: [Permission!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **PERMISSION**\n\n#### Description:\n\nGet the actual permissions that would be granted by a set of roles"
+  """Get the actual permissions that would be granted by a set of roles"""
   getPermissionsForRoles(roles: [Role!]!): [Permission!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **PERMISSION**\n\n#### Description:\n\nPreview the effective permissions for a combination of roles and explicit permissions"
+  """
+  Preview the effective permissions for a combination of roles and explicit permissions
+  """
   previewEffectivePermissions(roles: [Role!], permissions: [AddPermissionInput!]): [Permission!]!
 
   """Get all available authentication actions with possession"""
   getAvailableAuthActions: [AuthAction!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **API_KEY**\n\n#### Description:\n\nGet JSON Schema for API key creation form"
+  """Get JSON Schema for API key creation form"""
   getApiKeyCreationFormSchema: ApiKeyFormSettings!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**"
   config: Config!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DISPLAY**"
   display: InfoDisplay!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **FLASH**"
   flash: Flash!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ME**"
   me: UserAccount!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **NOTIFICATIONS**\n\n#### Description:\n\nGet all notifications"
+  """Get all notifications"""
   notifications: Notifications!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ONLINE**"
   online: Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **OWNER**"
   owner: Owner!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **WELCOME**\n\n#### Description:\n\nGet the latest onboarding context for configuring internal boot"
+  """Get the latest onboarding context for configuring internal boot"""
   internalBootContext: OnboardingInternalBootContext!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **REGISTRATION**"
   registration: Registration
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **SERVERS**"
   server: Server
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **SERVERS**"
   servers: [Server!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **SERVICES**"
   services: [Service!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **SHARE**"
   shares: [Share!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **VARS**"
   vars: Vars!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **VMS**\n\n#### Description:\n\nGet information about all VMs on the system"
+  """Get information about all VMs on the system"""
   vms: Vms!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ARRAY**"
   parityHistory: [ParityCheck!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ARRAY**"
   array: UnraidArray!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CUSTOMIZATIONS**"
   customization: Customization
 
   """Whether the system is a fresh install (no license key)"""
   isFreshInstall: Boolean!
   publicTheme: Theme!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
   info: Info!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
+  """Network interfaces"""
+  networkInterfaces: [InfoNetworkInterface!]!
   docker: Docker!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DISK**"
   disks: [Disk!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DISK**"
   assignableDisks: [Disk!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DISK**"
   disk(id: PrefixedID!): Disk!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **FLASH**"
   rclone: RCloneBackupSettings!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **LOGS**"
   logFiles: [LogFile!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **LOGS**"
   logFile(path: String!, lines: Int, startLine: Int): LogFileContent!
   settings: Settings!
   isSSOEnabled: Boolean!
@@ -3361,56 +3344,43 @@ type Query {
   """Get public OIDC provider information for login buttons"""
   publicOidcProviders: [PublicOidcProvider!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nGet all configured OIDC providers (admin only)"
+  """Get all configured OIDC providers (admin only)"""
   oidcProviders: [OidcProvider!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nGet a specific OIDC provider by ID"
+  """Get a specific OIDC provider by ID"""
   oidcProvider(id: PrefixedID!): OidcProvider
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nGet the full OIDC configuration (admin only)"
+  """Get the full OIDC configuration (admin only)"""
   oidcConfiguration: OidcConfiguration!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nValidate an OIDC session token (internal use for CLI validation)"
+  """Validate an OIDC session token (internal use for CLI validation)"""
   validateOidcSession(token: String!): OidcSessionValidation!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
   metrics: Metrics!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **VARS**\n\n#### Description:\n\nRetrieve current system time configuration"
+  """Retrieve current system time configuration"""
   systemTime: SystemTime!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nRetrieve available time zone options"
+  """Retrieve available time zone options"""
   timeZoneOptions: [TimeZoneOption!]!
   upsDevices: [UPSDevice!]!
   upsDeviceById(id: String!): UPSDevice
   upsConfiguration: UPSConfiguration!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nRetrieve a plugin installation operation by identifier"
+  """Retrieve a plugin installation operation by identifier"""
   pluginInstallOperation(operationId: ID!): PluginInstallOperation
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nList all tracked plugin installation operations"
+  """List all tracked plugin installation operations"""
   pluginInstallOperations: [PluginInstallOperation!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nList installed Unraid OS plugins by .plg filename"
+  """List installed Unraid OS plugins by .plg filename"""
   installedUnraidPlugins: [String!]!
 
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nList all installed plugins with their metadata"
+  """List all installed plugins with their metadata"""
   plugins: [Plugin!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONNECT**"
   remoteAccess: RemoteAccess!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONNECT**"
   connect: Connect!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **NETWORK**"
   network: Network!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CLOUD**"
   cloud: Cloud!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**\n\n#### Description:\n\nGet all network interfaces"
-  networkInterfaces: [InfoNetworkInterface!]!
 }
 
 type Mutation {
@@ -3448,77 +3418,47 @@ type Mutation {
   onboarding: OnboardingMutations!
   unraidPlugins: UnraidPluginsMutations!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **SERVERS**\n\n#### Description:\n\nUpdate server name, comment, and model"
+  """Update server name, comment, and model"""
   updateServerIdentity(name: String!, comment: String, sysModel: String): Server!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **VARS**"
   updateSshSettings(input: UpdateSshInput!): Vars!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   createDockerFolder(name: String!, parentId: String, childrenIds: [String!]): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   setDockerFolderChildren(folderId: String, childrenIds: [String!]!): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   deleteDockerEntries(entryIds: [String!]!): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   moveDockerEntriesToFolder(sourceEntryIds: [String!]!, destinationFolderId: String!): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   moveDockerItemsToPosition(sourceEntryIds: [String!]!, destinationFolderId: String!, position: Float!): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   renameDockerFolder(folderId: String!, newName: String!): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   createDockerFolderWithItems(name: String!, parentId: String, sourceEntryIds: [String!], position: Float): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   updateDockerViewPreferences(viewId: String = "default", prefs: JSON!): ResolvedOrganizerV1!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   syncDockerTemplatePaths: DockerTemplateSyncResult!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**\n\n#### Description:\n\nReset Docker template mappings to defaults. Use this to recover from corrupted state."
+  """
+  Reset Docker template mappings to defaults. Use this to recover from corrupted state.
+  """
   resetDockerTemplateMappings: Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **DOCKER**"
   refreshDockerDigests: Boolean!
 
   """Initiates a flash drive backup using a configured remote."""
   initiateFlashBackup(input: InitiateFlashBackupInput!): FlashBackupStatus!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONFIG**"
   updateSettings(input: JSON!): UpdateSettingsResponse!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **INFO**"
   updateTemperatureConfig(input: TemperatureConfigInput!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nUpdate system time configuration"
+  """Update system time configuration"""
   updateSystemTime(input: UpdateSystemTimeInput!): SystemTime!
   configureUps(config: UPSConfigInput!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nAdd one or more plugins to the API. Returns false if restart was triggered automatically, true if manual restart is required."
+  """
+  Add one or more plugins to the API. Returns false if restart was triggered automatically, true if manual restart is required.
+  """
   addPlugin(input: PluginManagementInput!): Boolean!
 
-  "\n#### Required Permissions:\n\n- Action: **DELETE_ANY**\n- Resource: **CONFIG**\n\n#### Description:\n\nRemove one or more plugins from the API. Returns false if restart was triggered automatically, true if manual restart is required."
+  """
+  Remove one or more plugins from the API. Returns false if restart was triggered automatically, true if manual restart is required.
+  """
   removePlugin(input: PluginManagementInput!): Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONFIG**"
   updateApiSettings(input: ConnectSettingsInput!): ConnectSettingsValues!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONNECT**"
   connectSignIn(input: ConnectSignInInput!): Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONNECT**"
   connectSignOut: Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONNECT**"
   setupRemoteAccess(input: SetupRemoteAccessInput!): Boolean!
-
-  "\n#### Required Permissions:\n\n- Action: **UPDATE_ANY**\n- Resource: **CONNECT__REMOTE_ACCESS**"
   enableDynamicRemoteAccess(input: EnableDynamicRemoteAccessInput!): Boolean!
 }
 
@@ -3766,52 +3706,21 @@ input AccessUrlInput {
 }
 
 type Subscription {
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DISPLAY**"
   displaySubscription: InfoDisplay!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **NOTIFICATIONS**"
   notificationAdded: Notification!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **NOTIFICATIONS**"
   notificationsOverview: NotificationOverview!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **NOTIFICATIONS**"
   notificationsWarningsAndAlerts: [Notification!]!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **OWNER**"
   ownerSubscription: Owner!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **SERVERS**"
   serversSubscription: Server!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ARRAY**"
   parityHistorySubscription: ParityCheck!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **ARRAY**"
   arraySubscription: UnraidArray!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **DOCKER**"
   dockerContainerStats: DockerContainerStats!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **LOGS**"
   logFile(path: String!): LogFileContent!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
   systemMetricsCpu: CpuUtilization!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
   systemMetricsCpuTelemetry: CpuPackages!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
   systemMetricsMemory: MemoryUtilization!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
+  systemMetricsNetwork: [NetworkMetrics!]!
   systemMetricsTemperature: TemperatureMetrics
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **INFO**"
-  systemMetricsNetwork: NetworkMetrics!
   upsUpdates: UPSDevice!
-
-  "\n#### Required Permissions:\n\n- Action: **READ_ANY**\n- Resource: **CONFIG**"
   pluginInstallUpdates(operationId: ID!): PluginInstallEvent!
 }

--- a/tests/http_layer/test_request_construction.py
+++ b/tests/http_layer/test_request_construction.py
@@ -325,11 +325,14 @@ class TestInfoToolRequests:
             return_value=_graphql_response(
                 {
                     "metrics": {
-                        "network": {
-                            "interface": "eth0",
-                            "rxBytesPerSec": 1.0,
-                            "txBytesPerSec": 2.0,
-                        }
+                        "network": [
+                            {
+                                "id": "metrics:eth0",
+                                "name": "eth0",
+                                "bytesReceived": 1,
+                                "bytesSent": 2,
+                            }
+                        ]
                     }
                 }
             )
@@ -341,8 +344,8 @@ class TestInfoToolRequests:
         assert "GetNetworkMetrics" in body["query"]
         assert "metrics" in body["query"]
         assert "network" in body["query"]
-        assert "rxBytesPerSec" in body["query"]
-        assert "txBytesPerSec" in body["query"]
+        assert "bytesReceived" in body["query"]
+        assert "rxSec" in body["query"]
 
     @respx.mock
     async def test_network_interfaces_sends_correct_query(self) -> None:
@@ -353,7 +356,7 @@ class TestInfoToolRequests:
                         {
                             "id": "net:eth0",
                             "name": "eth0",
-                            "ipv4Addresses": [{"address": "10.1.0.2", "cidr": 24}],
+                            "ipv4Addresses": [{"address": "10.1.0.2", "netmask": "255.255.255.0"}],
                             "ipv6Addresses": [],
                         }
                     ]

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -189,8 +189,8 @@ class TestUnraidInfoTool:
                     "virtual": False,
                     "vlanId": None,
                     "internal": False,
-                    "ipv4Addresses": [{"address": "10.1.0.2", "cidr": 24}],
-                    "ipv6Addresses": [{"address": "fd7a:115c:a1e0::1", "cidr": 64}],
+                    "ipv4Addresses": [{"address": "10.1.0.2", "netmask": "255.255.255.0"}],
+                    "ipv6Addresses": [{"address": "fd7a:115c:a1e0::1", "prefixLength": 64}],
                 }
             ]
         }
@@ -201,10 +201,10 @@ class TestUnraidInfoTool:
         assert "ipv4Addresses" in query
         assert "ipv6Addresses" in query
         assert result["network_interfaces"][0]["ipv4Addresses"] == [
-            {"address": "10.1.0.2", "cidr": 24}
+            {"address": "10.1.0.2", "netmask": "255.255.255.0"}
         ]
         assert result["network_interfaces"][0]["ipv6Addresses"] == [
-            {"address": "fd7a:115c:a1e0::1", "cidr": 64}
+            {"address": "fd7a:115c:a1e0::1", "prefixLength": 64}
         ]
         assert result["page"]["truncated"] is False
 
@@ -228,11 +228,17 @@ class TestUnraidInfoTool:
     ) -> None:
         _mock_graphql.return_value = {
             "metrics": {
-                "network": {
-                    "interface": "eth0",
-                    "rxBytesPerSec": 1024.0,
-                    "txBytesPerSec": 2048.0,
-                },
+                "network": [
+                    {
+                        "id": "metrics:eth0",
+                        "name": "eth0",
+                        "operstate": "up",
+                        "bytesReceived": 1024,
+                        "bytesSent": 2048,
+                        "rxSec": 100.0,
+                        "txSec": 200.0,
+                    },
+                ],
             }
         }
         tool_fn = _make_tool()
@@ -240,15 +246,21 @@ class TestUnraidInfoTool:
 
         query = _mock_graphql.call_args.args[0]
         assert "network" in query
-        assert "rxBytesPerSec" in query
-        assert "txBytesPerSec" in query
-        assert result == {
-            "interface": "eth0",
-            "rxBytesPerSec": 1024.0,
-            "txBytesPerSec": 2048.0,
-        }
+        assert "bytesReceived" in query
+        assert "rxSec" in query
+        assert result["network"] == [
+            {
+                "id": "metrics:eth0",
+                "name": "eth0",
+                "operstate": "up",
+                "bytesReceived": 1024,
+                "bytesSent": 2048,
+                "rxSec": 100.0,
+                "txSec": 200.0,
+            }
+        ]
 
-    @pytest.mark.parametrize("payload", [{}, {"metrics": None}, {"metrics": {"network": []}}])
+    @pytest.mark.parametrize("payload", [{}, {"metrics": None}, {"metrics": {"network": {}}}])
     async def test_network_metrics_requires_network_payload(
         self, _mock_graphql: AsyncMock, payload: dict
     ) -> None:

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -260,6 +260,32 @@ class TestUnraidInfoTool:
             }
         ]
 
+    async def test_network_metrics_are_capped(self, _mock_graphql: AsyncMock) -> None:
+        _mock_graphql.return_value = {
+            "metrics": {
+                "network": [{"id": f"metrics:eth{idx}", "name": f"eth{idx}"} for idx in range(3)]
+            }
+        }
+        tool_fn = _make_tool()
+        result = await tool_fn(action="system", subaction="network_metrics", limit=2)
+
+        assert [interface["name"] for interface in result["network"]] == ["eth0", "eth1"]
+        assert result["page"]["returned"] == 2
+        assert result["page"]["total"] == 3
+        assert result["page"]["truncated"] is True
+
+    async def test_network_metrics_accepts_empty_interface_list(
+        self, _mock_graphql: AsyncMock
+    ) -> None:
+        _mock_graphql.return_value = {"metrics": {"network": []}}
+        tool_fn = _make_tool()
+        result = await tool_fn(action="system", subaction="network_metrics")
+
+        assert result == {
+            "network": [],
+            "page": {"returned": 0, "total": 0, "truncated": False},
+        }
+
     @pytest.mark.parametrize("payload", [{}, {"metrics": None}, {"metrics": {"network": {}}}])
     async def test_network_metrics_requires_network_payload(
         self, _mock_graphql: AsyncMock, payload: dict

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -353,8 +353,27 @@ async def test_network_metrics_returns_snapshot(_mock_subscribe_once, _cold_cach
     result = await _make_tool()(action="live", subaction="network_metrics")
     assert result["success"] is True
     assert result["data"]["systemMetricsNetwork"][0]["name"] == "eth0"
+    assert result["page"] == {"returned": 1, "total": 1, "truncated": False}
     query = _mock_subscribe_once.call_args.args[0]
     assert "systemMetricsNetwork" in query
+
+
+@pytest.mark.asyncio
+async def test_network_metrics_snapshot_is_capped(_mock_subscribe_once, _cold_cache):
+    _mock_subscribe_once.return_value = {
+        "systemMetricsNetwork": [
+            {"id": f"metrics:eth{idx}", "name": f"eth{idx}"} for idx in range(3)
+        ]
+    }
+    result = await _make_tool()(action="live", subaction="network_metrics", limit=2)
+    assert result["success"] is True
+    assert [iface["name"] for iface in result["data"]["systemMetricsNetwork"]] == [
+        "eth0",
+        "eth1",
+    ]
+    assert result["page"]["returned"] == 2
+    assert result["page"]["total"] == 3
+    assert result["page"]["truncated"] is True
 
 
 @pytest.mark.asyncio
@@ -436,6 +455,32 @@ async def test_event_driven_snapshot_served_from_warm_cache(_warm_cache, _mock_s
 
     assert result["source"] == "cache"
     assert result["data"]["displaySubscription"]["theme"] == "black"
+    _mock_subscribe_once.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_network_metrics_warm_cache_is_capped(_warm_cache, _mock_subscribe_once):
+    """The warm-cache network_metrics path caps the interface list too."""
+    _seed_warm(
+        _warm_cache,
+        "network_metrics",
+        {
+            "systemMetricsNetwork": [
+                {"id": f"metrics:eth{idx}", "name": f"eth{idx}"} for idx in range(3)
+            ]
+        },
+    )
+
+    result = await _make_tool()(action="live", subaction="network_metrics", limit=2)
+
+    assert result["source"] == "cache"
+    assert [iface["name"] for iface in result["data"]["systemMetricsNetwork"]] == [
+        "eth0",
+        "eth1",
+    ]
+    assert result["page"]["returned"] == 2
+    assert result["page"]["total"] == 3
+    assert result["page"]["truncated"] is True
     _mock_subscribe_once.assert_not_called()
 
 

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -341,15 +341,18 @@ async def test_notifications_warnings_returns_snapshot(_mock_subscribe_once, _co
 @pytest.mark.asyncio
 async def test_network_metrics_returns_snapshot(_mock_subscribe_once, _cold_cache):
     _mock_subscribe_once.return_value = {
-        "systemMetricsNetwork": {
-            "interface": "eth0",
-            "rxBytesPerSec": 1024.0,
-            "txBytesPerSec": 2048.0,
-        }
+        "systemMetricsNetwork": [
+            {
+                "id": "metrics:eth0",
+                "name": "eth0",
+                "bytesReceived": 1024,
+                "bytesSent": 2048,
+            }
+        ]
     }
     result = await _make_tool()(action="live", subaction="network_metrics")
     assert result["success"] is True
-    assert result["data"]["systemMetricsNetwork"]["interface"] == "eth0"
+    assert result["data"]["systemMetricsNetwork"][0]["name"] == "eth0"
     query = _mock_subscribe_once.call_args.args[0]
     assert "systemMetricsNetwork" in query
 

--- a/tests/test_live.sh
+++ b/tests/test_live.sh
@@ -493,7 +493,7 @@ run_phase4() {
     "subscriptions" "test_query" \
     "$system_metrics_network_schema_re" \
     "systemMetricsNetwork requires newer/compatible Unraid API schema" \
-    '{"subscription_query":"subscription { systemMetricsNetwork { interface rxBytesPerSec txBytesPerSec } }"}'
+    '{"subscription_query":"subscription { systemMetricsNetwork { id name bytesReceived bytesSent rxSec txSec } }"}'
 
   # Phase 4b — Destructive guard bypass (confirm=True)
   section "Phase 4b · Destructive action guards (confirm=True bypass)"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -87,7 +87,7 @@ class TestLiveResourcesUseManagerCache:
 
     @pytest.mark.usefixtures("_mock_ensure_started")
     async def test_non_autostart_resource_uses_on_demand_fetch(self) -> None:
-        fallback_data = {"systemMetricsNetwork": {"interface": "eth0"}}
+        fallback_data = {"systemMetricsNetwork": [{"id": "metrics:eth0", "name": "eth0"}]}
         with (
             patch("unraid_mcp.subscriptions.resources.subscription_manager") as mock_mgr,
             patch(

--- a/tests/test_subscription_validation.py
+++ b/tests/test_subscription_validation.py
@@ -32,7 +32,7 @@ class TestValidateSubscriptionQueryAllowed:
     def test_system_metrics_network_accepted(self) -> None:
         assert (
             _validate_subscription_query(
-                "subscription { systemMetricsNetwork { interface rxBytesPerSec txBytesPerSec } }"
+                "subscription { systemMetricsNetwork { id name bytesReceived bytesSent } }"
             )
             == "systemMetricsNetwork"
         )

--- a/unraid_mcp/subscriptions/queries.py
+++ b/unraid_mcp/subscriptions/queries.py
@@ -55,7 +55,7 @@ SNAPSHOT_ACTIONS = {
         subscription { displaySubscription { id theme unit scale locale total usage warning critical hot max } }
     """,
     "network_metrics": """
-        subscription { systemMetricsNetwork { interface rxBytesPerSec txBytesPerSec } }
+        subscription { systemMetricsNetwork { id name operstate bytesReceived bytesSent packetsReceived packetsSent receiveErrors transmitErrors receiveDropped transmitDropped rxSec txSec utilizationPercent lastUpdated } }
     """,
 }
 

--- a/unraid_mcp/tools/_live.py
+++ b/unraid_mcp/tools/_live.py
@@ -29,6 +29,23 @@ from ._disk import _ALLOWED_LOG_PREFIXES, _validate_path
 _LIVE_EVENT_BYTE_BUDGET: int = max(1, UNRAID_MCP_MAX_RESPONSE_BYTES // 2)
 
 
+def _cap_network_metrics(
+    data: dict[str, Any], limit: int | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Cap the per-interface list in a ``systemMetricsNetwork`` snapshot payload.
+
+    ``systemMetricsNetwork`` moved from a single object to one entry per network
+    interface upstream — cap it the same way every other list subaction is
+    capped (``cap_list``) so a heavily virtualized/VLAN-heavy host can't return
+    an unbounded interface list through the live snapshot path.
+    """
+    network = data.get("systemMetricsNetwork")
+    if not isinstance(network, list):
+        return data, {"returned": 0, "total": 0, "truncated": False}
+    capped, meta = cap_list(network, limit)
+    return {**data, "systemMetricsNetwork": capped}, meta
+
+
 def _filter_log_event(event: dict[str, Any], level: str, context: int) -> dict[str, Any]:
     """Apply severity/context filtering to a single log_tail event's content.
 
@@ -103,6 +120,15 @@ async def _handle_live(
                         "live/%s served from warm subscription cache (skipped fresh WS)",
                         subaction,
                     )
+                    if subaction == "network_metrics":
+                        capped_data, page = _cap_network_metrics(cached, limit)
+                        return {
+                            "success": True,
+                            "subaction": subaction,
+                            "source": "cache",
+                            "data": capped_data,
+                            "page": page,
+                        }
                     return {
                         "success": True,
                         "subaction": subaction,
@@ -124,6 +150,15 @@ async def _handle_live(
                     raise
             else:
                 data = await subscribe_once(SNAPSHOT_ACTIONS[subaction], timeout=timeout)
+            if subaction == "network_metrics":
+                capped_data, page = _cap_network_metrics(data, limit)
+                return {
+                    "success": True,
+                    "subaction": subaction,
+                    "source": "live",
+                    "data": capped_data,
+                    "page": page,
+                }
             return {"success": True, "subaction": subaction, "source": "live", "data": data}
 
         if subaction == "log_tail":

--- a/unraid_mcp/tools/_system.py
+++ b/unraid_mcp/tools/_system.py
@@ -76,7 +76,7 @@ _SYSTEM_QUERIES: dict[str, str] = {
         }
     """,
     "metrics": "query GetMetrics { metrics { cpu { percentTotal } memory { total used free available buffcache percentTotal } } }",
-    "network_metrics": "query GetNetworkMetrics { metrics { network { interface rxBytesPerSec txBytesPerSec } } }",
+    "network_metrics": "query GetNetworkMetrics { metrics { network { id name operstate bytesReceived bytesSent packetsReceived packetsSent receiveErrors transmitErrors receiveDropped transmitDropped rxSec txSec utilizationPercent lastUpdated } } }",
     "services": "query GetServices { services { name online version } }",
     "display": "query GetDisplay { info { display { theme } } }",
     "display_details": """
@@ -170,8 +170,8 @@ _SYSTEM_QUERIES: dict[str, str] = {
             virtual
             vlanId
             internal
-            ipv4Addresses { address cidr }
-            ipv6Addresses { address cidr }
+            ipv4Addresses { address netmask }
+            ipv6Addresses { address prefixLength }
           }
         }
     """,
@@ -362,12 +362,13 @@ async def _handle_system(subaction: str, device_id: str | None, limit: int = 20)
             return dict(values) if isinstance(values, dict) else {"raw": values}
         if subaction == "network_metrics":
             network = safe_get(data, "metrics", "network", default=None)
-            if not isinstance(network, dict):
+            if not isinstance(network, list):
                 raise ToolError(
                     "Unraid API returned no metrics.network payload for "
                     "system/network_metrics. Check API version, permissions, and server logs."
                 )
-            return dict(network)
+            capped, meta = cap_list(network, limit)
+            return {"network": capped, "page": meta}
         if subaction == "server":
             info = data.get("info") or {}
             summary: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- Re-vendor `docs/unraid/UNRAID-SCHEMA.graphql` from `unraid/api@main` to pick up the latest upstream SDL (mostly cosmetic doc-comment reformatting, but with real breaking changes to network metrics)
- `Metrics.network` and `Subscription.systemMetricsNetwork` changed from a single `NetworkMetrics` object to `[NetworkMetrics!]!` (one entry per interface), with `interface`/`rxBytesPerSec`/`txBytesPerSec` replaced by a much richer set of counters (`bytesReceived`, `bytesSent`, `packetsReceived`, `packetsSent`, `receiveErrors`, `transmitErrors`, `receiveDropped`, `transmitDropped`, `rxSec`, `txSec`, `utilizationPercent`, `lastUpdated`, plus `id`/`name`/`operstate`)
- `InfoNetworkIpv4Address.cidr` → `netmask`, `InfoNetworkIpv6Address.cidr` → `prefixLength`
- Updated `system/network_metrics` and `live/network_metrics` GraphQL query strings to select the new `NetworkMetrics` fields
- `system/network_metrics` now returns `{"network": [...], "page": {...}}` (capped via `cap_list`, same pattern as `system/network_interfaces`) instead of a single flattened object, since the API now returns one entry per interface
- Updated `system/network_interfaces` query to select `netmask`/`prefixLength` instead of the removed `cidr` fields
- Updated affected tests (`tests/test_info.py`, `tests/test_live.py`, `tests/test_resources.py`, `tests/http_layer/test_request_construction.py`, `tests/test_subscription_validation.py`, `tests/test_live.sh`) to match the new response shapes

Closes #138

## Test plan
- [x] `uv run pytest -q` — 1775 passed, 9 skipped (skips are pre-existing, unrelated `npm` mock-fixture setup)
- [x] `uv run ruff check unraid_mcp/ tests/`
- [x] `uv run ruff format --check unraid_mcp/ tests/`
- [x] `uv run ty check unraid_mcp/`
- [x] `tests/schema/test_query_validation.py` validates the updated queries against the re-vendored SDL


---
_Generated by [Claude Code](https://claude.ai/code/session_019RcENHF3E9RLPxz9ztQJ3b)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update to the latest Unraid GraphQL schema and migrate network metrics to a per-interface list with richer counters. Also align IPv4/IPv6 address fields and cap both system and live network metrics to avoid unbounded responses.

- **Migration**
  - `metrics.network` and `systemMetricsNetwork` now return `[NetworkMetrics!]!` with fields: `id`, `name`, `operstate`, `bytesReceived`, `bytesSent`, `packetsReceived`, `packetsSent`, `receiveErrors`, `transmitErrors`, `receiveDropped`, `transmitDropped`, `rxSec`, `txSec`, `utilizationPercent`, `lastUpdated`.
  - `system/network_metrics` now returns `{"network": [...], "page": {...}}` capped via `cap_list` (same as `system/network_interfaces`).
  - IPv4/IPv6 fields changed: `InfoNetworkIpv4Address.netmask` replaces `cidr`; `InfoNetworkIpv6Address.prefixLength` replaces `cidr`.
  - Re-vendored `docs/unraid/UNRAID-SCHEMA.graphql`; refreshed API docs; updated queries in `unraid_mcp/tools/_system.py` and `unraid_mcp/subscriptions/queries.py`; adjusted tests and mocks.

- **Bug Fixes**
  - Cap the per-interface list in `live/network_metrics` snapshots (both warm-cache and fresh WS paths) and return `page` meta to match `system/network_metrics`.

<sup>Written for commit 059d0b0588fb109002d21333958e0e73a7ef7c0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/jmagar/unraid-mcp/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

