### PR TITLE
fix: stop plugin manifests from shadowing .env config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,17 @@ RUN mkdir -p /app/logs /app/backups /home/mcp/.unraid-mcp && \
     chown -R mcp:mcp /app/logs /app/backups /home/mcp/.unraid-mcp && \
     chmod 700 /home/mcp/.unraid-mcp
 
-# Default env — overridden by .env / docker-compose
-ENV UNRAID_MCP_TRANSPORT=streamable-http \
-    UNRAID_MCP_HOST=0.0.0.0 \
-    UNRAID_MCP_PORT=6970 \
-    UNRAID_MCP_LOG_LEVEL=INFO
+# UNRAID_MCP_HOST is the only var that genuinely needs a container-specific value
+# (the package default 127.0.0.1 would make the server unreachable from outside the
+# container network namespace). UNRAID_MCP_TRANSPORT/_PORT/_LOG_LEVEL are deliberately
+# NOT baked in here even though they used to match this image's intended defaults:
+# _load_env_files() loads ~/.unraid-mcp/.env with load_dotenv(override=False), so a
+# value already present in the process env (as these would be, coming from an image
+# ENV) permanently shadows the same var configured in that .env file. Package
+# defaults (streamable-http / 6970 / INFO — see unraid_mcp/config/settings.py) apply
+# identically when unset, so baking them in here would only ever silently block a
+# user's own configuration, never add real value (see issue #137).
+ENV UNRAID_MCP_HOST=0.0.0.0
 
 EXPOSE 6970
 

--- a/plugins/unraid/.codex-plugin/plugin.json
+++ b/plugins/unraid/.codex-plugin/plugin.json
@@ -21,12 +21,7 @@
         "unraid-mcp"
       ],
       "env": {
-        "UNRAID_MCP_TRANSPORT": "stdio",
-        "UNRAID_VERIFY_SSL": "true",
-        "UNRAID_MCP_LOG_LEVEL": "INFO",
-        "UNRAID_MCP_LOG_FILE": "unraid-mcp.log",
-        "UNRAID_AUTO_START_SUBSCRIPTIONS": "true",
-        "UNRAID_MAX_RECONNECT_ATTEMPTS": "10"
+        "UNRAID_MCP_TRANSPORT": "stdio"
       },
       "env_vars": [
         "UNRAID_API_URL",

--- a/plugins/unraid/.mcp.json
+++ b/plugins/unraid/.mcp.json
@@ -8,12 +8,7 @@
       "env": {
         "UNRAID_MCP_TRANSPORT": "stdio",
         "UNRAID_API_URL": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_URL}",
-        "UNRAID_API_KEY": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}",
-        "UNRAID_VERIFY_SSL": "true",
-        "UNRAID_MCP_LOG_LEVEL": "INFO",
-        "UNRAID_MCP_LOG_FILE": "unraid-mcp.log",
-        "UNRAID_AUTO_START_SUBSCRIPTIONS": "true",
-        "UNRAID_MAX_RECONNECT_ATTEMPTS": "10"
+        "UNRAID_API_KEY": "${CLAUDE_PLUGIN_OPTION_UNRAID_API_KEY}"
       }
     }
   }

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -18,6 +18,52 @@ def test_plugin_manifest_restores_stdio_server_definition() -> None:
     assert plugin["mcpServers"] == "./.mcp.json"
 
 
+def test_plugin_manifests_do_not_hardcode_env_configurable_defaults() -> None:
+    """Regression coverage for GitHub issue #137.
+
+    ``.mcp.json`` (Claude Code) and ``.codex-plugin/plugin.json`` (Codex) used to
+    hardcode ``UNRAID_VERIFY_SSL=true`` in their ``env`` block. Because
+    ``_load_env_files()`` uses ``load_dotenv(override=False)``, a value already
+    present in the process env from these manifests permanently shadows the same
+    var configured in ``~/.unraid-mcp/.env`` — so a user pointing
+    ``UNRAID_VERIFY_SSL`` at a CA-bundle path for a self-signed cert had that
+    silently ignored. The same shadowing risk applies to any other var these
+    manifests hardcode to a value that merely duplicates the package default
+    (``UNRAID_MCP_LOG_LEVEL``, ``UNRAID_MCP_LOG_FILE``,
+    ``UNRAID_AUTO_START_SUBSCRIPTIONS``, ``UNRAID_MAX_RECONNECT_ATTEMPTS``) —
+    none of them serve a purpose beyond matching ``Settings()``'s own default,
+    so none of them belong in the manifest. ``UNRAID_MCP_TRANSPORT=stdio`` is
+    the one legitimate exception: it differs from the package default
+    (``streamable-http``) and is mandatory for a plugin-launched subprocess,
+    which talks to its host over stdio.
+    """
+    shadowing_prone_vars = {
+        "UNRAID_VERIFY_SSL",
+        "UNRAID_MCP_LOG_LEVEL",
+        "UNRAID_MCP_LOG_FILE",
+        "UNRAID_AUTO_START_SUBSCRIPTIONS",
+        "UNRAID_MAX_RECONNECT_ATTEMPTS",
+    }
+
+    mcp_json = json.loads((PROJECT_ROOT / "plugins" / "unraid" / ".mcp.json").read_text())
+    mcp_env = mcp_json["mcpServers"]["unraid-mcp"]["env"]
+
+    codex_manifest = json.loads(
+        (PROJECT_ROOT / "plugins" / "unraid" / ".codex-plugin" / "plugin.json").read_text()
+    )
+    codex_env = codex_manifest["mcpServers"]["unraid-mcp"]["env"]
+
+    for env_block, label in ((mcp_env, ".mcp.json"), (codex_env, ".codex-plugin/plugin.json")):
+        leaked = shadowing_prone_vars & env_block.keys()
+        assert not leaked, (
+            f"{label} hardcodes {leaked}, which duplicates a Settings() default and would "
+            "silently shadow the same var configured in ~/.unraid-mcp/.env "
+            "(load_dotenv(override=False)) — see issue #137"
+        )
+        # The mandatory transport override must still be present.
+        assert env_block.get("UNRAID_MCP_TRANSPORT") == "stdio"
+
+
 def test_ci_gates_live_integration_job_on_unraid_secrets() -> None:
     workflow = (PROJECT_ROOT / ".github" / "workflows" / "ci.yml").read_text()
     # Secrets are mapped to env vars at job level; step if-condition checks env vars

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -82,6 +82,46 @@ def test_container_configs_use_runtime_port_variable() -> None:
     assert "${UNRAID_MCP_PORT:-6970}" in dockerfile
 
 
+def test_dockerfile_does_not_hardcode_env_configurable_defaults() -> None:
+    """Regression coverage for GitHub issue #137 (Dockerfile half of the fix).
+
+    The image used to bake ``ENV UNRAID_MCP_TRANSPORT=streamable-http`` and
+    ``UNRAID_MCP_LOG_LEVEL=INFO`` — both byte-identical to ``Settings()``'s own
+    defaults. Because ``_load_env_files()`` uses ``load_dotenv(override=False)``,
+    a value already present in the process env from an image ``ENV`` permanently
+    shadows the same var configured in the container-local
+    ``~/.unraid-mcp/.env`` (populated via the ``health/setup`` elicitation flow,
+    distinct from the host-side ``.env`` docker-compose's ``env_file:`` passes
+    through — that path already works correctly since compose-supplied runtime
+    env beats image ``ENV``). Neither var needs a container-specific value, so
+    neither belongs in the image. ``UNRAID_MCP_HOST=0.0.0.0`` is the one
+    legitimate exception: it differs from the package default (``127.0.0.1``)
+    and is required for the server to be reachable from outside the container's
+    network namespace. ``UNRAID_MCP_PORT`` was dropped too — every place that
+    reads it (the healthcheck here and in docker-compose.yaml) already has its
+    own ``${UNRAID_MCP_PORT:-6970}`` shell-level fallback, so baking it into the
+    image added nothing but the same shadowing risk.
+    """
+    dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
+    # Strip comment lines so this test isn't tripped up by its own docstring-style
+    # explanatory comments in the Dockerfile mentioning these var names in prose.
+    code_lines = "\n".join(
+        line for line in dockerfile.splitlines() if not line.strip().startswith("#")
+    )
+    for shadowing_prone_var in (
+        "UNRAID_MCP_TRANSPORT=",
+        "UNRAID_MCP_PORT=",
+        "UNRAID_MCP_LOG_LEVEL=",
+    ):
+        assert shadowing_prone_var not in code_lines, (
+            f"Dockerfile bakes {shadowing_prone_var!r}, which duplicates a Settings() "
+            "default and would silently shadow the same var configured in the "
+            "container-local ~/.unraid-mcp/.env (load_dotenv(override=False)) — see "
+            "issue #137"
+        )
+    assert "UNRAID_MCP_HOST=0.0.0.0" in dockerfile
+
+
 def test_docker_runtime_python_matches_builder_minor_version() -> None:
     dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
     assert "uv:python3.12-bookworm-slim" in dockerfile

--- a/tests/test_review_regressions.py
+++ b/tests/test_review_regressions.py
@@ -28,12 +28,15 @@ def test_plugin_manifests_do_not_hardcode_env_configurable_defaults() -> None:
     var configured in ``~/.unraid-mcp/.env`` — so a user pointing
     ``UNRAID_VERIFY_SSL`` at a CA-bundle path for a self-signed cert had that
     silently ignored. The same shadowing risk applies to any other var these
-    manifests hardcode to a value that merely duplicates the package default
-    (``UNRAID_MCP_LOG_LEVEL``, ``UNRAID_MCP_LOG_FILE``,
-    ``UNRAID_AUTO_START_SUBSCRIPTIONS``, ``UNRAID_MAX_RECONNECT_ATTEMPTS``) —
-    none of them serve a purpose beyond matching ``Settings()``'s own default,
-    so none of them belong in the manifest. ``UNRAID_MCP_TRANSPORT=stdio`` is
-    the one legitimate exception: it differs from the package default
+    manifests hardcode to a value that merely duplicates the package's own
+    default (``UNRAID_MCP_LOG_LEVEL``, ``UNRAID_MCP_LOG_FILE`` — both from
+    ``Settings()`` in ``unraid_mcp/config/settings.py``;
+    ``UNRAID_AUTO_START_SUBSCRIPTIONS``, ``UNRAID_MAX_RECONNECT_ATTEMPTS`` —
+    both from ``os.getenv(...)`` fallbacks in
+    ``unraid_mcp/subscriptions/manager.py``) — none of them serve a purpose
+    beyond matching a default that already applies when unset, so none of
+    them belong in the manifest. ``UNRAID_MCP_TRANSPORT=stdio`` is the one
+    legitimate exception: it differs from the package default
     (``streamable-http``) and is mandatory for a plugin-launched subprocess,
     which talks to its host over stdio.
     """
@@ -56,7 +59,7 @@ def test_plugin_manifests_do_not_hardcode_env_configurable_defaults() -> None:
     for env_block, label in ((mcp_env, ".mcp.json"), (codex_env, ".codex-plugin/plugin.json")):
         leaked = shadowing_prone_vars & env_block.keys()
         assert not leaked, (
-            f"{label} hardcodes {leaked}, which duplicates a Settings() default and would "
+            f"{label} hardcodes {leaked}, which duplicates a package default and would "
             "silently shadow the same var configured in ~/.unraid-mcp/.env "
             "(load_dotenv(override=False)) — see issue #137"
         )
@@ -103,8 +106,9 @@ def test_dockerfile_does_not_hardcode_env_configurable_defaults() -> None:
     image added nothing but the same shadowing risk.
     """
     dockerfile = (PROJECT_ROOT / "Dockerfile").read_text()
-    # Strip comment lines so this test isn't tripped up by its own docstring-style
-    # explanatory comments in the Dockerfile mentioning these var names in prose.
+    # Strip comment lines so a future rewording of the explanatory comment above
+    # ENV UNRAID_MCP_HOST=0.0.0.0 (which today only abbreviates these var names,
+    # not spelling out VAR=value) can't accidentally false-positive this check.
     code_lines = "\n".join(
         line for line in dockerfile.splitlines() if not line.strip().startswith("#")
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 """Tests for the setting subactions of the consolidated unraid tool."""
 
 import importlib
+import os
 from collections.abc import Generator
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -389,6 +390,16 @@ def _reload_settings_from_dotenv(
     final reload — otherwise that "restore a clean module" reload would still
     see ``UNRAID_CREDENTIALS_DIR`` pointing at this test's tmp ``.env`` file and
     re-load whatever TLS value it contains, leaking into the next test.
+
+    The TLS vars are popped from ``os.environ`` directly (not just via
+    ``monkeypatch.delenv``) because ``load_dotenv()`` writes them straight into
+    ``os.environ`` during the test, bypassing monkeypatch's own tracking. If
+    the *only* monkeypatch touch of a key beforehand was a no-op
+    ``delenv(raising=False)`` on an already-absent var, monkeypatch's undo
+    stack has no earlier "restore to unset" entry to fall back on — so its
+    automatic teardown would faithfully restore the leaked ``load_dotenv``
+    value into ``os.environ`` for every later test, undoing our own cleanup.
+    The raw pop empties them before monkeypatch's ledger is ever consulted.
     """
     monkeypatch.delenv("UNRAID_VERIFY_SSL", raising=False)
     monkeypatch.delenv("UNRAID_ALLOW_INSECURE_TLS", raising=False)
@@ -396,6 +407,8 @@ def _reload_settings_from_dotenv(
     try:
         yield tmp_path
     finally:
+        os.environ.pop("UNRAID_VERIFY_SSL", None)
+        os.environ.pop("UNRAID_ALLOW_INSECURE_TLS", None)
         monkeypatch.delenv("UNRAID_VERIFY_SSL", raising=False)
         monkeypatch.delenv("UNRAID_ALLOW_INSECURE_TLS", raising=False)
         monkeypatch.delenv("UNRAID_CREDENTIALS_DIR", raising=False)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,7 @@
 
 import importlib
 from collections.abc import Generator
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -370,4 +371,102 @@ class TestVerifySslGuard:
         monkeypatch.setenv("UNRAID_VERIFY_SSL", ca_path)
         importlib.reload(settings_module)
         assert ca_path == settings_module.UNRAID_VERIFY_SSL
-        assert isinstance(settings_module.UNRAID_VERIFY_SSL, str)
+
+
+@pytest.fixture
+def _reload_settings_from_dotenv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Generator[Path, None, None]:
+    """Point the canonical credentials dir at an isolated tmp_path .env file.
+
+    ``CREDENTIALS_DIR``/``CREDENTIALS_ENV_PATH`` are computed once at module
+    import time from ``UNRAID_CREDENTIALS_DIR``, so re-deriving them for a test
+    requires both setting that env var *and* reloading the module (a bare
+    ``monkeypatch.setattr(settings_module, "CREDENTIALS_ENV_PATH", ...)`` would
+    just get clobbered the moment anything reloads the module).
+
+    Teardown clears the TLS vars *and* ``UNRAID_CREDENTIALS_DIR`` before the
+    final reload — otherwise that "restore a clean module" reload would still
+    see ``UNRAID_CREDENTIALS_DIR`` pointing at this test's tmp ``.env`` file and
+    re-load whatever TLS value it contains, leaking into the next test.
+    """
+    monkeypatch.delenv("UNRAID_VERIFY_SSL", raising=False)
+    monkeypatch.delenv("UNRAID_ALLOW_INSECURE_TLS", raising=False)
+    monkeypatch.setenv("UNRAID_CREDENTIALS_DIR", str(tmp_path))
+    try:
+        yield tmp_path
+    finally:
+        monkeypatch.delenv("UNRAID_VERIFY_SSL", raising=False)
+        monkeypatch.delenv("UNRAID_ALLOW_INSECURE_TLS", raising=False)
+        monkeypatch.delenv("UNRAID_CREDENTIALS_DIR", raising=False)
+        importlib.reload(settings_module)
+
+
+class TestVerifySslDotenvPrecedence:
+    """Regression coverage for GitHub issue #137.
+
+    The bundled Claude Code (``.mcp.json``) and Codex (``.codex-plugin/plugin.json``)
+    manifests used to hardcode ``UNRAID_VERIFY_SSL=true`` in the launched
+    process's env. Because ``_load_env_files()`` uses
+    ``load_dotenv(override=False)``, that pre-set value permanently shadowed
+    whatever ``UNRAID_VERIFY_SSL`` a user configured in the canonical
+    ``~/.unraid-mcp/.env`` (most notably a CA-bundle path for a self-signed
+    cert). The manifests no longer hardcode this var; these tests pin the
+    underlying ``_load_env_files()`` + ``Settings()`` precedence rule — both
+    that a ``.env``-configured value is honored once nothing shadows it, and
+    (explicitly) that a manifest-style pre-set value still wins if one is ever
+    reintroduced — so a future manifest edit can't silently bring the bug back.
+    """
+
+    @staticmethod
+    def _write_env(env_dir: Path, **values: str) -> None:
+        (env_dir / ".env").write_text("\n".join(f"{k}={v}" for k, v in values.items()) + "\n")
+
+    def test_ca_bundle_path_from_dotenv_is_picked_up_when_unset(
+        self, _reload_settings_from_dotenv: Path
+    ) -> None:
+        """Nothing pre-sets UNRAID_VERIFY_SSL (the fixed manifest state) ->
+        the .env-configured CA-bundle path is used."""
+        ca_path = "/etc/ssl/certs/unraid-ca.pem"
+        self._write_env(_reload_settings_from_dotenv, UNRAID_VERIFY_SSL=ca_path)
+        importlib.reload(settings_module)
+        assert ca_path == settings_module.UNRAID_VERIFY_SSL
+
+    def test_true_from_dotenv_is_picked_up_when_unset(
+        self, _reload_settings_from_dotenv: Path
+    ) -> None:
+        self._write_env(_reload_settings_from_dotenv, UNRAID_VERIFY_SSL="true")
+        importlib.reload(settings_module)
+        assert settings_module.UNRAID_VERIFY_SSL is True
+
+    def test_false_from_dotenv_requires_opt_in(self, _reload_settings_from_dotenv: Path) -> None:
+        self._write_env(_reload_settings_from_dotenv, UNRAID_VERIFY_SSL="false")
+        with pytest.raises(SystemExit) as excinfo:
+            importlib.reload(settings_module)
+        assert excinfo.value.code == 1
+
+    def test_false_from_dotenv_with_opt_in_disables_verification(
+        self, _reload_settings_from_dotenv: Path
+    ) -> None:
+        self._write_env(
+            _reload_settings_from_dotenv,
+            UNRAID_VERIFY_SSL="false",
+            UNRAID_ALLOW_INSECURE_TLS="true",
+        )
+        importlib.reload(settings_module)
+        assert settings_module.UNRAID_VERIFY_SSL is False
+
+    def test_manifest_style_preset_env_shadows_dotenv_ca_path(
+        self, _reload_settings_from_dotenv: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Documents the actual bug mechanism from issue #137: if something
+        pre-sets UNRAID_VERIFY_SSL in the process env before the server reads
+        .env (exactly what the old hardcoded manifest 'true' did), the .env
+        file's CA-bundle path is silently ignored. This is why plugin
+        manifests must never hardcode this var.
+        """
+        ca_path = "/etc/ssl/certs/unraid-ca.pem"
+        self._write_env(_reload_settings_from_dotenv, UNRAID_VERIFY_SSL=ca_path)
+        monkeypatch.setenv("UNRAID_VERIFY_SSL", "true")  # simulates the old manifest hardcode
+        importlib.reload(settings_module)
+        assert settings_module.UNRAID_VERIFY_SSL is True  # .env's CA path was shadowed


### PR DESCRIPTION
## Summary
- `.mcp.json` (Claude Code) and `.codex-plugin/plugin.json` (Codex) hardcoded `UNRAID_VERIFY_SSL=true` plus four other vars (`UNRAID_MCP_LOG_LEVEL`, `UNRAID_MCP_LOG_FILE`, `UNRAID_AUTO_START_SUBSCRIPTIONS`, `UNRAID_MAX_RECONNECT_ATTEMPTS`) that just duplicate `Settings()`'s own defaults.
- The `Dockerfile` had the same bug via a different mechanism: it baked `ENV UNRAID_MCP_TRANSPORT=streamable-http` and `UNRAID_MCP_LOG_LEVEL=INFO`, both identical to the package defaults.
- Because `_load_env_files()` uses `load_dotenv(override=False)`, a value already present in the process env from any of these sources permanently shadows the same var configured in `~/.unraid-mcp/.env` — so a user pointing `UNRAID_VERIFY_SSL` at a CA-bundle path for a self-signed cert had that silently overridden back to `"true"`, rejecting the cert.
- Dropped all five redundant/shadowing-prone keys from both plugin manifests, and `UNRAID_MCP_TRANSPORT`/`UNRAID_MCP_PORT`/`UNRAID_MCP_LOG_LEVEL` from the Dockerfile. Kept `UNRAID_MCP_TRANSPORT=stdio` in the manifests (mandatory — differs from the package default `streamable-http`, required for a plugin-launched subprocess) and `UNRAID_MCP_HOST=0.0.0.0` in the Dockerfile (mandatory — differs from the package default `127.0.0.1`, required for the server to be reachable from outside the container's network namespace). `UNRAID_MCP_PORT` was dropped too even though it wasn't part of the original 5-var manifest list, since every place that reads it (the Dockerfile's own `HEALTHCHECK` and `docker-compose.yaml`) already has its own `${UNRAID_MCP_PORT:-6970}` shell fallback.
- Audited every other manifest/config surface (`gemini-extension.json`, `docker-compose.yaml`) for the same shadowing pattern — `gemini-extension.json` doesn't set any of these vars (unaffected), and `docker-compose.yaml` passes through the host's real `~/.unraid-mcp/.env` via `env_file:` rather than a hardcoded literal, which is a different, non-buggy mechanism (Docker's runtime env already beats image `ENV` there).

Closes #137

## Regression tests
- `tests/test_review_regressions.py::test_plugin_manifests_do_not_hardcode_env_configurable_defaults` — structural check that neither plugin manifest re-hardcodes any of the five shadowing-prone vars, while still requiring `UNRAID_MCP_TRANSPORT=stdio`.
- `tests/test_review_regressions.py::test_dockerfile_does_not_hardcode_env_configurable_defaults` — same idea for the Dockerfile: asserts none of `UNRAID_MCP_TRANSPORT`/`UNRAID_MCP_PORT`/`UNRAID_MCP_LOG_LEVEL` are baked in, while still requiring `UNRAID_MCP_HOST=0.0.0.0`.
- `tests/test_settings.py::TestVerifySslDotenvPrecedence` — covers all three `UNRAID_VERIFY_SSL` forms (`true`, `false` + `UNRAID_ALLOW_INSECURE_TLS`, CA-bundle path) being correctly read from `~/.unraid-mcp/.env` when nothing pre-shadows them, plus an explicit test pinning the actual bug mechanism (a manifest-style pre-set env value still wins over `.env` if one is ever reintroduced).

## Test plan
- [x] `uv run ruff check unraid_mcp/ tests/` / `uv run ruff format --check unraid_mcp/ tests/`
- [x] `uv run ty check unraid_mcp/`
- [x] `hadolint Dockerfile` — clean
- [x] `uv run pytest -q` — 1795 passed, 0 skipped

🤖 Generated with [Claude Code](https://claude.ai/code)